### PR TITLE
Add type system documentation and README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ See [Installation Guide](docs/installation.md) for detailed setup instructions.
 
 - **[Getting Started](docs/getting-started.md)** — First steps with T
 - **[Language Overview](docs/language_overview.md)** — Types, syntax, and core concepts
+- **[Type System](docs/type-system.md)** — REPL vs strict mode, typed lambdas, and current limitations
 - **[API Reference](docs/api-reference.md)** — Complete function reference
 - **[Data Manipulation](docs/data_manipulation_examples.md)** — Practical examples with data verbs
 - **[Pipeline Tutorial](docs/pipeline_tutorial.md)** — Step-by-step guide to pipelines
@@ -176,6 +177,29 @@ df |> filter($age > 30) |> select($name, $salary)
 mean([1, NA, 3])              -- Error: NA encountered
 mean([1, NA, 3], na_rm = true) -- 2.0 (explicit handling)
 ```
+
+### Type System (Alpha)
+
+T now includes an early type-system layer focused on function signatures and mode-dependent validation:
+
+- `--mode repl` keeps exploration flexible and does not enforce top-level annotations.
+- `--mode strict` enforces typed top-level function signatures.
+- `t run file.t` defaults to `strict` mode (unless `--mode repl` is explicitly passed).
+
+Current typed lambda syntax:
+
+```t
+-- Untyped lambda (expression body)
+add = \(x, y) x + y
+
+-- Typed lambda (return type requires a block body)
+add_int = \(x: Int, y: Int) -> Int { x + y }
+
+-- Generic typed lambda (type variables must be declared)
+id = \<T>(x: T) -> T { x }
+```
+
+See [docs/type-system.md](docs/type-system.md) for details on what is implemented today and what is still planned.
 
 ### Data Verbs
 

--- a/docs/type-system.md
+++ b/docs/type-system.md
@@ -1,0 +1,111 @@
+# Type System
+
+T currently has an **alpha-stage, mode-aware type system**. The implementation focuses on typed lambda signatures and strict validation for top-level functions, with broader static typing features planned for later phases.
+
+## Why this exists
+
+The typing design in `spec_files/typing_system.md` sets a dual goal:
+
+- keep REPL exploration lightweight,
+- while making scripts and packages more explicit and safer.
+
+PRs #83 and #84 introduced the first concrete implementation of that plan: typed lambda syntax, generic parameter declarations, and strict-mode validation behavior.
+
+## Execution modes
+
+Two checker modes are available:
+
+- `repl`
+- `strict`
+
+### Current behavior
+
+- `t repl` defaults to `repl` mode.
+- `t run <file.t>` defaults to `strict` mode.
+- `--mode repl|strict` can be used to override defaults.
+
+In `strict` mode, only **top-level lambda assignments** are validated today.
+
+## Lambda syntax
+
+T supports both untyped and typed lambda forms.
+
+### Untyped lambda
+
+Body is any expression.
+
+```t
+add = \(x, y) x + y
+```
+
+### Typed lambda
+
+When a return type annotation is present, the body must be a block (`{ ... }`) to avoid parser ambiguity.
+
+```t
+add_int = \(x: Int, y: Int) -> Int { x + y }
+```
+
+### Generic typed lambda
+
+Generic type variables must be declared explicitly with `<...>`.
+
+```t
+id = \<T>(x: T) -> T { x }
+pair = \<A, B>(x: A, y: B) -> Tuple[A, B] { [x, y] }
+```
+
+## Type annotation forms currently parsed
+
+### Base types
+
+- `Int`
+- `Float`
+- `Bool`
+- `String`
+- `Null`
+
+### Composite forms
+
+- `List[T]`
+- `Dict[K, V]`
+- `Tuple[T1, T2, ...]`
+- `DataFrame[SchemaLikeType]` (parsed as a type argument shape, not yet enforced semantically)
+
+### Generic variables
+
+Single uppercase identifiers are interpreted as type variables (for example `T`, `A`, `B`).
+
+## What strict mode validates today
+
+In `strict` mode, for top-level lambdas assigned with `name = \(...) ...`, T validates:
+
+1. all parameters have type annotations,
+2. return type is annotated,
+3. if type variables are used, generic parameters are declared,
+4. all used type variables are declared.
+
+If any rule fails, evaluation is blocked with a type error.
+
+## What is **not** implemented yet
+
+The current implementation is intentionally narrow. The following items from the spec are still future work:
+
+- full expression-level type inference (HM-style),
+- end-to-end static typing of function application and operators,
+- typeclass/constraint resolution,
+- fully typed DataFrame schemas and column-level checks,
+- typed AST pipeline stages beyond signature validation.
+
+In other words, this is a **signature validation layer**, not yet a full static typechecker.
+
+## Practical guidance
+
+- Use `repl` mode for exploratory work.
+- Use `strict` mode (default in `run`) for scripts and packages.
+- Prefer explicit signatures on exported/top-level functions to make behavior auditable and future-proof as stricter checks are added.
+
+## References
+
+- Typing spec: `spec_files/typing_system.md`
+- Initial implementation context: PR #83 and PR #84


### PR DESCRIPTION
### Motivation
- Document the new, alpha-stage mode-aware type-system (typed lambdas, generic params, and strict vs REPL behavior) implemented in recent PRs and capture current limitations and usage guidance.

### Description
- Add `docs/type-system.md` that explains execution modes (`repl` vs `strict`), typed/untyped/generic lambda syntax, parsed annotation forms, strict-mode validation rules, and remaining work from the spec; update `README.md` to include a link and a short "Type System (Alpha)" section with examples.

### Testing
- Attempted to run the focused test binary with `dune runtest tests/core/test_typing_mode.exe`, but `dune` is not available in this environment so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992e9143f10832684073ada1b23e073)