### PR TITLE
Resolve latest tagged `tlang` release when scaffolding flake inputs

### DIFF
--- a/src/package_manager/scaffold.ml
+++ b/src/package_manager/scaffold.ml
@@ -29,29 +29,36 @@ let git_init dir =
 
 let default_tlang_tag = "v0.5.0"
 
-let starts_with ~prefix s =
-  let lp = String.length prefix in
-  String.length s >= lp && String.sub s 0 lp = prefix
+(* Strip the "v" prefix from a tag to get a plain version number. *)
+let strip_v_prefix tag =
+  if String.starts_with ~prefix:"v" tag then
+    String.sub tag 1 (String.length tag - 1)
+  else
+    tag
 
-let ends_with ~suffix s =
-  let ls = String.length suffix in
-  let l = String.length s in
-  l >= ls && String.sub s (l - ls) ls = suffix
-
-let split_on_char c s =
-  let rec loop i j acc =
-    if j = String.length s then
-      List.rev (String.sub s i (j - i) :: acc)
-    else if s.[j] = c then
-      loop (j + 1) (j + 1) (String.sub s i (j - i) :: acc)
-    else
-      loop i (j + 1) acc
+(* Validate and sanitize a tag string to ensure it only contains safe characters.
+   This prevents potential code injection when the tag is used in templates.
+   Only allows alphanumeric characters, dots, hyphens, and the "v" prefix. *)
+let sanitize_tag tag =
+  let is_safe_char c =
+    (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+    (c >= '0' && c <= '9') || c = '.' || c = '-' || c = 'v'
   in
-  loop 0 0 []
+  let rec check i =
+    if i >= String.length tag then true
+    else if is_safe_char tag.[i] then check (i + 1)
+    else false
+  in
+  if check 0 then tag else default_tlang_tag
 
+(* Parse a semantic version tag.
+   This parser handles basic semver tags (vX.Y.Z or X.Y.Z) but does NOT handle
+   pre-release versions (e.g., "v1.0.0-alpha") or build metadata (e.g., "v1.0.0+build123").
+   Tags with hyphens or plus signs will be silently ignored.
+   See https://semver.org/spec/v2.0.0.html for the full semver specification. *)
 let parse_semver tag =
   let without_v =
-    if starts_with ~prefix:"v" tag then String.sub tag 1 (String.length tag - 1)
+    if String.starts_with ~prefix:"v" tag then String.sub tag 1 (String.length tag - 1)
     else tag
   in
   let parse_component s =
@@ -62,7 +69,7 @@ let parse_semver tag =
     let n = scan 0 in
     if n = 0 then None else int_of_string_opt (String.sub s 0 n)
   in
-  match split_on_char '.' without_v with
+  match String.split_on_char '.' without_v with
   | [major; minor; patch] ->
       begin match parse_component major, parse_component minor, parse_component patch with
       | Some ma, Some mi, Some pa -> Some (ma, mi, pa)
@@ -86,9 +93,10 @@ let latest_tlang_tag () =
     match input_line ic with
     | line ->
         begin match String.split_on_char '\t' line with
-        | [_sha; refname] when starts_with ~prefix:"refs/tags/" refname ->
-            let tag = String.sub refname 10 (String.length refname - 10) in
-            if starts_with ~prefix:"v" tag && not (ends_with ~suffix:"^{}" tag) then
+        | [_sha; refname] when String.starts_with ~prefix:"refs/tags/" refname ->
+            let prefix_len = String.length "refs/tags/" in
+            let tag = String.sub refname prefix_len (String.length refname - prefix_len) in
+            if String.starts_with ~prefix:"v" tag && not (String.ends_with ~suffix:"^{}" tag) then
               read_tags (tag :: acc)
             else
               read_tags acc
@@ -97,7 +105,17 @@ let latest_tlang_tag () =
     | exception End_of_file -> List.rev acc
   in
   let tags = read_tags [] in
-  let _ = Unix.close_process_in ic in
+  let status = Unix.close_process_in ic in
+  (match status with
+   | Unix.WEXITED 0 -> ()
+   | Unix.WEXITED code ->
+       Printf.eprintf
+         "Warning: command `%s` exited with code %d; using default tlang tag %s if needed.\n%!"
+         cmd code default_tlang_tag
+   | Unix.WSIGNALED signal | Unix.WSTOPPED signal ->
+       Printf.eprintf
+         "Warning: command `%s` was terminated by signal %d; using default tlang tag %s if needed.\n%!"
+         cmd signal default_tlang_tag);
   let versioned_tags =
     List.fold_left
       (fun acc tag ->
@@ -141,7 +159,7 @@ repository = ""
 
 [t]
 # Minimum T language version required
-min_version = "{{tlang_tag}}"
+min_version = "{{tlang_version}}"
 |}
 
 let package_flake_nix = {|{
@@ -326,7 +344,7 @@ description = "A T data analysis project"
 
 [t]
 # Minimum T language version required
-min_version = "{{tlang_tag}}"
+min_version = "{{tlang_version}}"
 |}
 
 let project_flake_nix = {|{
@@ -493,9 +511,25 @@ print("Hello from {{name}}!")
 (* Scaffolding Logic                                                *)
 (* ================================================================ *)
 
+(* Cache the resolved tlang tag for the duration of the process to avoid
+   repeated network calls to latest_tlang_tag on every scaffold operation. *)
+let resolved_tlang_tag_cache : string option ref = ref None
+
 let resolve_tlang_tag () =
-  try latest_tlang_tag () with
-  | _ -> default_tlang_tag
+  match !resolved_tlang_tag_cache with
+  | Some tag -> tag
+  | None ->
+      let tag =
+        try latest_tlang_tag () with
+        | exn ->
+            prerr_endline
+              ("Warning: Failed to resolve latest tlang tag, using default: "
+               ^ Printexc.to_string exn);
+            default_tlang_tag
+      in
+      let sanitized_tag = sanitize_tag tag in
+      resolved_tlang_tag_cache := Some sanitized_tag;
+      sanitized_tag
 
 (** Scaffold a new T package *)
 let scaffold_package (opts : scaffold_options) : (unit, string) result =
@@ -508,7 +542,11 @@ let scaffold_package (opts : scaffold_options) : (unit, string) result =
       Error (Printf.sprintf "Directory '%s' already exists. Use --force to overwrite." dir)
     else begin
       let tlang_tag = resolve_tlang_tag () in
-      let ctx = ("tlang_tag", tlang_tag) :: Template_engine.context_of_options opts in
+      let tlang_version = strip_v_prefix tlang_tag in
+      let ctx = [
+        ("tlang_tag", tlang_tag);
+        ("tlang_version", tlang_version)
+      ] @ Template_engine.context_of_options opts in
       let sub = Template_engine.substitute ctx in
       (* Create directory structure *)
       create_dir dir;
@@ -596,7 +634,11 @@ let scaffold_project (opts : scaffold_options) : (unit, string) result =
       Error (Printf.sprintf "Directory '%s' already exists. Use --force to overwrite." dir)
     else begin
       let tlang_tag = resolve_tlang_tag () in
-      let ctx = ("tlang_tag", tlang_tag) :: Template_engine.context_of_options opts in
+      let tlang_version = strip_v_prefix tlang_tag in
+      let ctx = [
+        ("tlang_tag", tlang_tag);
+        ("tlang_version", tlang_version)
+      ] @ Template_engine.context_of_options opts in
       let sub = Template_engine.substitute ctx in
       (* Create directory structure *)
       create_dir dir;


### PR DESCRIPTION
### Motivation
- Ensure newly generated `flake.nix` files point to a reproducible, up-to-date `tlang` release by selecting the latest tagged `vX.Y.Z` at scaffold generation time. 
- Keep generated flakes pinned to an immutable tag (no floating or hardcoded internal versions) while remaining convenient for engineers.

### Description
- Add tag-resolution logic to `src/package_manager/scaffold.ml` that queries `git ls-remote --tags https://github.com/b-rodrigues/tlang.git`, parses `vX.Y.Z` tags, and selects the highest semantic version. 
- Provide a safe fallback `default_tlang_tag = "v0.5.0"` via `resolve_tlang_tag()` when remote resolution fails. 
- Replace hardcoded `t-lang.url` entries in package/project flake templates with a `{{tlang_tag}}` placeholder and inject the resolved `tlang_tag` into the template substitution context before writing files. 
- Implement lightweight semver parsing and comparison utilities (`parse_semver`, `compare_semver`, helpers) and keep the rest of the scaffold flow unchanged.

### Testing
- Ran `git ls-remote --tags https://github.com/b-rodrigues/tlang.git` and `curl -s https://api.github.com/repos/b-rodrigues/tlang/tags` to validate the remote tag endpoint shape (command ran in the environment; remote responses were checked). 
- Verified resulting template substitution changes and `t-lang.url` placeholders by inspecting the generated diff for `src/package_manager/scaffold.ml` using `git diff` and file listing commands. 
- Attempted `dune build` for a full compile, but it could not run in this container because `dune` is not installed (build not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995664dcb5883268b3483605a1d3bce)