### PR TITLE
Normalize named-argument syntax in examples and move `data` param first in parser

### DIFF
--- a/src/tdoc/tdoc_markdown.ml
+++ b/src/tdoc/tdoc_markdown.ml
@@ -3,6 +3,50 @@
 
 open Tdoc_types
 
+let normalize_named_argument_syntax (line : string) : string =
+  let len = String.length line in
+  let buf = Buffer.create len in
+  let is_ident_start = function
+    | 'a' .. 'z' | 'A' .. 'Z' | '_' -> true
+    | _ -> false
+  in
+  let is_ident_char = function
+    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' -> true
+    | _ -> false
+  in
+  let rec copy_ident j =
+    if j < len && is_ident_char line.[j] then copy_ident (j + 1) else j
+  in
+  let rec skip_spaces j =
+    if j < len && line.[j] = ' ' then skip_spaces (j + 1) else j
+  in
+  let rec prev_non_space j =
+    if j < 0 then None
+    else if line.[j] = ' ' then prev_non_space (j - 1)
+    else Some line.[j]
+  in
+  let rec loop i =
+    if i >= len then ()
+    else if is_ident_start line.[i] then begin
+      let j = copy_ident (i + 1) in
+      let k = skip_spaces j in
+      let prev = prev_non_space (i - 1) in
+      if k < len && line.[k] = ':' && (prev = Some '(' || prev = Some ',') then begin
+        Buffer.add_substring buf line i (j - i);
+        Buffer.add_string buf " = ";
+        loop (skip_spaces (k + 1))
+      end else begin
+        Buffer.add_substring buf line i (j - i);
+        loop j
+      end
+    end else begin
+      Buffer.add_char buf line.[i];
+      loop (i + 1)
+    end
+  in
+  loop 0;
+  Buffer.contents buf
+
 let generate_function_doc entry =
   let buf = Buffer.create 1024 in
   Printf.bprintf buf "# %s\n\n" entry.name;
@@ -24,14 +68,14 @@ let generate_function_doc entry =
   
   begin match entry.return_value with
   | Some r ->
-      Printf.bprintf buf "## Returns\n\n";
-      Printf.bprintf buf "%s\n\n" r.description
+      Printf.bprintf buf "## Returns:\n\n";
+      Printf.bprintf buf "Returns: %s\n\n" r.description
   | None -> ()
   end;
   
   if entry.examples <> [] then begin
     Printf.bprintf buf "## Examples\n\n```t\n";
-    List.iter (fun e -> Printf.bprintf buf "%s\n" e) entry.examples;
+    List.iter (fun e -> Printf.bprintf buf "%s\n" (normalize_named_argument_syntax e)) entry.examples;
     Printf.bprintf buf "```\n\n";
   end;
   

--- a/src/tdoc/tdoc_parser.ml
+++ b/src/tdoc/tdoc_parser.ml
@@ -101,11 +101,17 @@ let parse_block lines filename line_num =
     )
   ) lines;
 
+  let data_first_params params =
+    let is_data_param (p : param_doc) = String.lowercase_ascii p.name = "data" in
+    let data_params, other_params = List.partition is_data_param params in
+    data_params @ other_params
+  in
+
   {
     name = (match !name_override with Some n -> n | None -> "unknown");
     description_brief = !brief;
     description_full = String.trim (Buffer.contents full);
-    params = List.rev !params;
+    params = data_first_params (List.rev !params);
     return_value = !return_val;
     examples = List.rev !examples;
     see_also = List.rev !see_also;


### PR DESCRIPTION
### Motivation

- Ensure example code uses a consistent named-argument syntax and improve readability of generated Markdown examples. 
- Make the documented parameter ordering prefer the primary `data` parameter so generated docs list it first.
- Slightly adjust the Returns section Markdown formatting for consistency.

### Description

- Add `normalize_named_argument_syntax` in `src/tdoc/tdoc_markdown.ml` to rewrite example lines where named arguments appear as `name: value` (when immediately following `(` or `,`) into `name = value` form and apply it to all example lines. 
- Change examples emission to pass each example through `normalize_named_argument_syntax` before printing. 
- Modify the Returns block formatting in `tdoc_markdown.ml` to use the heading `## Returns:` and prefix the return description with `Returns:`. 
- Add `data_first_params` to `src/tdoc/tdoc_parser.ml` and use it to reorder parsed parameters so any parameter named `data` (case-insensitive) is placed first.

### Testing

- Ran `dune build` which completed successfully. 
- Ran `dune runtest` and existing unit tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a45e97a6988326a2adae33ff30d5be)