### PR TITLE
Soft error

### DIFF
--- a/docs/api-reference.html
+++ b/docs/api-reference.html
@@ -1464,6 +1464,36 @@ generate a stub. Default: <code>false</code>.</li>
 <p>The evaluated return value of the command.</p>
 <hr />
 <h3
+id="qnscript-na-serializer-default-deserializer-default-env_vars-args-functions-include-noop-false"><code>qn(script = NA, serializer = "default", deserializer = "default", env_vars = [:], args = [:], functions = [], include = [], noop = false)</code></h3>
+<p>Configure a Quarto pipeline node. A convenience wrapper around
+<code>node()</code> with <code>runtime = "Quarto"</code>. Use it to
+render <code>.qmd</code> files inside <code>pipeline { ... }</code>
+blocks.</p>
+<p><strong>Parameters:</strong></p>
+<ul>
+<li><code>script</code> (optional) — Path to an external
+<code>.qmd</code> file. Mutually exclusive with
+<code>command</code>.</li>
+<li><code>serializer</code> (optional) — Custom serializer function.
+Default: <code>default</code>.</li>
+<li><code>deserializer</code> (optional) — Custom deserializer function.
+Default: <code>default</code>.</li>
+<li><code>env_vars</code> (optional) — Dictionary of environment
+variables to pass into the Nix sandbox.</li>
+<li><code>args</code> (optional) — Runtime/tool arguments for Quarto,
+such as <code>subcommand</code>, <code>path</code>, <code>to</code>, and
+other CLI options.</li>
+<li><code>functions</code> (optional) — Files to source before
+execution.</li>
+<li><code>include</code> (optional) — Additional files for the
+sandbox.</li>
+<li><code>noop</code> (optional) — Whether to skip execution and
+generate a stub. Default: <code>false</code>.</li>
+</ul>
+<p><strong>Returns:</strong></p>
+<p>The evaluated return value of the command.</p>
+<hr />
+<h3
 id="shncommand-script-na-serializer-text-deserializer-default-env_vars-args-shell-sh-shell_args-functions-include-noop-false"><code>shn(command, script = NA, serializer = "text", deserializer = "default", env_vars = [:], args = [], shell = "sh", shell_args = [], functions = [], include = [], noop = false)</code></h3>
 <p>Configure a shell pipeline node. A convenience wrapper around
 <code>node()</code> with <code>runtime = "sh"</code>. Use it for CLI

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -36,6 +36,87 @@
 <h1 id="changelog">Changelog</h1>
 <h2 id="xx-upcoming">[0.51.4] - 2026-04-xx (upcoming)</h2>
 <p><strong>Status</strong>: Beta</p>
+<h3 id="language-ergonomics-auto-quoting">Language Ergonomics &amp;
+Auto-Quoting</h3>
+<ul>
+<li><strong>Auto-Quoted Parameters (<code>$param</code>)</strong>:
+<ul>
+<li>Introduced <code>$param</code> syntax in lambda and
+<code>function()</code> parameter lists.</li>
+<li>Parameters prefixed with <code>$</code> automatically capture bare
+names (like column names) as <strong>Symbols</strong> rather than
+evaluating them.</li>
+<li>Simplified the creation of data-wrangling wrappers, removing the
+need for <code>enquo()</code> in simple forwarding cases.</li>
+</ul></li>
+<li><strong>Unified <code>get()</code> and New <code>sym()</code>
+Builtin</strong>:
+<ul>
+<li>Added the <code>sym()</code> core builtin for programmatic symbol
+creation.</li>
+<li>Unified the <code>get()</code> dispatcher across <code>core</code>
+and <code>lens</code> packages, ensuring a single, stable interface for
+variable lookup, collection indexing, and lens-based retrieval.</li>
+<li><strong>Regression Safety</strong>: Added regression tests to ensure
+core primitives remain stable when the <code>lens</code> package is
+loaded.</li>
+</ul></li>
+</ul>
+<h3 id="structural-integrity-terminal-error-handling">Structural
+Integrity &amp; Terminal Error Handling</h3>
+<ul>
+<li><strong>Introduced <code>StructuralError</code> Category</strong>:
+<ul>
+<li>Added <code>StructuralError</code> as a new terminal diagnostic code
+for fundamental pipeline orchestration failures.</li>
+<li><strong>DAG Validation</strong>: Dependency cycles, self-referential
+nodes, and missing sibling node references are now classified as
+<code>StructuralError</code>.</li>
+<li><strong>Orchestration Failure</strong>: Materialization errors in
+<code>populate_pipeline</code> (e.g., missing dependencies in
+<code>tproject.toml</code>, missing Nix build tools, or stalled artifact
+directories) now emit <code>StructuralError</code>.</li>
+</ul></li>
+<li><strong>Terminal Evaluation Policy</strong>:
+<ul>
+<li>The core evaluator now treats <code>StructuralError</code> as a
+<strong>terminal event</strong> that bypasses “Resilient-by-Default”
+(<code>resilient=true</code>) settings.</li>
+<li>This ensures that fundamental infrastructure or topology breaks stop
+script execution immediately, preventing confusing downstream “cascading
+gibberish” errors while maintaining resilience for standard
+data-computation errors (like <code>1 / 0</code>).</li>
+</ul></li>
+<li><strong>Environment-Aware Failures</strong>:
+<ul>
+<li>Pipeline dependency checks now respect the
+<code>TLANG_AUTO_ADD_PIPELINE_DEPS</code> environment variable.</li>
+<li>If auto-injection is disabled or impossible (non-interactive
+sessions), the system raises a fatal <code>StructuralError</code>
+instead of implicitly continuing into a broken Nix state.</li>
+</ul></li>
+</ul>
+<h3 id="pipeline-infrastructure-lens-orchestration">Pipeline
+Infrastructure &amp; Lens Orchestration</h3>
+<ul>
+<li><strong>Resolution Stabilization</strong>:
+<ul>
+<li>Implemented robust lazy resolution for cross-pipeline dependencies
+and out-of-order pipeline nodes.</li>
+<li>Fixed a regression where pipeline nodes were returning
+<code>unbuilt</code> states instead of resolved values in complex
+dependency graphs.</li>
+</ul></li>
+<li><strong>Improved Failure Visibility</strong>:
+<ul>
+<li>Introduced structured <code>MissingArtifactError</code> in the lens
+system to provide precise feedback on unbuilt dependencies during lazy
+evaluation.</li>
+<li>Clarified the error contract for <code>get()</code> when targeting
+plotting nodes, ensuring metadata dictionaries are returned
+predictably.</li>
+</ul></li>
+</ul>
 <h3 id="first-class-visual-metadata-plot-inspection">First-Class Visual
 Metadata &amp; Plot Inspection</h3>
 <ul>
@@ -101,6 +182,15 @@ documentation (descriptions, parameters, examples) for
 <code>t_doc("parse")</code> and <code>t_doc("generate")</code> workflows
 for extracting and publishing reference pages for new core
 functions.</li>
+<li><strong>Auto-Quoting Documentation</strong>: Updated
+<code>docs/language_overview.md</code> and
+<code>docs/quotation.md</code> with comprehensive examples of the new
+<code>$param</code> auto-quoting feature. ### Core Evaluator &amp;
+Emitter Refinements</li>
+<li><strong>Quarto Wrapper Ergonomics</strong>: Added <code>qn()</code>
+as a first-class convenience wrapper around <code>node()</code> with
+<code>runtime = Quarto</code>, matching the existing <code>rn()</code>
+and <code>pyn()</code> helpers for R and Python nodes.</li>
 <li><strong>Improved Pretty Printing</strong>: Updated the core pretty
 printer to handle complex nested dictionaries and diagnostics summaries
 more gracefully.</li>
@@ -120,6 +210,28 @@ visualizations.</li>
 <li><strong>Improved REPL interaction</strong>: Explicitly flush
 stdout/stderr around <code>show_plot</code> calls so the rendered path
 is reported cleanly before local viewer launch.</li>
+<li><strong>Helper Consistency</strong>: Standardized lens helper names
+and improved internal consistency in <code>lens.ml</code>.</li>
+</ul>
+<h3 id="resilient-by-default-evaluation">Resilient-by-Default
+Evaluation</h3>
+<ul>
+<li><strong>Global Resilience</strong>: Evaluation now defaults to
+resilient mode (<code>resilient=true</code>). This ensures that scripts
+and pipelines continue execution upon encountering <code>VError</code>
+values, aligning with the “Errors are Values” philosophy.</li>
+<li><strong><code>--failfast</code> Flag</strong>: Replaced the
+<code>--resilient</code> CLI flag with <code>--failfast</code>. Users
+can now explicitly opt-in to the usual, common behaviour of
+short-circuiting upon the first error.</li>
+<li><strong><code>t_make()</code> &amp; <code>t_run()</code>
+Integration</strong>: Added <code>failfast</code> parameter to the main
+pipeline orchestrator and script runner for granular control.</li>
+<li><strong>Improved Serialization Restoration</strong>: Fixed a
+critical bug where <code>VError</code> values were deserialized as
+Dictionaries. The system now correctly restores the native
+<code>Error</code> type across node boundaries, even when using modern
+JSON interchange.</li>
 </ul>
 <h2 id="section">[0.51.3] - 2026-04-12</h2>
 <p><strong>Status</strong>: Beta</p>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -836,3 +836,4 @@ models.</li>
 </script>
 </body>
 </html>
+

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,18 @@
     - Unified the `get()` dispatcher across `core` and `lens` packages, ensuring a single, stable interface for variable lookup, collection indexing, and lens-based retrieval.
     - **Regression Safety**: Added regression tests to ensure core primitives remain stable when the `lens` package is loaded.
 
+### Structural Integrity & Terminal Error Handling
+- **Introduced `StructuralError` Category**:
+    - Added `StructuralError` as a new terminal diagnostic code for fundamental pipeline orchestration failures.
+    - **DAG Validation**: Dependency cycles, self-referential nodes, and missing sibling node references are now classified as `StructuralError`.
+    - **Orchestration Failure**: Materialization errors in `populate_pipeline` (e.g., missing dependencies in `tproject.toml`, missing Nix build tools, or stalled artifact directories) now emit `StructuralError`.
+- **Terminal Evaluation Policy**:
+    - The core evaluator now treats `StructuralError` as a **terminal event** that bypasses "Resilient-by-Default" (`resilient=true`) settings.
+    - This ensures that fundamental infrastructure or topology breaks stop script execution immediately, preventing confusing downstream "cascading gibberish" errors while maintaining resilience for standard data-computation errors (like `1 / 0`).
+- **Environment-Aware Failures**:
+    - Pipeline dependency checks now respect the `TLANG_AUTO_ADD_PIPELINE_DEPS` environment variable.
+    - If auto-injection is disabled or impossible (non-interactive sessions), the system raises a fatal `StructuralError` instead of implicitly continuing into a broken Nix state.
+
 ### Pipeline Infrastructure & Lens Orchestration
 - **Resolution Stabilization**:
     - Implemented robust lazy resolution for cross-pipeline dependencies and out-of-order pipeline nodes.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -60,7 +60,7 @@
 
 ### Resilient-by-Default Evaluation
 - **Global Resilience**: Evaluation now defaults to resilient mode (`resilient=true`). This ensures that scripts and pipelines continue execution upon encountering `VError` values, aligning with the "Errors are Values" philosophy.
-- **`--failfast` Flag**: Replaced the `--resilient` CLI flag with `--failfast`. Users can now explicitly opt-in to legacy short-circuiting behavior.
+- **`--failfast` Flag**: Replaced the `--resilient` CLI flag with `--failfast`. Users can now explicitly opt-in to the usual, common behaviour of short-circuiting upon the first error.
 - **`t_make()` & `t_run()` Integration**: Added `failfast` parameter to the main pipeline orchestrator and script runner for granular control.
 - **Improved Serialization Restoration**: Fixed a critical bug where `VError` values were deserialized as Dictionaries. The system now correctly restores the native `Error` type across node boundaries, even when using modern JSON interchange.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -58,6 +58,12 @@
 - **Helper Consistency**: Standardized lens helper names and improved internal consistency in `lens.ml`.
 
 
+### Resilient-by-Default Evaluation
+- **Global Resilience**: Evaluation now defaults to resilient mode (`resilient=true`). This ensures that scripts and pipelines continue execution upon encountering `VError` values, aligning with the "Errors are Values" philosophy.
+- **`--failfast` Flag**: Replaced the `--resilient` CLI flag with `--failfast`. Users can now explicitly opt-in to legacy short-circuiting behavior.
+- **`t_make()` & `t_run()` Integration**: Added `failfast` parameter to the main pipeline orchestrator and script runner for granular control.
+- **Improved Serialization Restoration**: Fixed a critical bug where `VError` values were deserialized as Dictionaries. The system now correctly restores the native `Error` type across node boundaries, even when using modern JSON interchange.
+
 ## [0.51.3] - 2026-04-12
 
 **Status**: Beta  

--- a/docs/error-handling.html
+++ b/docs/error-handling.html
@@ -73,6 +73,30 @@ traceability.</li>
 <p><strong>Key Principle</strong>: Errors are data, and data can be
 transformed, inspected, and recovered from.</p>
 <hr />
+<h2 id="execution-modes-resilient-vs.-fail-fast">Execution Modes:
+Resilient vs. Fail-Fast</h2>
+<p>T-Lang provides two modes of evaluation, controlled by the
+“resilience” setting:</p>
+<h3 id="resilient-mode-default">1. Resilient Mode (Default)</h3>
+<p>Evaluation continues even when statements or pipeline nodes result in
+<code>VError</code> values. This is aligned with the “Errors are Values”
+philosophy, allowing you to collect as much information as possible from
+a single run. Residual errors are simply passed to downstream functions
+(which may short-circuit via <code>|&gt;</code> or recover via
+<code>?|&gt;</code>). This is the recommended mode for complex data
+pipelines where you want to observe as many diagnostic outcomes as
+possible in a single pass.</p>
+<h3 id="fail-fast-mode">2. Fail-Fast Mode</h3>
+<p>Evaluation stops immediately upon encountering the first
+<code>VError</code>. This is the usual, common behaviour for critical
+scripts where subsequent steps should only run if previous ones were
+flawlessly successful.</p>
+<p><strong>How to toggle</strong>: - <strong>CLI</strong>: Use
+<code>t run --failfast script.t</code> - <strong>REPL</strong>: Set
+<code>t_run(failfast = true, ...)</code> - <strong>Pipelines</strong>:
+Use <code>t_make(failfast = true)</code></p>
+<hr />
+<hr />
 <h2 id="error-types">Error Types</h2>
 <p>T has several categories of errors:</p>
 <h3 id="type-errors">1. Type Errors</h3>

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -36,10 +36,10 @@ T treats errors as **first-class values**, not exceptions. This design enables:
 T-Lang provides two modes of evaluation, controlled by the "resilience" setting:
 
 ### 1. Resilient Mode (Default)
-Evaluation continues even when statements or pipeline nodes result in `VError` values. This is aligned with the "Errors are Values" philosophy, allowing you to collect as much information as possible from a single run. Residual errors are simply passed to downstream functions (which may short-circuit via `|>` or recover via `?|>`).
+Evaluation continues even when statements or pipeline nodes result in `VError` values. This is aligned with the "Errors are Values" philosophy, allowing you to collect as much information as possible from a single run. Residual errors are simply passed to downstream functions (which may short-circuit via `|>` or recover via `?|>`). This is the recommended mode for complex data pipelines where you want to observe as many diagnostic outcomes as possible in a single pass.
 
 ### 2. Fail-Fast Mode
-Evaluation stops immediately upon encountering the first `VError`. This is useful for critical scripts where subsequent steps should only run if previous ones were flawlessly successful.
+Evaluation stops immediately upon encountering the first `VError`. This is the usual, common behaviour for critical scripts where subsequent steps should only run if previous ones were flawlessly successful.
 
 **How to toggle**:
 - **CLI**: Use `t run --failfast script.t`

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -31,6 +31,25 @@ T treats errors as **first-class values**, not exceptions. This design enables:
 
 ---
 
+## Execution Modes: Resilient vs. Fail-Fast
+
+T-Lang provides two modes of evaluation, controlled by the "resilience" setting:
+
+### 1. Resilient Mode (Default)
+Evaluation continues even when statements or pipeline nodes result in `VError` values. This is aligned with the "Errors are Values" philosophy, allowing you to collect as much information as possible from a single run. Residual errors are simply passed to downstream functions (which may short-circuit via `|>` or recover via `?|>`).
+
+### 2. Fail-Fast Mode
+Evaluation stops immediately upon encountering the first `VError`. This is useful for critical scripts where subsequent steps should only run if previous ones were flawlessly successful.
+
+**How to toggle**:
+- **CLI**: Use `t run --failfast script.t`
+- **REPL**: Set `t_run(failfast = true, ...)`
+- **Pipelines**: Use `t_make(failfast = true)`
+
+---
+
+---
+
 ## Error Types
 
 T has several categories of errors:

--- a/docs/index.html
+++ b/docs/index.html
@@ -203,6 +203,8 @@ Emacs, and VS Code</li>
 <ul>
 <li><a href="api-reference.html">API Reference</a> — complete function
 reference by package</li>
+<li><a href="pipes.html">Pipe Operator</a> — monadic short-circuiting
+and philosophy</li>
 <li><a href="data_manipulation_examples.html">Data Manipulation
 Examples</a> — practical examples with core data verbs</li>
 <li><a href="factors.html">Factors &amp; Categorical Data</a> — factor

--- a/docs/language_overview.html
+++ b/docs/language_overview.html
@@ -297,6 +297,19 @@ square = function(x) x * x</code></pre>
 <h3 id="multi-argument-functions">Multi-Argument Functions</h3>
 <pre class="t"><code>add = \(a, b) a + b
 add(3, 7)  -- 10</code></pre>
+<h3 id="auto-quotation-param">Auto-Quotation (<code>$param</code>)</h3>
+<p>T supports auto-quoting for function parameters. Prefixing a
+parameter with <code>$</code> indicates that the caller can pass a bare
+name (like a column name), which is automatically captured as a
+<strong>Symbol</strong> rather than being evaluated.</p>
+<pre class="t"><code>my_select = \(df, $col) select(df, col)
+
+-- Caller passes bare &#39;salary&#39; which is captured as a symbol
+my_select(df, salary)</code></pre>
+<p>This is particularly useful when writing wrappers around data verbs
+like <code>select</code> or <code>mutate</code>. See <a
+href="quotation.html">Quotation and Metaprogramming</a> for more advanced
+usage involving <code>!!</code> (unquote).</p>
 <h3 id="closures">Closures</h3>
 <p>Functions capture their enclosing environment:</p>
 <pre class="t"><code>make_adder = \(n) \(x) x + n
@@ -492,7 +505,8 @@ config.port  -- 8080</code></pre>
 primitive and the <strong>Lens</strong> library. Lenses allow you to
 focus on specific parts of complex data structures (DataFrames, Lists,
 Pipelines) and perform serializable, cross-node data operations.</p>
-<h3 id="the-unified-get-built-in">The Unified <code>get()</code> Built-in</h3>
+<h3 id="the-unified-get-built-in">The Unified <code>get()</code>
+Built-in</h3>
 <p>The <code>get()</code> function is the primary entry point for
 retrieving data. It supports several modes of operation:</p>
 <h4 id="variable-lookup-r-style">1. Variable Lookup (R-style)</h4>

--- a/docs/lens.html
+++ b/docs/lens.html
@@ -306,14 +306,48 @@ to query or modify pipelines based on configuration data.</p>
 
 -- Choose which model to query at runtime
 best_model_name = &quot;model_py&quot;
-model_value = get(p, node_lens(best_model_name))</code></pre>
-<h3 id="serialization-multi-node-safety">7. Serialization &amp;
-Multi-Node Safety</h3>
-<p>T lenses are fully serializable. This means you can define a complex
-<code>FilterLens</code> in one pipeline node, pass it as a parameter to
-another node (even one running in a different runtime like R or Python),
-and it will maintain its structure.</p>
-<pre class="t"><code>-- Node A: Define a &quot;quality control&quot; lens
+model_value = get(p, node_lens(best_model_name))
+
+### 7. Core Orchestration: `node_meta_lens`
+
+While `node_lens` focuses on a node&#39;s *result*, `node_meta_lens` focuses on its *inner configuration*. This is essential for dynamic orchestration: toggling `noop` status, swapping runtimes, or updating (de)serializers before a build.
+
+- **`node_meta_lens(node_name, field)`**: Targets the configuration of a node.
+- **Fields**: `&quot;runtime&quot;`, `&quot;noop&quot;`, `&quot;serializer&quot;`, `&quot;deserializer&quot;`.
+
+```t
+p = pipeline {
+    data_gen = node(command = &lt;{ [1, 2, 3, 4] }&gt;)
+    model_r  = node(data_gen, command = &lt;{ train(data_gen) }&gt;, runtime = R)
+}
+
+-- Surgical update: toggle &#39;noop&#39; status to skip computation
+noop_l = node_meta_lens(&quot;model_r&quot;, &quot;noop&quot;)
+p_noop = p |&gt; set(noop_l, true)
+
+-- Re-orchestration: Swap a node&#39;s runtime to Python
+p_py = p |&gt; set(node_meta_lens(&quot;model_r&quot;, &quot;runtime&quot;), &quot;Python&quot;)</code></pre>
+<h3 id="pipeline-traversals-filter_lens-on-vpipeline">8. Pipeline
+Traversals: <code>filter_lens</code> on VPipeline</h3>
+<p>You can now use <code>filter_lens</code> on a
+<strong>Pipeline</strong> object to query or modify sets of nodes. The
+predicate receives a <code>Dict</code> of node metadata (including
+<code>$name</code>, <code>$runtime</code>, <code>$noop</code>,
+<code>$depth</code>, etc.).</p>
+<pre class="t"><code>-- Identify all nodes currently marked as noop
+noop_nodes_l = filter_lens(\(meta) meta.noop == true)
+noop_node_list = get(p, noop_nodes_l)
+
+-- Re-run all R nodes locally by swapping runtime to T
+r_nodes_l = filter_lens(\(meta) meta.runtime == &quot;R&quot;)
+p_local = p |&gt; over(r_nodes_l, \(n) n |&gt; set(node_meta_lens(n.name, &quot;runtime&quot;), &quot;T&quot;))</code></pre>
+<pre><code>
+### 7. Serialization &amp; Multi-Node Safety
+
+T lenses are fully serializable. This means you can define a complex `FilterLens` in one pipeline node, pass it as a parameter to another node (even one running in a different runtime like R or Python), and it will maintain its structure.
+
+```t
+-- Node A: Define a &quot;quality control&quot; lens
 qc_lens = filter_lens(\(r) r.std_err &gt; 0.05)
 
 -- Node B: Receives qc_lens as an argument and applies it to its local data
@@ -372,7 +406,14 @@ style="text-align: left;"><strong><code>col_lens(name)</code></strong></td>
 <td
 style="text-align: left;"><strong><code>node_lens(name)</code></strong></td>
 <td style="text-align: left;"><code>String -&gt; Lens</code></td>
-<td style="text-align: left;">Pipeline node focus.</td>
+<td style="text-align: left;">Pipeline node result focus.</td>
+</tr>
+<tr>
+<td
+style="text-align: left;"><strong><code>node_meta_lens(n, f)</code></strong></td>
+<td
+style="text-align: left;"><code>(String, String) -&gt; Lens</code></td>
+<td style="text-align: left;">Pipeline node metadata focus.</td>
 </tr>
 <tr>
 <td
@@ -397,7 +438,8 @@ style="text-align: left;"><strong><code>row_lens(i)</code></strong></td>
 <td
 style="text-align: left;"><strong><code>filter_lens(p)</code></strong></td>
 <td style="text-align: left;"><code>Function -&gt; Traversal</code></td>
-<td style="text-align: left;">Condition-based multi-focus.</td>
+<td style="text-align: left;">Condition-based multi-focus (Lists,
+Vectors, DataFrames, Pipelines).</td>
 </tr>
 </tbody>
 </table>

--- a/docs/pipeline_tutorial.html
+++ b/docs/pipeline_tutorial.html
@@ -417,21 +417,38 @@ results:</p>
 p2 = pipeline { a = 5; b = a * 2; c = b + 1 }
 p1.c == p2.c  -- true</code></pre>
 <hr />
-<h2 id="error-handling">12. Error Handling</h2>
+<h2 id="error-handling-resilience">12. Error Handling &amp;
+Resilience</h2>
+<h3 id="errors-are-values">Errors are Values</h3>
+<p>In T, errors are <strong>first-class values</strong>. By default,
+evaluation is <strong>resilient</strong>: if a node fails, it produces
+an <code>Error</code> value instead of crashing the pipeline. This
+allows other independent nodes to continue building, giving you a full
+picture of which parts of your DAG are healthy.</p>
+<pre class="t"><code>p = pipeline {
+  a = 1 / 0      -- Produces an Error(DivisionByZero)
+  b = 1 + 1      -- Still succeeds! (2)
+  c = a + 1      -- Fails because &#39;a&#39; is an error (Error)
+}</code></pre>
+<p>When you print or build this pipeline, T provides a summary of which
+nodes succeeded and which failed.</p>
+<h3 id="the---failfast-flag">The <code>--failfast</code> Flag</h3>
+<p>If you prefer the usual, common behaviour where evaluation stops
+immediately at the first error, you can use the <code>--failfast</code>
+flag:</p>
+<div class="sourceCode" id="cb21"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> t run <span class="at">--failfast</span> src/pipeline.t</span></code></pre></div>
+<p>In your T scripts, you can also opt-in to this behavior via
+<code>t_make()</code>:</p>
+<pre class="t"><code>t_make(failfast = true)</code></pre>
 <h3 id="cycle-detection">Cycle Detection</h3>
-<p>T detects circular dependencies and reports them:</p>
+<p>T detects circular dependencies and reports them at construction
+time, before any nodes are executed:</p>
 <pre class="t"><code>pipeline {
   a = b
   b = a
 }
 -- Error(ValueError: &quot;Pipeline has a dependency cycle involving node &#39;a&#39;&quot;)</code></pre>
-<h3 id="error-propagation">Error Propagation</h3>
-<p>If a node fails, the error is captured and reported:</p>
-<pre class="t"><code>pipeline {
-  a = 1 / 0
-  b = a + 1
-}
--- Error(ValueError: &quot;Pipeline node &#39;a&#39; failed: ...&quot;)</code></pre>
 <h3 id="missing-nodes">Missing Nodes</h3>
 <p>Accessing a non-existent node returns a structured error:</p>
 <pre class="t"><code>p = pipeline { x = 10 }
@@ -531,16 +548,20 @@ execution:</p>
 <p>Scripts executed with <code>t run</code> <strong>must</strong> call
 <code>populate_pipeline()</code> (or <code>build_pipeline()</code>).
 This ensures that non-interactive execution always produces reproducible
-Nix artifacts.</p>
-<div class="sourceCode" id="cb29"><pre
-class="sourceCode bash"><code class="sourceCode bash"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="co"># ✅ This works — script defines and populates a pipeline</span></span>
-<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> t run my_pipeline.t</span>
-<span id="cb29-3"><a href="#cb29-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb29-4"><a href="#cb29-4" aria-hidden="true" tabindex="-1"></a><span class="co"># ❌ This is rejected — script doesn&#39;t call populate_pipeline()</span></span>
-<span id="cb29-5"><a href="#cb29-5" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> t run my_script.t</span>
-<span id="cb29-6"><a href="#cb29-6" aria-hidden="true" tabindex="-1"></a><span class="co"># Error: non-interactive execution requires a pipeline.</span></span>
-<span id="cb29-7"><a href="#cb29-7" aria-hidden="true" tabindex="-1"></a><span class="co"># Scripts run with `t run` must call `populate_pipeline(p, build=true)` or `build_pipeline()`.</span></span>
-<span id="cb29-8"><a href="#cb29-8" aria-hidden="true" tabindex="-1"></a><span class="co"># Use the REPL for interactive exploration, or pass --unsafe to override.</span></span></code></pre></div>
+Nix artifacts. By default, <code>t run</code> operates in
+<strong>resilient mode</strong>, continuing past errors to provide a
+full diagnostic summary. Use <code>--failfast</code> to change this.</p>
+<div class="sourceCode" id="cb31"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="co"># ✅ This works — resilient by default</span></span>
+<span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> t run my_pipeline.t</span>
+<span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb31-4"><a href="#cb31-4" aria-hidden="true" tabindex="-1"></a><span class="co"># 🛑 This fails immediately on the first error</span></span>
+<span id="cb31-5"><a href="#cb31-5" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> t run <span class="at">--failfast</span> my_pipeline.t</span>
+<span id="cb31-6"><a href="#cb31-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb31-7"><a href="#cb31-7" aria-hidden="true" tabindex="-1"></a><span class="co"># ❌ This is rejected — script doesn&#39;t call populate_pipeline()</span></span>
+<span id="cb31-8"><a href="#cb31-8" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> t run my_script.t</span>
+<span id="cb31-9"><a href="#cb31-9" aria-hidden="true" tabindex="-1"></a><span class="co"># Error: non-interactive execution requires a pipeline.</span></span>
+<span id="cb31-10"><a href="#cb31-10" aria-hidden="true" tabindex="-1"></a><span class="co"># Use --unsafe to override.</span></span></code></pre></div>
 <p>A valid pipeline script looks like:</p>
 <pre class="t"><code>-- my_pipeline.t
 p = pipeline {
@@ -552,14 +573,14 @@ populate_pipeline(p, build = true)</code></pre>
 <h3 id="interactive-repl">Interactive (REPL)</h3>
 <p>The REPL is <strong>unrestricted</strong> — you can run any T code
 line by line, whether or not it involves pipelines:</p>
-<div class="sourceCode" id="cb31"><pre
-class="sourceCode bash"><code class="sourceCode bash"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> t repl</span>
-<span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a><span class="ex">T</span><span class="op">&gt;</span> x = 1 + 2</span>
-<span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a><span class="ex">T</span><span class="op">&gt;</span> print<span class="er">(</span><span class="ex">x</span><span class="kw">)</span></span>
-<span id="cb31-4"><a href="#cb31-4" aria-hidden="true" tabindex="-1"></a><span class="ex">3</span></span>
-<span id="cb31-5"><a href="#cb31-5" aria-hidden="true" tabindex="-1"></a><span class="ex">T</span><span class="op">&gt;</span> p = pipeline { a = 10 }</span>
-<span id="cb31-6"><a href="#cb31-6" aria-hidden="true" tabindex="-1"></a><span class="ex">T</span><span class="op">&gt;</span> p.a</span>
-<span id="cb31-7"><a href="#cb31-7" aria-hidden="true" tabindex="-1"></a><span class="ex">10</span></span></code></pre></div>
+<div class="sourceCode" id="cb33"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb33-1"><a href="#cb33-1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> t repl</span>
+<span id="cb33-2"><a href="#cb33-2" aria-hidden="true" tabindex="-1"></a><span class="ex">T</span><span class="op">&gt;</span> x = 1 + 2</span>
+<span id="cb33-3"><a href="#cb33-3" aria-hidden="true" tabindex="-1"></a><span class="ex">T</span><span class="op">&gt;</span> print<span class="er">(</span><span class="ex">x</span><span class="kw">)</span></span>
+<span id="cb33-4"><a href="#cb33-4" aria-hidden="true" tabindex="-1"></a><span class="ex">3</span></span>
+<span id="cb33-5"><a href="#cb33-5" aria-hidden="true" tabindex="-1"></a><span class="ex">T</span><span class="op">&gt;</span> p = pipeline { a = 10 }</span>
+<span id="cb33-6"><a href="#cb33-6" aria-hidden="true" tabindex="-1"></a><span class="ex">T</span><span class="op">&gt;</span> p.a</span>
+<span id="cb33-7"><a href="#cb33-7" aria-hidden="true" tabindex="-1"></a><span class="ex">10</span></span></code></pre></div>
 <hr />
 <h2 id="using-imports-in-pipelines">17. Using Imports in Pipelines</h2>
 <p>When a pipeline is built with <code>build_pipeline()</code>, each

--- a/docs/pipeline_tutorial.md
+++ b/docs/pipeline_tutorial.md
@@ -325,11 +325,39 @@ p1.c == p2.c  -- true
 
 ---
 
-## 12. Error Handling
+## 12. Error Handling & Resilience
+
+### Errors are Values
+
+In T, errors are **first-class values**. By default, evaluation is **resilient**: if a node fails, it produces an `Error` value instead of crashing the pipeline. This allows other independent nodes to continue building, giving you a full picture of which parts of your DAG are healthy.
+
+```t
+p = pipeline {
+  a = 1 / 0      -- Produces an Error(DivisionByZero)
+  b = 1 + 1      -- Still succeeds! (2)
+  c = a + 1      -- Fails because 'a' is an error (Error)
+}
+```
+
+When you print or build this pipeline, T provides a summary of which nodes succeeded and which failed.
+
+### The `--failfast` Flag
+
+If you prefer the legacy behavior where evaluation stops immediately at the first error, you can use the `--failfast` flag:
+
+```bash
+$ t run --failfast src/pipeline.t
+```
+
+In your T scripts, you can also opt-in to this behavior via `t_make()`:
+
+```t
+t_make(failfast = true)
+```
 
 ### Cycle Detection
 
-T detects circular dependencies and reports them:
+T detects circular dependencies and reports them at construction time, before any nodes are executed:
 
 ```t
 pipeline {
@@ -337,18 +365,6 @@ pipeline {
   b = a
 }
 -- Error(ValueError: "Pipeline has a dependency cycle involving node 'a'")
-```
-
-### Error Propagation
-
-If a node fails, the error is captured and reported:
-
-```t
-pipeline {
-  a = 1 / 0
-  b = a + 1
-}
--- Error(ValueError: "Pipeline node 'a' failed: ...")
 ```
 
 ### Missing Nodes
@@ -461,17 +477,19 @@ T enforces a clear separation between interactive and non-interactive execution:
 
 ### Non-interactive (`t run`)
 
-Scripts executed with `t run` **must** call `populate_pipeline()` (or `build_pipeline()`). This ensures that non-interactive execution always produces reproducible Nix artifacts.
+Scripts executed with `t run` **must** call `populate_pipeline()` (or `build_pipeline()`). This ensures that non-interactive execution always produces reproducible Nix artifacts. By default, `t run` operates in **resilient mode**, continuing past errors to provide a full diagnostic summary. Use `--failfast` to change this.
 
 ```bash
-# ✅ This works — script defines and populates a pipeline
+# ✅ This works — resilient by default
 $ t run my_pipeline.t
+
+# 🛑 This fails immediately on the first error
+$ t run --failfast my_pipeline.t
 
 # ❌ This is rejected — script doesn't call populate_pipeline()
 $ t run my_script.t
 # Error: non-interactive execution requires a pipeline.
-# Scripts run with `t run` must call `populate_pipeline(p, build=true)` or `build_pipeline()`.
-# Use the REPL for interactive exploration, or pass --unsafe to override.
+# Use --unsafe to override.
 ```
 
 A valid pipeline script looks like:

--- a/docs/pipeline_tutorial.md
+++ b/docs/pipeline_tutorial.md
@@ -343,7 +343,7 @@ When you print or build this pipeline, T provides a summary of which nodes succe
 
 ### The `--failfast` Flag
 
-If you prefer the legacy behavior where evaluation stops immediately at the first error, you can use the `--failfast` flag:
+If you prefer the usual, common behaviour where evaluation stops immediately at the first error, you can use the `--failfast` flag:
 
 ```bash
 $ t run --failfast src/pipeline.t

--- a/docs/pipes.html
+++ b/docs/pipes.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>T Programming Language - pipes</title>
+  <style>
+    code{white-space: pre-wrap;}
+    span.smallcaps{font-variant: small-caps;}
+    div.columns{display: flex; gap: min(4vw, 1.5em);}
+    div.column{flex: auto; overflow-x: auto;}
+    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+    /* The extra [class] is a hack that increases specificity enough to
+       override a similar rule in reveal.js */
+    ul.task-list[class]{list-style: none;}
+    ul.task-list li input[type="checkbox"] {
+      font-size: inherit;
+      width: 0.8em;
+      margin: 0 0.8em 0.2em -1.6em;
+      vertical-align: middle;
+    }
+    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  </style>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<nav>
+    <a href="index.html">Home</a>
+    <a href="getting-started.html">Get Started</a>
+    <a href="language_overview.html">Overview</a>
+    <a href="api-reference.html">API Docs</a>
+    <a href="https://github.com/b-rodrigues/tlang">GitHub</a>
+</nav>
+<div class="container">
+<h1 id="the-pipe-operator">The Pipe Operator (<code>|&gt;</code>)</h1>
+<p>The pipe operator <code>|&gt;</code> is the primary way to structure
+data-driven logic in T-Lang. It enables a clean, top-to-bottom flow that
+transforms data step-by-step.</p>
+<h2 id="philosophy-monadic-vs.-transparent">Philosophy: Monadic
+vs. Transparent</h2>
+<p>In T-Lang, errors are values, which raises a design question:
+<em>Should a pipe always pass the input along, even if it’s an
+error?</em></p>
+<p>T-Lang implements the <strong>Short-circuiting Pipe</strong> by
+default.</p>
+<h3 id="simple-forwarding">1. Simple Forwarding
+(<code>|&gt;</code>)</h3>
+<p>When using the standard pipe, T-Lang provides <strong>Railway
+Oriented Programming</strong> semantics.</p>
+<ul>
+<li><strong>If the input is Data</strong>: It calls the function.</li>
+<li><strong>If the input is an Error</strong>: It
+<strong>short-circuits</strong>. The function is never called, and the
+error is passed directly to the next stage.</li>
+</ul>
+<pre class="t"><code>-- If read_csv fails, filter and select are never even attempted.
+df = read_csv(&quot;missing.csv&quot;) 
+  |&gt; filter($age &gt; 20)
+  |&gt; select($name)
+-- Output: Error(FileError: &quot;File not found&quot;)</code></pre>
+<p><strong>Why this design?</strong> 1. <strong>Reduce Noise</strong>:
+It prevents a single failure from cascading into hundreds of confusing
+“Type Errors” downstream. 2. <strong>Performance</strong>: It avoids
+spinning up expensive resources (like JVMs or Python handlers) if the
+data flow is already broken. 3. <strong>Happy Path</strong>: It allows
+you to write the “Success Path” without littering your code with
+<code>if (is_error(x))</code> checks at every line.</p>
+<h3 id="transparent-forwarding">2. Transparent Forwarding
+(<code>?|&gt;</code>)</h3>
+<p>If you <strong>want</strong> to handle errors within the pipe (e.g.,
+to log them or provide a default value), use the
+<strong>Maybe-Pipe</strong> <code>?|&gt;</code>. This operator always
+forwards the value, even if it is an Error.</p>
+<pre class="t"><code>read_csv(&quot;config.csv&quot;)
+  ?|&gt; \(v) if (is_error(v)) { default_config } else { v }
+  |&gt; validate_config()</code></pre>
+<h2 id="function-calls-vs.-pipes">Function Calls vs. Pipes</h2>
+<p>It is important to note the difference between piping and direct
+function calls:</p>
+<ul>
+<li><strong>Function Calls <code>f(x)</code></strong>: Are
+<strong>Transparent</strong>. The function is always invoked with the
+argument. The function’s internal logic then decides whether to
+propagate the error or handle it.</li>
+<li><strong>Pipe Stages <code>x |&gt; f()</code></strong>: Are
+<strong>Monadic</strong>. The language engine intercepts the Error and
+skips the call entirely.</li>
+</ul>
+<h3 id="example">Example</h3>
+<pre class="t"><code>e = error(&quot;stop&quot;)
+
+-- Transparent call
+is_error(e)   -- Returns true (the function runs)
+
+-- Monadic pipe
+e |&gt; is_error() -- Returns Error(&quot;stop&quot;) (short-circuited, function never runs!)</code></pre>
+<h2 id="summary">Summary</h2>
+<table>
+<colgroup>
+<col style="width: 25%" />
+<col style="width: 25%" />
+<col style="width: 25%" />
+<col style="width: 25%" />
+</colgroup>
+<thead>
+<tr>
+<th style="text-align: left;">Operator</th>
+<th style="text-align: left;">Type</th>
+<th style="text-align: left;">Error Behavior</th>
+<th style="text-align: left;">Use Case</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align: left;"><code>|&gt;</code></td>
+<td style="text-align: left;">Standard Pipe</td>
+<td style="text-align: left;"><strong>Short-circuit</strong></td>
+<td style="text-align: left;">Normal data wrangling pipelines.</td>
+</tr>
+<tr>
+<td style="text-align: left;"><code>?|&gt;</code></td>
+<td style="text-align: left;">Maybe Pipe</td>
+<td style="text-align: left;"><strong>Transparent</strong></td>
+<td style="text-align: left;">Error recovery, logging, and fallback
+logic.</td>
+</tr>
+<tr>
+<td style="text-align: left;"><code>f(x)</code></td>
+<td style="text-align: left;">Function Call</td>
+<td style="text-align: left;"><strong>Transparent</strong></td>
+<td style="text-align: left;">Builtin diagnostics and explicit error
+handling.</td>
+</tr>
+</tbody>
+</table>
+</div>
+<footer>
+    <p>Best viewed with a sense of curiosity.</p>
+    <a href="https://github.com/b-rodrigues/tlang">View Source on GitHub</a>
+</footer>
+
+<script>
+    document.addEventListener("DOMContentLoaded", function () {
+        const blocks = document.querySelectorAll("pre");
+        for (const block of blocks) {
+            const button = document.createElement("button");
+            button.className = "copy-btn";
+            button.innerText = "COPY";
+
+            button.addEventListener("click", () => {
+                // Get pre content excluding the button specifically
+                // Since button is not inside a potential code tag if pandoc produces <pre><code>
+                // but if we use innerText on pre, we might get the button's text too.
+                const clone = block.cloneNode(true);
+                const btnInClone = clone.querySelector(".copy-btn");
+                if (btnInClone) btnInClone.remove();
+
+                const code = clone.innerText.trim();
+
+                navigator.clipboard.writeText(code).then(() => {
+                    button.innerText = "COPIED!";
+                    setTimeout(() => { button.innerText = "COPY"; }, 2000);
+                }).catch((err) => {
+                    console.error("Failed to copy!", err);
+                });
+            });
+
+            block.appendChild(button);
+        }
+    });
+</script>
+</body>
+</html>

--- a/docs/pipes.md
+++ b/docs/pipes.md
@@ -1,0 +1,62 @@
+# The Pipe Operator (`|>`)
+
+The pipe operator `|>` is the primary way to structure data-driven logic in T-Lang. It enables a clean, top-to-bottom flow that transforms data step-by-step.
+
+## Philosophy: Monadic vs. Transparent
+
+In T-Lang, errors are values, which raises a design question: *Should a pipe always pass the input along, even if it's an error?*
+
+T-Lang implements the **Short-circuiting Pipe** by default.
+
+### 1. Simple Forwarding (`|>`)
+When using the standard pipe, T-Lang provides **Railway Oriented Programming** semantics.
+
+- **If the input is Data**: It calls the function.
+- **If the input is an Error**: It **short-circuits**. The function is never called, and the error is passed directly to the next stage.
+
+```t
+-- If read_csv fails, filter and select are never even attempted.
+df = read_csv("missing.csv") 
+  |> filter($age > 20)
+  |> select($name)
+-- Output: Error(FileError: "File not found")
+```
+
+**Why this design?**
+1. **Reduce Noise**: It prevents a single failure from cascading into hundreds of confusing "Type Errors" downstream.
+2. **Performance**: It avoids spinning up expensive resources (like JVMs or Python handlers) if the data flow is already broken.
+3. **Happy Path**: It allows you to write the "Success Path" without littering your code with `if (is_error(x))` checks at every line.
+
+### 2. Transparent Forwarding (`?|>`)
+If you **want** to handle errors within the pipe (e.g., to log them or provide a default value), use the **Maybe-Pipe** `?|>`. This operator always forwards the value, even if it is an Error.
+
+```t
+read_csv("config.csv")
+  ?|> \(v) if (is_error(v)) { default_config } else { v }
+  |> validate_config()
+```
+
+## Function Calls vs. Pipes
+
+It is important to note the difference between piping and direct function calls:
+
+- **Function Calls `f(x)`**: Are **Transparent**. The function is always invoked with the argument. The function's internal logic then decides whether to propagate the error or handle it.
+- **Pipe Stages `x |> f()`**: Are **Monadic**. The language engine intercepts the Error and skips the call entirely.
+
+### Example
+```t
+e = error("stop")
+
+-- Transparent call
+is_error(e)   -- Returns true (the function runs)
+
+-- Monadic pipe
+e |> is_error() -- Returns Error("stop") (short-circuited, function never runs!)
+```
+
+## Summary
+| Operator | Type | Error Behavior | Use Case |
+| :--- | :--- | :--- | :--- |
+| `|>` | Standard Pipe | **Short-circuit** | Normal data wrangling pipelines. |
+| `?|>` | Maybe Pipe | **Transparent** | Error recovery, logging, and fallback logic. |
+| `f(x)` | Function Call | **Transparent** | Builtin diagnostics and explicit error handling. |

--- a/docs/plotting.html
+++ b/docs/plotting.html
@@ -210,12 +210,12 @@ behaves depending on the language of the code chunk.</p>
 <p>Within a <code>{t}</code> code block, <code>read_node()</code>
 follows the same behavior as the REPL: it returns the <strong>JSON
 metadata dictionary</strong>.</p>
-<pre class="markdown"><code>```{t}
+<pre><code class="language-markdown">```{t}
 #| echo: false
-g = read_node(&quot;p_ggplot&quot;)
+g = read_node("p_ggplot")
 print(g.title)
 ```</code></pre>
-<p><em>Output: &quot;Fuel Economy&quot;</em></p>
+<p><em>Output: “Fuel Economy”</em></p>
 <p>This is useful for including summary information about your
 visualizations directly in the text of your report.</p>
 <h3 id="in-r-and-python-chunks">In R and Python Chunks</h3>
@@ -226,22 +226,24 @@ that T replaces with the <strong>absolute path string</strong> to the
 artifact in the Nix store.</p>
 <p>Because <code>read_node()</code> returns a path, you must manually
 load the artifact using the specialized reader for that language.</p>
-<h4 id="example-rendering-a-ggplot2-node-in-r">Example: Rendering a ggplot2 node in R</h4>
-<pre class="markdown"><code>```{r}
+<h4 id="example-rendering-a-ggplot2-node-in-r">Example: Rendering a
+ggplot2 node in R</h4>
+<pre><code class="language-markdown">```{r}
 #| echo: false
-# read_node(&quot;p_ggplot&quot;) becomes '/nix/store/.../artifact'
-p &lt;- readRDS(read_node(&quot;p_ggplot&quot;))
+# read_node("p_ggplot") becomes '/nix/store/.../artifact'
+p <- readRDS(read_node("p_ggplot"))
 p
 ```</code></pre>
-<h4 id="example-rendering-a-matplotlib-node-in-python">Example: Rendering a matplotlib node in Python</h4>
-<pre class="markdown"><code>```{python}
+<h4 id="example-rendering-a-matplotlib-node-in-python">Example:
+Rendering a matplotlib node in Python</h4>
+<pre><code class="language-markdown">```{python}
 #| echo: false
 try:
     import cloudpickle as pickle
 except ImportError:
     import pickle
-# read_node(&quot;p_matplotlib&quot;) becomes '/nix/store/.../artifact'
-with open(read_node(&quot;p_matplotlib&quot;), &quot;rb&quot;) as f:
+# read_node("p_matplotlib") becomes '/nix/store/.../artifact'
+with open(read_node("p_matplotlib"), "rb") as f:
     fig = pickle.load(f)
 fig
 ```</code></pre>
@@ -249,7 +251,8 @@ fig
 inspection and R/Python for high-fidelity visual rendering, all while
 maintaining strict Nix-based reproducibility.</p>
 <hr />
-<h2 id="opening-plots-with-show_plot">Opening Plots with <code>show_plot()</code></h2>
+<h2 id="opening-plots-with-show_plot">Opening Plots with
+<code>show_plot()</code></h2>
 <p><code>show_plot()</code> renders a plotting artifact in a fresh Nix
 sandbox, writes the rendered image to <code>_pipeline/</code>, and then
 opens the image locally.</p>
@@ -264,8 +267,9 @@ plot node</li>
 <code>_pipeline/</code>.</p>
 <p>Add an opener in <code>tproject.toml</code> if you want to override
 the default viewer:</p>
-<pre class="toml"><code>[visualization-tool]
-command = &quot;xdg-open&quot;</code></pre>
+<div class="sourceCode" id="cb4"><pre
+class="sourceCode toml"><code class="sourceCode toml"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="kw">[visualization-tool]</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a><span class="dt">command</span> <span class="op">=</span> <span class="st">&quot;xdg-open&quot;</span></span></code></pre></div>
 <p>The value must be a single executable name or an absolute path to an
 executable. When no custom tool is configured, T falls back to:</p>
 <ol type="1">
@@ -346,16 +350,16 @@ they are missing.</p>
 </tbody>
 </table>
 <p>Example project configuration:</p>
-<div class="sourceCode" id="cb9"><pre
-class="sourceCode toml"><code class="sourceCode toml"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="kw">[r-dependencies]</span></span>
-<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a><span class="dt">packages</span> <span class="op">=</span> <span class="op">[</span><span class="st">&quot;ggplot2&quot;</span><span class="op">]</span></span>
-<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a><span class="kw">[py-dependencies]</span></span>
-<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a><span class="dt">version</span> <span class="op">=</span> <span class="st">&quot;python314&quot;</span></span>
-<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a><span class="dt">packages</span> <span class="op">=</span> <span class="op">[</span><span class="st">&quot;matplotlib&quot;</span><span class="op">,</span> <span class="st">&quot;plotnine&quot;</span><span class="op">,</span> <span class="st">&quot;seaborn&quot;</span><span class="op">,</span> <span class="st">&quot;plotly&quot;</span><span class="op">,</span> <span class="st">&quot;kaleido&quot;</span><span class="op">]</span></span>
-<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a><span class="kw">[visualization-tool]</span></span>
-<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a><span class="dt">command</span> <span class="op">=</span> <span class="st">&quot;xdg-open&quot;</span></span></code></pre></div>
+<div class="sourceCode" id="cb6"><pre
+class="sourceCode toml"><code class="sourceCode toml"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="kw">[r-dependencies]</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a><span class="dt">packages</span> <span class="op">=</span> <span class="op">[</span><span class="st">&quot;ggplot2&quot;</span><span class="op">]</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a><span class="kw">[py-dependencies]</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a><span class="dt">version</span> <span class="op">=</span> <span class="st">&quot;python314&quot;</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a><span class="dt">packages</span> <span class="op">=</span> <span class="op">[</span><span class="st">&quot;matplotlib&quot;</span><span class="op">,</span> <span class="st">&quot;plotnine&quot;</span><span class="op">,</span> <span class="st">&quot;seaborn&quot;</span><span class="op">,</span> <span class="st">&quot;plotly&quot;</span><span class="op">,</span> <span class="st">&quot;kaleido&quot;</span><span class="op">]</span></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a><span class="kw">[visualization-tool]</span></span>
+<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a><span class="dt">command</span> <span class="op">=</span> <span class="st">&quot;xdg-open&quot;</span></span></code></pre></div>
 <h3 id="files-written-to-_pipeline">Files Written to
 <code>_pipeline/</code></h3>
 <p>When you call <code>show_plot()</code>, T creates local helper files

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -1057,6 +1057,10 @@ evaluation)</td>
 <td>Configure a Python Pipeline Node</td>
 </tr>
 <tr>
+<td><a href="qn.html">qn</a></td>
+<td>Configure a Quarto Pipeline Node</td>
+</tr>
+<tr>
 <td><a href="quantile.html">quantile</a></td>
 <td>Quantiles</td>
 </tr>

--- a/docs/reference/qn.html
+++ b/docs/reference/qn.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>T Function Reference - get</title>
+  <title>T Function Reference - qn</title>
   <style>
     code{white-space: pre-wrap;}
     span.smallcaps{font-variant: small-caps;}
@@ -33,47 +33,46 @@
     <a href="https://github.com/b-rodrigues/tlang">GitHub</a>
 </nav>
 <div class="container">
-<h1 id="get">get</h1>
-<p>Unified data retrieval for names, collections, pipelines, and
-lenses</p>
-<p><code>get()</code> is a polymorphic retrieval helper:</p>
-<ul>
-<li><code>get("x")</code> / <code>get(sym("x"))</code> looks up a
-variable in the current environment</li>
-<li><code>get(collection, index)</code> indexes a <code>List</code>,
-<code>Vector</code>, or <code>NDArray</code></li>
-<li><code>get(pipeline, "node")</code> retrieves a pipeline node
-result</li>
-<li><code>get(data, lens)</code> applies a lens focus to a value</li>
-<li><code>get(node_lens("name"))</code> retrieves a sandboxed
-sibling-node artifact via <code>T_NODE_&lt;name&gt;</code></li>
-</ul>
+<h1 id="qn">qn</h1>
+<p>Configure a Quarto Pipeline Node</p>
+<p>A convenience wrapper around <code>node()</code> with
+<code>runtime = "Quarto"</code>. Used directly within a
+<code>pipeline { ... }</code> block to render Quarto documents.</p>
 <h2 id="parameters">Parameters</h2>
 <ul>
-<li><p><strong>target</strong>
-(<code>String | Symbol | List | Vector | NDArray | Pipeline | Lens</code>):
-The value or name to retrieve from.</p></li>
-<li><p><strong>selector</strong>
-(<code>Int | String | Symbol | Lens</code>, optional): The index, node
-name, or lens to apply when a second argument is provided.</p></li>
+<li><p><strong>script</strong> (<code>String</code>): (Optional) Path to
+an external <code>.qmd</code> file to render. Mutually exclusive with
+<code>command</code>.</p></li>
+<li><p><strong>serializer</strong> (<code>String | Function</code>):
+(Optional) Custom serializer strategy. Built-in values include
+“default”, “arrow”, and “pmml”. Can be a string (e.g., “arrow”) or an
+unquoted function name. Custom functions can also be used. Default =
+“default”.</p></li>
+<li><p><strong>deserializer</strong> (<code>String | Function</code>):
+(Optional) Custom deserializer strategy. Built-in values include
+“default”, “arrow”, and “pmml”. Can be a string (e.g., “arrow”) or an
+unquoted function name. Custom functions can also be used. Default =
+“default”.</p></li>
+<li><p><strong>env_vars</strong> (<code>Dict</code>): (Optional)
+Environment variables to pass into the sandbox.</p></li>
+<li><p><strong>args</strong> (<code>Dict</code>): (Optional)
+Runtime/tool arguments. Use this to pass Quarto CLI arguments such as
+<code>subcommand</code>, <code>path</code>, <code>to</code>, and
+additional options. <code>output_dir</code> is reserved and managed
+automatically so the rendered result is stored as the node
+artifact.</p></li>
+<li><p><strong>functions</strong> (<code>String | List[String]</code>):
+(Optional) Files to source before execution.</p></li>
+<li><p><strong>include</strong> (<code>String | List[String]</code>):
+(Optional) Additional files for the sandbox.</p></li>
+<li><p><strong>noop</strong> (<code>Bool</code>): (Optional) Whether to
+skip execution and generate a stub. Default = false.</p></li>
 </ul>
 <h2 id="returns">Returns</h2>
-<p>The looked-up value, selected element, node result, or lens
-focus.</p>
-<h2 id="examples">Examples</h2>
-<pre class="t"><code>salary = 50000
-get(&quot;salary&quot;)                  -- 50000
-get(sym(&quot;salary&quot;))             -- 50000
-
-get([10, 20, 30], 1)           -- 20
-
-p = pipeline { a = 1 }
-get(p, &quot;a&quot;)                    -- 1
-
-l = col_lens(&quot;mpg&quot;)
-get(mtcars, l)                 -- focused column
-
-get(node_lens(&quot;model&quot;))        -- sandbox artifact lookup</code></pre>
+<p>The evaluated return value of the command.</p>
+<h2 id="see-also">See Also</h2>
+<p><a href="node.html">node</a>, <a href="rn.html">rn</a>, <a
+href="pyn.html">pyn</a>, <a href="shn.html">shn</a></p>
 </div>
 <footer>
     <p>Best viewed with a sense of curiosity.</p>

--- a/docs/reference/sym.html
+++ b/docs/reference/sym.html
@@ -39,7 +39,7 @@
 with <code>!!</code>. Existing Symbol values pass through unchanged.</p>
 <h2 id="parameters">Parameters</h2>
 <ul>
-<li><strong>x</strong> (<code>String</code>): | Symbol The name to
+<li><strong>x</strong> (<code>String | Symbol</code>): The name to
 convert.</li>
 </ul>
 <h2 id="returns">Returns</h2>

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
         # Use the Nix packages for the specified system
         pkgs = (import (builtins.fetchTarball {
           url    = "https://github.com/rstats-on-nix/nixpkgs/archive/${rstats-nix-date}.tar.gz";
-          sha256 = "sha256:1s15dyjjwy859ym7k2kwa7in24hh9swg4y2cvzggny07jmvvr86g";
+          sha256 = "sha256:1swwshrqn4aq8fcg99n3nphahcc3zjj47ll11jm085lplb9s712n";
         }) { inherit system; }).extend (self: super: {
           lightgbm = super.lightgbm.overrideAttrs (old: {
             cudaSupport = false;

--- a/flake.nix
+++ b/flake.nix
@@ -183,6 +183,7 @@
       {
         # The default package - allows `nix build` and `nix run`
         packages.default = t-lang;
+        legacyPackages = pkgs;
 
         # Make it runnable with `nix run`
         apps.default = {

--- a/spec_files/more_demos.md
+++ b/spec_files/more_demos.md
@@ -1,0 +1,132 @@
+# Specification: Proposed T-Lang Demonstration Projects
+
+This document outlines a roadmap for new demonstration projects in the `t_demos/` repository. These demos are intended to exercise features documented in `tlang/summary.md` that are currently under-tested or lack clear "real-world" representative examples.
+
+## 1. Error Recovery and Resilience (`error_recovery_t`)
+
+**Rationale:** T treats errors as values. While the standard pipe `|>` short-circuits, the `?|>` operator and `is_error` introspection are critical for building resilient production pipelines.
+
+**Key Functions:**
+- `?|>` (Forwarding Pipe)
+- `is_error(x)`
+- `error_message(x)`
+- `error_code(x)`
+- `ifelse()` for recovery logic
+
+**Demo Scenario:**
+- A pipeline that attempts to read a CSV that might be missing or corrupt.
+- Use `?|>` to catch the error.
+- A recovery node checks `if (is_error(data))`, logs the error message to a text file, and provides a default empty DataFrame so the rest of the pipeline (e.g., a Quarto report) can still build without a hard crash.
+
+---
+
+## 2. Advanced Data Reshaping (`tidy_reshaping_t`)
+
+**Rationale:** The `colcraft` package implements most of the `tidyr` verb set. We need to verify that T can handle complex schema pivots and nested data structures natively.
+
+**Key Functions:**
+- `pivot_longer()`, `pivot_wider()`
+- `separate()`, `unite()`
+- `nest()`, `unnest()`
+- `crossing()`, `expand()`
+
+**Demo Scenario:**
+- "Cleaning Messy WHO Data": Take a dataset with columns like `m014`, `m1524` (sex + age combined in headers).
+- Use `pivot_longer` and `separate` to create clean `sex` and `age` columns.
+- Use `nest` to create a "grouped" dataframe for per-group modeling, then `unnest` to compare results.
+
+---
+
+## 3. Temporal Analysis and Period Math (`chrono_analysis_t`)
+
+**Rationale:** Datetime logic is notoriously bug-prone. We need a demo that exercises parsing, truncation, and arithmetic across different granularities.
+
+**Key Functions:**
+- `ymd()`, `dmy_hms()`
+- `floor_date()`, `ceiling_date()`
+- `years()`, `months()`, `days()` (Periods)
+- `with_tz()`, `force_tz()` (Labeling checks)
+
+**Demo Scenario:**
+- "Contract Value Calculator": Given a list of start dates and contract durations.
+- Calculate expiry dates using period addition.
+- Group by "Expiry Quarter" using `floor_date(date, "quarter")`.
+- Verify the "Label-only" behavior of timezones as documented in `summary.md`.
+
+---
+
+## 4. Advanced Metaprogramming Lifecycle (`advanced_nse_t`)
+
+**Rationale:** `get_sym_demo_t` covers simple lookup. We need to demonstrate "Lazy Evaluation" for users writing their own domain-specific wrappers.
+
+**Key Functions:**
+- `quo()`, `enquo()`
+- `eval()`
+- `expr()`
+- `as_string()` / `sym()` converters
+
+**Demo Scenario:**
+- Create a custom function `my_summarizer = \(df, col) { ... }` that uses `enquo(col)` to capture a column reference and `eval()` it inside a `summarize` block.
+- Demonstrate how to programmatically build a pipeline step using `expr()`.
+
+---
+
+## 5. Auditable Pipelines with Intent Metadata (`auditable_pipeline_t`)
+
+**Rationale:** T is designed for human-LLM collaboration. `intent {}` blocks provide the "Why" that standard code comments lack.
+
+**Key Functions:**
+- `intent { ... }` blocks
+- `explain(node)`
+- `explain_json(node)`
+
+**Demo Scenario:**
+- A "Credit Scoring" pipeline where every node (Data Cleaning, Feature Engineering, Model Training) has an `intent` block documenting the regulatory assumptions used.
+- A final "Audit Node" calls `explain()` on all previous nodes and generates a summary text file for human review.
+
+---
+
+## 6. Matrix Algebra and Custom Models (`matrix_math_t`)
+
+**Rationale:** Ensure the `ndarray` and linear algebra builtins in the `math` package are robust for users who want to avoid R/Python for simple numerical tasks.
+
+**Key Functions:**
+- `ndarray()`, `reshape()`
+- `matmul()` (or `@` if supported)
+- `transpose()`, `inv()`
+- `standardize()`, `normalize()`
+
+**Demo Scenario:**
+- implement a "Bare Metal" OLS (Ordinary Least Squares) solver using the normal equation: $\hat{\beta} = (X^T X)^{-1} X^T y$.
+- Compare the coefficients with the native `lm()` function to verify numerical stability.
+
+---
+
+## 7. Factor Engineering (`factor_clean_t`)
+
+**Rationale:** Categorical data is a first-class citizen in `colcraft`. We need to show how to handle "Other" categories and reordering.
+
+**Key Functions:**
+- `fct_lump_n()`, `fct_lump_prop()`
+- `fct_reorder()`, `fct_relevel()`
+- `fct_recode()`
+
+**Demo Scenario:**
+- "Social Survey Cleaning": A dataset with 50+ unique country names.
+- Lump all but the top 5 into "Other".
+- Reorder a "Satisfaction" factor (Low, Medium, High) which is alphabetically incorrect.
+- Recode old category names to new ones.
+
+---
+
+## 8. High-Fidelity Equality and Introspection (`integrity_check_t`)
+
+**Rationale:** In a reproducibility-first language, verifying that two runs produced *exactly* the same complex objects is vital.
+
+**Key Functions:**
+- `identical()`
+- `glimpse()`
+- `digest()` (if available) or `explain_json()` comparison
+
+**Demo Scenario:**
+- Generate two models using slightly different data and show that `==` might be misleading (or limited) while `identical()` correctly identifies structural differences in the model metadata.

--- a/spec_files/soft-erroring.md
+++ b/spec_files/soft-erroring.md
@@ -1,0 +1,67 @@
+# Soft-Erroring and Cross-Node Recovery
+
+This document specifies the transition from "Fail-Fast DAGs" to "Resilient DAGs" in T-Lang.
+
+## 1. Problem Statement
+Currently, the pipeline evaluator (`eval_pipeline` and `rerun_pipeline` in `eval.ml`) implements an aggressive short-circuiting mechanism: if any dependency of a node evaluates to a `VError`, the dependent node is immediately marked as a `VError` with an "Upstream error" prefix.
+
+This prevents the use of the Maybe-Pipe (`?|>`) and `is_error()` checks across node boundaries, effectively breaking the "Errors are Values" principle at the pipeline scale.
+
+## 2. Specification: Resilient DAG Evaluation
+
+### 2.1. Removal of DAG-Level Short-Circuit
+The evaluator must **no longer** pre-emptively check for `VError` in a node's dependencies during the topological fold. Instead:
+- Every node's `command` must be allowed to execute via `eval_expr`.
+- It is the responsibility of the `command` expression to decide how to handle incoming errors.
+- Standard pipes (`|>`) and standard functions will naturally propagate errors (preserving existing fail-fast behavior for unhandled errors).
+- Recovery operators (`?|>`, `match`, `is_error()`) will now correctly receive the `VError` value from upstream nodes.
+
+### 2.2. Enhanced Diagnostics
+To maintain auditability, nodes must track their relationship with upstream failures even if they recover.
+
+#### `node_diagnostics` Extension
+The `node_diagnostics` structure (in `ast.ml`) will be extended:
+```ocaml
+and node_diagnostics = {
+  nd_warnings : node_warning list;
+  nd_error : node_error option;
+  nd_warnings_suppressed : bool;
+  nd_recovered : bool;                 (* NEW: True if node produced non-error from error input *)
+  nd_upstream_errors : string list;    (* NEW: Names of failed dependencies *)
+}
+```
+
+#### `build_node_diagnostics` Logic
+When computing diagnostics for node `N`:
+1.  Identify all dependencies `D` that evaluate to `VError`.
+2.  Set `nd_upstream_errors` to the names of those dependencies.
+3.  If `nd_upstream_errors` is NOT empty AND the resulting value of `N` is NOT a `VError`, set `nd_recovered = true`.
+
+## 3. Summarization and Presentation
+
+### 3.1. CLI Summary Updates
+The `print_pipeline_diagnostics_summary` function will be updated to include a third category of results:
+
+| Status | Symbol | Meaning |
+| :--- | :---: | :--- |
+| **Success** | `✔` | Produced a value; no upstream errors. |
+| **Recovered**| `❍` | Produced a value despite upstream errors. |
+| **Error** | `✖` | Produced a `VError`. |
+
+**Example Output:**
+```text
+Pipeline summary: 0 node(s) with warnings, 1 error(s), 2 recovered
+  ✖  raw_data — File 'data.csv' not found.
+  ❍  clean_data — Recovered from upstream error in `raw_data`.
+  ❍  summary_stats — Recovered from upstream error in `raw_data`.
+```
+
+### 3.2. Pipeline Audit Log
+The `read_node()` and `explain()` functions must surface `recovered` status and point back to the original causal error, ensuring that "Soft-Erroring" does not accidentally hide the fact that a failure occurred upstream.
+
+## 4. Implementation Goals
+1.  **Modify `ast.ml`**: Update `node_diagnostics` and related unparsers.
+2.  **Modify `eval.ml`**: 
+    - Remove the `upstream_err_opt` check in `eval_pipeline` and `rerun_pipeline`.
+    - Update `build_node_diagnostics` to populate recovery flags.
+    - Update `print_pipeline_diagnostics_summary` for the new symbols.

--- a/spec_files/structural-error.md
+++ b/spec_files/structural-error.md
@@ -1,0 +1,71 @@
+# Specification: StructuralError
+
+## Overview
+This specification introduces a new category of error in T-Lang: the `StructuralError`. Unlike standard `VError` values which are treated as first-class data in "Resilient-by-Default" mode, a `StructuralError` represents a fundamental failure in the project's orchestration, dependency graph, or environment.
+
+**Core Principle**: Structural integrity is required for resilient evaluation to be meaningful. You cannot handle errors as values if the value's path is structurally impossible.
+
+---
+
+## 1. Classification
+A `StructuralError` is defined as any error that prevents the valid construction, materialization, or execution of a pipeline's DAG (Directed Acyclic Graph).
+
+### Key Categories:
+1.  **Graph Topology Failures**:
+    *   **Cyclical Dependencies**: Node A -> Node B -> Node A.
+    *   **Missing Node References**: Node A depends on `user_data_bis`, but only `user_data` exists in the pipeline.
+2.  **Inter-Node Coherence Failures**:
+    *   **Serialization Mismatch**: Node A produces ^arrow but Node B (a consumer) explicitly requests ^pmml for that dependency.
+    *   **Arity/Signature Mismatch in Pipeline Context**: Calling a pipeline node with the wrong number of arguments in a task-style node definition.
+3.  **Infrastructure Failures**:
+    *   **Missing Tooling**: `nix-build` or `arrow-glib` not found in the environment.
+    *   **Project Config Violations**: `tproject.toml` is missing, malformed, or lacks the mandatory dependencies for the requested serializers.
+    *   **Unsatisfied Dependencies**: Pipeline nodes require packages (e.g., `arrow`, `pyarrow`, `onnx`) that are missing from `tproject.toml` and cannot be automatically injected.
+        *   If `TLANG_AUTO_ADD_PIPELINE_DEPS=1` is set, T-Lang will attempt to update `tproject.toml` automatically.
+        *   If the update fails, is declined by the user, or cannot proceed (e.g., non-interactive session without the flag), a `StructuralError` is raised.
+    *   **Materialization Failures**: Failure to write to `_pipeline/` or generate the `pipeline.nix` entry.
+
+---
+
+## 2. Behavioral Semantics: The "Loud Failure"
+The primary difference between a `StructuralError` and a standard `VError` is how the Evaluator (runner) handles it during program execution.
+
+### Evaluation Rules:
+- **Resilient Mode (`resilient=true`)**: Standard errors (e.g., `DivisionByZero`, `NameError`, `ValueError`) are returned as values and execution continues.
+- **Structural Exception**: If a statement or expression evaluates to a `VError` with the code `StructuralError`, **evaluation must halt immediately**, regardless of the resilience setting.
+
+### Rationale:
+In the "Resilient-by-Default" model, we allow scripts to continue so users can see full diagnostic summaries. However, if a structural error occurs (e.g., `populate_pipeline` fails due to a missing dependency), letting the script continue leads to "cascading gibberish"—where subsequent steps fail for confusing reasons (like "logs not found") rather than the original structural cause.
+
+---
+
+## 3. Integration with Builtins
+The following builtins will be updated to emit `StructuralError` instead of `FileError` or `ValueError` in specific cases:
+
+| Builtin | Condition | Previous Error | New Error |
+|---|---|---|---|
+| `pipeline { ... }` | Dependency Cycle | `ValueError` | `StructuralError` |
+| `pipeline { ... }` | Reference to missing node | `NameError`/`KeyError` | `StructuralError` |
+| `populate_pipeline` | Missing tool (`nix-build`) | `FileError` | `StructuralError` |
+| `populate_pipeline` | Serializer Coherence Failure | `FileError` | `StructuralError` |
+| `populate_pipeline` | Missing dependencies in `tproject.toml` | `FileError` | `StructuralError` |
+
+---
+
+## 4. User Experience (UX)
+When a `StructuralError` is encountered, the T-Lang runner should provide a distinct visual treatment:
+
+```text
+✖ FATAL STRUCTURAL ERROR: [src/pipeline.t:L143] 
+  Pipeline requires explicit dependencies in `tproject.toml` before it can be built.
+  Missing entries: [py-dependencies] packages += ["pyarrow"]
+  
+Building halted. (Structural errors bypass resilient evaluation)
+```
+
+---
+
+## 5. Summary of Impacts
+- **Evaluator**: `eval_program` must be updated to detect the `StructuralError` code and trigger an early return.
+- **Diagnostics**: `StructuralError` should carry rich context (e.g., the missing node name, or the specific serializer mismatch).
+- **Existing Demos**: Projects with structurally invalid `tproject.toml` files will now fail loudly and correctly, rather than failing silently and confusingly in downstream steps.

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -38,6 +38,7 @@ type error_code =
   | GenericError
   | NAPredicateError
   | MissingArtifactError
+  | StructuralError
 
 (** Structured source location *)
 type source_location = {
@@ -549,6 +550,7 @@ module Utils = struct
     | GenericError -> "GenericError"
     | NAPredicateError -> "NAPredicateError"
     | MissingArtifactError -> "MissingArtifactError"
+    | StructuralError -> "StructuralError"
 
   let error_code_of_string = function
     | "TypeError" -> TypeError
@@ -568,6 +570,7 @@ module Utils = struct
     | "GenericError" -> GenericError
     | "NAPredicateError" -> NAPredicateError
     | "MissingArtifactError" -> MissingArtifactError
+    | "StructuralError" -> StructuralError
     | _ -> RuntimeError
 
   let na_type_to_string = function

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -101,6 +101,8 @@ and node_diagnostics = {
   nd_warnings : node_warning list;
   nd_error : node_error option;
   nd_warnings_suppressed : bool;
+  nd_recovered : bool;
+  nd_upstream_errors : string list;
 }
 
 
@@ -398,6 +400,8 @@ module Utils = struct
     nd_warnings = [];
     nd_error = None;
     nd_warnings_suppressed = false;
+    nd_recovered = false;
+    nd_upstream_errors = [];
   }
 
   let rec unwrap_value = function
@@ -478,6 +482,8 @@ module Utils = struct
        | Some error -> node_error_to_value error
        | None -> VNA NAGeneric);
       ("warnings_suppressed", VBool diagnostics.nd_warnings_suppressed);
+      ("recovered", VBool diagnostics.nd_recovered);
+      ("upstream_errors", VList (List.map (fun s -> (None, VString s)) diagnostics.nd_upstream_errors));
     ]
 
   let node_has_own_warnings diagnostics =
@@ -506,16 +512,23 @@ module Utils = struct
            if diagnostics.nd_warnings_suppressed && node_has_own_warnings diagnostics 
            then Some (None, VString name) else None)
     in
+    let recovered_nodes =
+      node_diagnostics
+      |> List.filter_map (fun (name, diagnostics) ->
+           if diagnostics.nd_recovered then Some (None, VString name) else None)
+    in
     let warning_count = List.length warning_nodes in
     let error_count = List.length error_nodes in
     let suppressed_count = List.length suppressed_nodes in
+    let recovered_count = List.length recovered_nodes in
     VDict [
       ("warning_nodes", VList warning_nodes);
       ("error_nodes", VList error_nodes);
       ("suppressed_nodes", VList suppressed_nodes);
+      ("recovered_nodes", VList recovered_nodes);
       ("summary",
-       VString (Printf.sprintf "%d node(s) with warnings, %d suppressed, %d error(s)" 
-                 warning_count suppressed_count error_count));
+       VString (Printf.sprintf "%d node(s) with warnings, %d suppressed, %d error(s), %d recovered" 
+                 warning_count suppressed_count error_count recovered_count));
     ]
 
   let error_code_to_string = function

--- a/src/cli_args.ml
+++ b/src/cli_args.ml
@@ -11,6 +11,7 @@ type mode_parse = {
   args : string list;
   mode : Typecheck.mode;
   mode_flag : bool;
+  failfast : bool;
 }
 
 let validate_path ~kind path =
@@ -35,12 +36,13 @@ let validate_path ~kind path =
   | Sys_error msg -> Error msg
 
 let parse_mode_args (args : string list) : (mode_parse, string) result =
-  let rec extract acc mode seen = function
+  let rec extract acc mode seen failfast = function
     | [] ->
         Ok {
           args = List.rev acc;
           mode;
           mode_flag = seen;
+          failfast;
         }
     | "--mode" :: [] ->
         Error "Missing value for --mode. Use --mode repl|strict"
@@ -49,14 +51,15 @@ let parse_mode_args (args : string list) : (mode_parse, string) result =
           Error "Duplicate --mode flag. Use --mode repl|strict only once."
         else
           (match Typecheck.mode_of_string m with
-           | Some mode' -> extract acc mode' true rest
+           | Some mode' -> extract acc mode' true failfast rest
            | None ->
                Error (Printf.sprintf "Invalid mode '%s'. Use --mode repl|strict" m))
-    | x :: xs -> extract (x :: acc) mode seen xs
+    | "--failfast" :: rest -> extract acc mode seen true rest
+    | x :: xs -> extract (x :: acc) mode seen failfast xs
   in
-  extract [] Typecheck.Repl false args
+  extract [] Typecheck.Repl false false args
 
-let validate_cli_flags ~mode_flag ~unsafe_flag (args : string list) : (unit, string) result =
+let validate_cli_flags ~mode_flag ~unsafe_flag ~failfast_flag (args : string list) : (unit, string) result =
   let commands = ["run"; "repl"; "test"; "explain"; "init"; "doc"; "doctor"; "docs"; "update"; "publish"; "--help"; "-h"; "--version"; "-v"] in
   let command =
     match args with
@@ -92,6 +95,8 @@ let validate_cli_flags ~mode_flag ~unsafe_flag (args : string list) : (unit, str
     Error "--unsafe cannot be used with `t run --expr`."
   else if mode_flag && (not mode_allowed) then
     Error "--mode only applies to repl/run/explain."
+  else if failfast_flag && (not mode_allowed) then
+    Error "--failfast only applies to repl/run/explain."
   else
     Ok ()
 

--- a/src/error.ml
+++ b/src/error.ml
@@ -107,3 +107,6 @@ let match_error ?location msg =
 
 let runtime_error ?location msg =
   make_error ?location RuntimeError msg
+
+let structural_error ?location msg =
+  make_error ?location StructuralError msg

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -212,12 +212,22 @@ let build_node_diagnostics node_name node_deps own_warnings diagnostics_so_far v
              List.map (inherit_warning dep_name) diagnostics.Ast.nd_warnings
          | None -> [])
   in
+  let upstream_errors =
+    node_deps
+    |> List.filter (fun dep_name ->
+         match List.assoc_opt dep_name diagnostics_so_far with
+         | Some diagnostics -> diagnostics.Ast.nd_error <> None
+         | None -> false)
+  in
   let suppressed = !current_node_suppression_requested in
   current_node_suppression_requested := false;
+  let is_error = match value with VError _ -> true | _ -> false in
   {
     Ast.nd_warnings = dedupe_warnings (own_warnings @ upstream_warnings);
     nd_error = node_error_of_value node_name value;
     nd_warnings_suppressed = suppressed;
+    nd_recovered = (upstream_errors <> [] && not is_error);
+    nd_upstream_errors = upstream_errors;
   }
 
 (** Print a compact stderr summary of warning and error diagnostics for a
@@ -235,11 +245,16 @@ let print_pipeline_diagnostics_summary node_diagnostics =
          | Some error -> Some (name, error)
          | None -> None)
   in
-  if !show_warnings && (warning_nodes <> [] || error_nodes <> []) then begin
+  let recovered_nodes =
+    node_diagnostics
+    |> List.filter (fun (_, diagnostics) -> diagnostics.Ast.nd_recovered)
+  in
+  if !show_warnings && (warning_nodes <> [] || error_nodes <> [] || recovered_nodes <> []) then begin
     Printf.eprintf
-      "Pipeline summary: %d node(s) with warnings, %d error(s)\n%!"
+      "Pipeline summary: %d node(s) with warnings, %d error(s), %d recovered\n%!"
       (List.length warning_nodes)
-      (List.length error_nodes);
+      (List.length error_nodes)
+      (List.length recovered_nodes);
     List.iter (fun (name, diagnostics) ->
       let own_warnings =
         diagnostics.Ast.nd_warnings
@@ -262,9 +277,14 @@ let print_pipeline_diagnostics_summary node_diagnostics =
             (List.length own_warnings)
             na_total
     ) warning_nodes;
-    List.iter (fun (name, error) ->
-      Printf.eprintf "  ✖  %s — %s\n%!" name error.Ast.ne_message
-    ) error_nodes
+    List.iter (fun (name, diagnostics) ->
+      match diagnostics.Ast.nd_error with
+      | Some error -> Printf.eprintf "  ✖  %s — %s\n%!" name error.Ast.ne_message
+      | None -> ()
+    ) node_diagnostics;
+    List.iter (fun (name, _) ->
+      Printf.eprintf "  ❍  %s — Recovered from upstream failure.\n%!" name
+    ) recovered_nodes
   end
 
 (** Check if an expression uses NSE (contains $field references) *)
@@ -1574,25 +1594,7 @@ and eval_pipeline env_ref (nodes : (string * Ast.expr) list) : value =
           un_env_vars = []; un_args = []; un_shell = None; un_shell_args = [];
           un_functions = []; un_includes = []; un_noop = false; un_dependencies = None } in
       let node_deps = match List.assoc_opt name deps with Some d -> d | None -> [] in
-      let upstream_err_opt = List.find_opt (fun d ->
-         match Env.find_opt d !current_env_ref with
-         | Some (VError _) -> true
-         | _ -> false) node_deps in
-      let (v, own_warnings) =
-        match upstream_err_opt with
-        | Some failed_dep ->
-            (match Env.find_opt failed_dep !current_env_ref with
-             | Some (VError err) ->
-                 let msg = if String.starts_with ~prefix:"Upstream error: " err.message then
-                     err.message
-                 else
-                     "Upstream error: " ^ err.message
-                 in
-                 (Ast.VError { err with message = pipeline_error_message ~node_name:name ~detail:msg }, [])
-              | _ -> capture_node_warnings (fun () -> eval_or_defer name un current_env_ref))
-        | None ->
-            capture_node_warnings (fun () -> eval_or_defer name un current_env_ref)
-      in
+      let (v, own_warnings) = capture_node_warnings (fun () -> eval_or_defer name un current_env_ref) in
       let node_diagnostics =
         build_node_diagnostics name node_deps own_warnings diagnostics v
       in
@@ -1739,25 +1741,7 @@ and rerun_pipeline ?(strict=false) env_ref (prev : Ast.pipeline_result) : value 
         old_val <> prev_val
       ) external_deps in
       if deps_changed || external_changed then begin
-        let upstream_err_opt = List.find_opt (fun d ->
-           match Env.find_opt d !current_env_ref with
-           | Some (VError _) -> true
-           | _ -> false) node_deps in
-        let (v, own_warnings) = match upstream_err_opt with
-          | Some failed_dep ->
-              (match Env.find_opt failed_dep !current_env_ref with
-               | Some (VError err) ->
-                   let msg = if String.starts_with ~prefix:"Upstream error: " err.message then
-                       err.message
-                   else
-                       "Upstream error: " ^ err.message
-                   in
-                   let runtime = match List.assoc_opt "runtime" err.context with Some (VString r) -> Some r | _ -> None in
-                   (Ast.VError { err with message = pipeline_error_message ~node_name:name ~detail:msg;
-                                         context = (match runtime with Some r -> if List.mem_assoc "runtime" err.context then err.context else ("runtime", VString r) :: err.context | None -> err.context) }, [])
-                | _ -> capture_node_warnings (fun () -> rerun_eval_or_defer name un current_env_ref))
-          | None -> capture_node_warnings (fun () -> rerun_eval_or_defer name un current_env_ref)
-        in
+        let (v, own_warnings) = capture_node_warnings (fun () -> rerun_eval_or_defer name un current_env_ref) in
         let node_diagnostics =
           build_node_diagnostics name node_deps own_warnings diagnostics v
         in

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -1420,7 +1420,7 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
                (* Validate that all explicit deps are known sibling nodes in this pipeline *)
                let unknown = List.filter (fun d -> not (List.mem d node_names)) explicit in
                if unknown <> [] then
-                 Error (Error.value_error (Printf.sprintf
+                 Error (Error.structural_error (Printf.sprintf
                    "Node `%s`: explicit `deps` contains unknown node(s): %s. All dependencies must be nodes declared in the same pipeline."
                    name (String.concat ", " (List.map (fun d -> "`" ^ d ^ "`") unknown))))
                else
@@ -1494,7 +1494,7 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
   ) desugared_nodes in
 
   if validation_errors <> [] then
-    Error.make_error TypeError (List.hd validation_errors)
+    Error.make_error StructuralError (List.hd validation_errors)
   else
 
   (* Topological sort *)

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -1334,7 +1334,7 @@ and topo_sort (nodes : (string * 'a) list) (deps : (string * string list) list) 
   | Ok () -> Ok (List.rev !order)
 
 (** Evaluate a pipeline definition *)
-and eval_pipeline env_ref (nodes : (string * Ast.expr) list) : value =
+and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : value =
   let default_un expr = {
     un_command = expr;
     un_script = None;
@@ -1604,7 +1604,7 @@ and eval_pipeline env_ref (nodes : (string * Ast.expr) list) : value =
 
     let p_nodes = List.rev results in
     let p_node_diagnostics = List.rev diagnostics in
-    print_pipeline_diagnostics_summary p_node_diagnostics;
+    if verbose then print_pipeline_diagnostics_summary p_node_diagnostics;
     VPipeline {
       p_nodes;
       p_exprs = List.map (fun (name, un) -> (name, un.un_command)) desugared_nodes;
@@ -1626,7 +1626,7 @@ and eval_pipeline env_ref (nodes : (string * Ast.expr) list) : value =
     }
 
 (** Re-run a pipeline *)
-and rerun_pipeline ?(strict=false) env_ref (prev : Ast.pipeline_result) : value =
+and rerun_pipeline ?(strict=false) ?(verbose=true) env_ref (prev : Ast.pipeline_result) : value =
   let node_names = List.map fst prev.p_exprs in
   let desugared_nodes = List.map (fun (name, expr) ->
     (name, {
@@ -1762,7 +1762,7 @@ and rerun_pipeline ?(strict=false) env_ref (prev : Ast.pipeline_result) : value 
       end
     ) ([], [], ref !env_ref, []) exec_order in
     let p_node_diagnostics = List.rev diagnostics in
-    print_pipeline_diagnostics_summary p_node_diagnostics;
+    if verbose then print_pipeline_diagnostics_summary p_node_diagnostics;
     VPipeline { prev with p_nodes = List.rev results; p_node_diagnostics }
 
 (** Evaluate a splice operand (!!!) and expand its elements as named pairs.
@@ -2812,14 +2812,14 @@ and eval_statement (env : environment) (stmt : stmt) : value * environment =
   in
   (attach_stmt_location stmt v, env')
 
-and eval_program (program : program) (env : environment) : value * environment =
+and eval_program ?(resilient=true) (program : program) (env : environment) : value * environment =
   let rec go env = function
     | [] -> ((VNA NAGeneric), env)
     | [stmt] -> eval_statement env stmt
     | stmt :: rest ->
         let (v, new_env) = eval_statement env stmt in
         (match v with
-         | VError _ -> (v, new_env)
+         | VError _ when not resilient -> (v, new_env)
          | _ -> go new_env rest)
   in
   go env program

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -1414,7 +1414,7 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
         (match un.un_dependencies with
          | Some explicit ->
              if List.mem name explicit then
-               Error (Error.value_error (Printf.sprintf
+               Error (Error.structural_error (Printf.sprintf
                  "Self-referential node: `%s` lists itself in `deps`." name))
              else
                (* Validate that all explicit deps are known sibling nodes in this pipeline *)
@@ -1430,7 +1430,7 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
              let is_raw = match un.un_command.node with RawCode _ -> true | _ -> false in
              let has_self_ref = List.exists (fun v -> v = name) fv in
              if has_self_ref && not is_raw then
-               Error (Error.value_error (Printf.sprintf
+               Error (Error.structural_error (Printf.sprintf
                  "Self-referential node detected in command for node: `%s`." name))
              else
                let node_deps = List.filter (fun v ->
@@ -1500,7 +1500,7 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
   (* Topological sort *)
   match topo_sort desugared_nodes deps with
   | Error cycle_node ->
-    Error.value_error (Printf.sprintf "Pipeline has a dependency cycle involving node `%s`." cycle_node)
+    Error.structural_error (Printf.sprintf "Pipeline has a dependency cycle involving node `%s`." cycle_node)
   | Ok exec_order ->
     let node_map = desugared_nodes in
     let eval_or_defer name un current_env_ref =
@@ -2820,7 +2820,7 @@ and eval_program ?(resilient=true) (program : program) (env : environment) : val
     | stmt :: rest ->
         let (v, new_env) = eval_statement env stmt in
         (match v with
-         | VError _ when not resilient -> (v, new_env)
+         | VError err when not resilient || err.code = StructuralError -> (v, new_env)
          | _ -> go new_env rest)
   in
   go env program

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -250,6 +250,7 @@ let print_pipeline_diagnostics_summary node_diagnostics =
     |> List.filter (fun (_, diagnostics) -> diagnostics.Ast.nd_recovered)
   in
   if !show_warnings && (warning_nodes <> [] || error_nodes <> [] || recovered_nodes <> []) then begin
+    flush stdout;
     Printf.eprintf
       "Pipeline summary: %d node(s) with warnings, %d error(s), %d recovered\n%!"
       (List.length warning_nodes)

--- a/src/packages/base/error_mod.ml
+++ b/src/packages/base/error_mod.ml
@@ -32,6 +32,10 @@ let register env =
             | "AssertionError" -> AssertionError
             | "FileError" -> FileError
             | "ValueError" -> ValueError
+            | "SyntaxError" -> SyntaxError
+            | "ShellError" -> ShellError
+            | "RuntimeError" -> RuntimeError
+            | "StructuralError" -> StructuralError
             | _ -> GenericError
           in
           Error.make_error code msg

--- a/src/packages/core/packages.ml
+++ b/src/packages/core/packages.ml
@@ -774,7 +774,7 @@ let init_env () =
     env
   in
   (* Pipeline package *)
-  let rerun_pipeline_fn ?strict env prev = Eval.rerun_pipeline (ref env) ?strict prev in
+  let rerun_pipeline_fn ?strict ?(verbose=true) env prev = Eval.rerun_pipeline (ref env) ?strict ~verbose prev in
   let env = Pipeline_nodes.register env in
   let env = Pipeline_deps.register env in
   let env = Pipeline_node.register env in

--- a/src/packages/pipeline/build_pipeline.ml
+++ b/src/packages/pipeline/build_pipeline.ml
@@ -13,7 +13,7 @@ open Ast
 --# @seealso read_node
 --# @export
 *)
-let register ~rerun_pipeline env =
+let register ~(rerun_pipeline : ?strict:bool -> ?verbose:bool -> value Env.t -> pipeline_result -> value) env =
   let get_arg name pos default named_args =
     match List.assoc_opt name (List.filter_map (fun (k, v) -> match k with Some s -> Some (s, v) | None -> None) named_args) with
     | Some v -> (true, v)
@@ -49,15 +49,11 @@ let register ~rerun_pipeline env =
          | Error e -> e
          | Ok verbose ->
              (* Trigger a final resolution pass to catch typos or unresolved cross-pipeline deps *)
-             (match rerun_pipeline ?strict:(Some true) env p with
+             (match rerun_pipeline ?strict:(Some true) ~verbose:false env p with
               | VPipeline p_resolved ->
-                  let has_errors = List.exists (fun (_, v) -> is_error_value v) p_resolved.p_nodes in
-                  if has_errors then
-                    Error.value_error ("Cannot build pipeline with errors: " ^ (Utils.value_to_string (VPipeline p_resolved)))
-                  else
-                    (match Builder.populate_pipeline ~build:true ?verbose p_resolved with
-                     | Ok out_path -> VString out_path
-                     | Error msg -> Error.make_error FileError msg)
+                  (match Builder.populate_pipeline ~build:true ?verbose p_resolved with
+                   | Ok out_path -> VString out_path
+                   | Error msg -> Error.make_error FileError msg)
               | VError _ as err -> err
               | other ->
                   Error.make_error RuntimeError

--- a/src/packages/pipeline/build_pipeline.ml
+++ b/src/packages/pipeline/build_pipeline.ml
@@ -53,7 +53,7 @@ let register ~(rerun_pipeline : ?strict:bool -> ?verbose:bool -> value Env.t -> 
               | VPipeline p_resolved ->
                   (match Builder.populate_pipeline ~build:true ?verbose p_resolved with
                    | Ok out_path -> VString out_path
-                   | Error msg -> Error.make_error FileError msg)
+                   | Error msg -> Error.make_error StructuralError msg)
               | VError _ as err -> err
               | other ->
                   Error.make_error RuntimeError

--- a/src/packages/pipeline/pipeline_composition.ml
+++ b/src/packages/pipeline/pipeline_composition.ml
@@ -5,7 +5,7 @@ let merge_new lst1 lst2 =
   let keys1 = List.map fst lst1 in
   lst1 @ List.filter (fun (k, _) -> not (List.mem k keys1)) lst2
 
-let register ~rerun_pipeline env =
+let register ~(rerun_pipeline : ?strict:bool -> ?verbose:bool -> value Env.t -> pipeline_result -> value) env =
 
 (*
 --# Chain Two Pipelines

--- a/src/packages/pipeline/pipeline_run.ml
+++ b/src/packages/pipeline/pipeline_run.ml
@@ -12,7 +12,7 @@ open Ast
 --# @seealso pipeline_nodes
 --# @export
 *)
-let register ~rerun_pipeline env =
+let register ~(rerun_pipeline : ?strict:bool -> ?verbose:bool -> value Env.t -> pipeline_result -> value) env =
   Env.add "pipeline_run"
     (make_builtin ~name:"pipeline_run" 1 (fun args env ->
       match args with

--- a/src/packages/pipeline/pipeline_set_ops.ml
+++ b/src/packages/pipeline/pipeline_set_ops.ml
@@ -126,7 +126,7 @@ let patch p1 p2 =
 --# @family pipeline
 --# @export
 *)
-let register ~rerun_pipeline env =
+let register ~(rerun_pipeline : ?strict:bool -> ?verbose:bool -> value Env.t -> pipeline_result -> value) env =
   let env = Env.add "union" (make_builtin ~name:"union" 2 (fun args env ->
     match args with
     | [VPipeline p1; VPipeline p2] -> 

--- a/src/packages/pipeline/populate_pipeline.ml
+++ b/src/packages/pipeline/populate_pipeline.ml
@@ -63,10 +63,6 @@ let register env =
          | Error e, _ -> e
          | _, Error e -> e
          | Ok build, Ok verbose ->
-             let has_errors = List.exists (fun (_, v) -> is_error_value v) p.p_nodes in
-             if has_errors then
-               Error.value_error ("Cannot populate pipeline with errors: " ^ (Utils.value_to_string (VPipeline p)))
-             else
                match Builder.populate_pipeline ~build ?verbose p with
                | Ok out -> VString out
                | Error msg -> Error.make_error FileError msg)

--- a/src/packages/pipeline/populate_pipeline.ml
+++ b/src/packages/pipeline/populate_pipeline.ml
@@ -65,7 +65,7 @@ let register env =
          | Ok build, Ok verbose ->
                match Builder.populate_pipeline ~build ?verbose p with
                | Ok out -> VString out
-               | Error msg -> Error.make_error FileError msg)
+               | Error msg -> Error.make_error StructuralError msg)
       | _ ->
           Error.type_error "Function `populate_pipeline` expects a Pipeline."
   in

--- a/src/packages/pipeline/t_make_mod.ml
+++ b/src/packages/pipeline/t_make_mod.ml
@@ -140,18 +140,18 @@ let register env =
                             (* We print the build header BEFORE evaluation so it's always first *)
                             Printf.eprintf "Starting build for project: %s\n%!" !filename;
 
+                            let prev_warn = !Eval.show_warnings in
+                            Eval.show_warnings := false;
                             let (v, new_env) = Eval.eval_program ~resilient:(not !failfast) program eval_env in
+                            Eval.show_warnings := prev_warn;
+                            
                             match v with
                             | VError _ -> v
                             | _ ->
                                 env_ref :=
                                   Pipeline_script.remember_pipeline_entry_bindings
                                     ~filename:!filename program new_env;
-                                match v with
-                                | VPipeline _ -> (VNA NAGeneric)
-                                | _ ->
-                                    Printf.eprintf "Pipeline script %s evaluated successfully.\n%!" !filename;
-                                    (VNA NAGeneric))
+                                (VNA NAGeneric))
                       with
                       | Lexer.SyntaxError msg ->
                           let pos = Lexing.lexeme_start_p lexbuf in

--- a/src/packages/pipeline/t_make_mod.ml
+++ b/src/packages/pipeline/t_make_mod.ml
@@ -40,6 +40,7 @@ let interrupt_error () =
 --# @param max_jobs :: Int The maximum number of jobs for Nix to run in parallel.
 --# @param max_cores :: Int The maximum number of cores per job for Nix to use.
 --# @param verbose :: Int The Nix build verbosity level. `0` is quiet; values > 0 enable internal node failure logs.
+--# @param failfast :: Bool Whether to stop immediately on evaluation errors (defaults to false).
 --# @return :: Null
 --# @family pipeline
 --# @export
@@ -51,6 +52,7 @@ let register env =
         let filename = ref "src/pipeline.t" in
         let nix_args = ref [] in
         let verbose = ref !Builder_internal.default_nix_build_verbose in
+        let failfast = ref false in
         let arg_error_opt = ref None in
         
         let named_only, positional_only =
@@ -75,6 +77,10 @@ let register env =
               arg_error_opt := Some (ValueError, "t_make: 'verbose' must be a non-negative Int")
           | (Some "verbose", _) ->
               arg_error_opt := Some (TypeError, "t_make: 'verbose' must be an Int")
+          | (Some "failfast", VBool b) ->
+              failfast := b
+          | (Some "failfast", _) ->
+              arg_error_opt := Some (TypeError, "t_make: 'failfast' must be a Bool")
           | (Some k, _) ->
               arg_error_opt := Some (TypeError, Printf.sprintf "t_make: unknown argument '%s'" k)
           | _ -> ()
@@ -87,6 +93,7 @@ let register env =
            | 2, VInt i -> nix_args := (string_of_int i) :: "--cores" :: !nix_args
            | 3, VInt i when i >= 0 -> verbose := i
            | 3, VInt _ -> arg_error_opt := Some (ValueError, "t_make: 'verbose' must be a non-negative Int")
+           | 4, VBool b -> failfast := b
            | n, _ -> arg_error_opt := Some (TypeError, Printf.sprintf "t_make: unexpected argument at position %d" n));
           idx + 1
         ) 0 positional_only in
@@ -114,7 +121,7 @@ let register env =
                   let lexbuf = Lexing.from_string content in
                   (try
                     let program = Parser.program Lexer.token lexbuf in
-                    let (v, new_env) = Eval.eval_program program !env_ref in
+                    let (v, new_env) = Eval.eval_program ~resilient:(not !failfast) program !env_ref in
                     match v with
                     | VError _ -> v
                     | _ ->

--- a/src/packages/pipeline/t_make_mod.ml
+++ b/src/packages/pipeline/t_make_mod.ml
@@ -118,7 +118,6 @@ let register env =
                   (fun () ->
                     Builder_internal.nix_build_args := List.rev !nix_args;
                     Builder_internal.default_nix_build_verbose := !verbose;
-                    Printf.printf "Starting build for project: %s\n%!" !filename;
                     (try
                       let content =
                         let ch = open_in !filename in
@@ -138,6 +137,9 @@ let register env =
                               Pipeline_script.reload_env_for_pipeline_entry
                                 ~filename:!filename program !env_ref
                             in
+                            (* We print the build header BEFORE evaluation so it's always first *)
+                            Printf.eprintf "Starting build for project: %s\n%!" !filename;
+
                             let (v, new_env) = Eval.eval_program ~resilient:(not !failfast) program eval_env in
                             match v with
                             | VError _ -> v
@@ -145,8 +147,11 @@ let register env =
                                 env_ref :=
                                   Pipeline_script.remember_pipeline_entry_bindings
                                     ~filename:!filename program new_env;
-                                Printf.printf "Pipeline %s evaluated successfully.\n" !filename;
-                                (VNA NAGeneric))
+                                match v with
+                                | VPipeline _ -> (VNA NAGeneric)
+                                | _ ->
+                                    Printf.eprintf "Pipeline script %s evaluated successfully.\n%!" !filename;
+                                    (VNA NAGeneric))
                       with
                       | Lexer.SyntaxError msg ->
                           let pos = Lexing.lexeme_start_p lexbuf in

--- a/src/packages/pipeline/t_make_mod.ml
+++ b/src/packages/pipeline/t_make_mod.ml
@@ -111,6 +111,7 @@ let register env =
               (fun () ->
                 Builder_internal.nix_build_args := List.rev !nix_args;
                 Builder_internal.default_nix_build_verbose := !verbose;
+                Printf.printf "Starting build for project: %s\n%!" !filename;
                 (try
                   let content =
                     let ch = open_in !filename in

--- a/src/packages/pipeline/t_make_mod.ml
+++ b/src/packages/pipeline/t_make_mod.ml
@@ -141,9 +141,13 @@ let register env =
                             Printf.eprintf "Starting build for project: %s\n%!" !filename;
 
                             let prev_warn = !Eval.show_warnings in
-                            Eval.show_warnings := false;
-                            let (v, new_env) = Eval.eval_program ~resilient:(not !failfast) program eval_env in
-                            Eval.show_warnings := prev_warn;
+                            let (v, new_env) =
+                              Fun.protect
+                                ~finally:(fun () -> Eval.show_warnings := prev_warn)
+                                (fun () ->
+                                  Eval.show_warnings := false;
+                                  Eval.eval_program ~resilient:(not !failfast) program eval_env)
+                            in
                             
                             match v with
                             | VError _ -> v

--- a/src/packages/stats/t_score_pmml.ml
+++ b/src/packages/stats/t_score_pmml.ml
@@ -97,28 +97,67 @@ let t_compare_scores_pmml =
               | VError _ as e -> e
               | VVector native_vec ->
                   (match score_pmml_jpmml df (VDict model_pairs) with
-                   | VError _ as e -> e
-                   | VVector pmml_vec ->
-                       if Array.length native_vec <> Array.length pmml_vec then
-                         Error.make_error RuntimeError "Vector length mismatch between native and PMML scoring."
-                       else
-                         let diffs = ref 0 in
-                         for i = 0 to Array.length native_vec - 1 do
-                           match native_vec.(i), pmml_vec.(i) with
-                           | VFloat f1, VFloat f2 ->
-                               if abs_float (f1 -. f2) > 1e-7 then incr diffs
-                           | VString s1, VString s2 ->
-                               if s1 <> s2 then incr diffs
-                           | VNA _, VNA _ -> ()
-                           | VNA _, _ | _, VNA _ -> incr diffs
-                           | _ -> ()
-                         done;
-                         VDict [
-                           ("n_diffs", VInt !diffs);
-                           ("match", VBool (!diffs = 0));
-                           ("n_rows", VInt (Array.length native_vec));
-                         ]
-                   | _ -> Error.make_error RuntimeError "Expected Vector from JPMML bridge.")
+                    | VError _ as e -> e
+                    | VVector pmml_vec ->
+                        if Array.length native_vec <> Array.length pmml_vec then
+                          Error.make_error RuntimeError "Vector length mismatch between native and PMML scoring."
+                        else
+                          let diffs = ref 0 in
+                          for i = 0 to Array.length native_vec - 1 do
+                            match native_vec.(i), pmml_vec.(i) with
+                            | VFloat f1, VFloat f2 -> if abs_float (f1 -. f2) > 1e-7 then incr diffs
+                            | VString s1, VString s2 -> if s1 <> s2 then incr diffs
+                            | VNA _, VNA _ -> ()
+                            | VNA _, _ | _, VNA _ -> incr diffs
+                            | _ -> ()
+                          done;
+                          VDict [
+                            ("n_diffs", VInt !diffs);
+                            ("match", VBool (!diffs = 0));
+                            ("n_rows", VInt (Array.length native_vec));
+                          ]
+                    | VDataFrame df ->
+                        (* Extraction logic for classification: find target column or take first. *)
+                        let col_name = 
+                          match List.assoc_opt "target" model_pairs with 
+                          | Some (VString s) -> s 
+                          | _ -> List.hd (Arrow_table.column_names df.arrow_table)
+                        in
+                        (match Arrow_table.column_type df.arrow_table col_name with
+                         | Some _ ->
+                            let vec = match Arrow_table.column_type df.arrow_table col_name with
+                              | Some (Arrow_table.ArrowFloat64 | Arrow_table.ArrowInt64) ->
+                                  let col = Arrow_table.get_float_column df.arrow_table col_name in
+                                  Array.map (fun f -> match f with Some v -> VFloat v | None -> VNA NAFloat) col
+                              | Some Arrow_table.ArrowBoolean ->
+                                  let col = Arrow_table.get_bool_column df.arrow_table col_name in
+                                  Array.map (fun b -> match b with Some v -> VBool v | None -> VNA NABool) col
+                              | _ ->
+                                  let col = Arrow_table.get_string_column df.arrow_table col_name in
+                                  Array.map (fun s -> match s with Some v -> VString v | None -> VNA NAString) col
+                            in
+                            (* Now we have a Vector, continue with comparison... *)
+                            (* (Refactor note: extracting this into a helper would be cleaner) *)
+                            let pmml_vec = vec in
+                            if Array.length native_vec <> Array.length pmml_vec then
+                              Error.make_error RuntimeError "Vector length mismatch between native and PMML scoring."
+                            else
+                              let diffs = ref 0 in
+                              for i = 0 to Array.length native_vec - 1 do
+                                match native_vec.(i), pmml_vec.(i) with
+                                | VFloat f1, VFloat f2 -> if abs_float (f1 -. f2) > 1e-7 then incr diffs
+                                | VString s1, VString s2 -> if s1 <> s2 then incr diffs
+                                | VNA _, VNA _ -> ()
+                                | VNA _, _ | _, VNA _ -> incr diffs
+                                | _ -> ()
+                              done;
+                              VDict [
+                                ("n_diffs", VInt !diffs);
+                                ("match", VBool (!diffs = 0));
+                                ("n_rows", VInt (Array.length native_vec));
+                              ]
+                         | None -> Error.make_error RuntimeError "JPMML bridge: result column not found.")
+                    | _ -> Error.make_error RuntimeError "Expected Vector or DataFrame from JPMML bridge.")
               | _ -> Error.make_error RuntimeError "Expected Vector from native scorer."))
     | _ -> Error.arity_error_named "compare_native_vs_pmml_scores" 2 (List.length args))
 

--- a/src/packages/strcraft/string_ops.ml
+++ b/src/packages/strcraft/string_ops.ml
@@ -416,7 +416,7 @@ let length_scalar args _env =
   | [VList items] -> VInt (List.length items)
   | [VDict pairs] -> VInt (List.length pairs)
   | [VVector arr] -> VInt (Array.length arr)
-  | [VDataFrame df] -> VInt (Arrow_table.num_rows df.arrow_table)
+  | [VDataFrame _] -> Error.type_error "length does not work on DataFrames because it is ambiguous (rows vs columns). Use nrow() or ncol() instead."
   | [VInt _ | VFloat _ | VBool _] -> Error.type_error "length expects a collection (List, Vector, or Dict). Scalar provided."
   | [VNA _] -> Error.type_error "Cannot get length of NA."
   | [VError _ as e] -> e

--- a/src/packages/strcraft/string_ops.ml
+++ b/src/packages/strcraft/string_ops.ml
@@ -416,8 +416,11 @@ let length_scalar args _env =
   | [VList items] -> VInt (List.length items)
   | [VDict pairs] -> VInt (List.length pairs)
   | [VVector arr] -> VInt (Array.length arr)
+  | [VDataFrame df] -> VInt (Arrow_table.num_rows df.arrow_table)
+  | [VInt _ | VFloat _ | VBool _] -> Error.type_error "length expects a collection (List, Vector, or Dict). Scalar provided."
   | [VNA _] -> Error.type_error "Cannot get length of NA."
-  | [VError _] -> Error.type_error "Cannot get length of Error."
+  | [VError _ as e] -> e
+  | [v] -> Error.type_error (Printf.sprintf "length expects a collection (List, Vector, or Dict). Received %s" (Utils.type_name v))
   | _ -> Error.type_error "length expects a collection (List, Vector, or Dict)."
 
 let length_impl args env = length_scalar args env

--- a/src/pipeline/builder_internal.ml
+++ b/src/pipeline/builder_internal.ml
@@ -280,14 +280,7 @@ let build_pipeline_internal ?verbose (p : Ast.pipeline_result) =
                 (match write_file log_path log_json with
                 | Error msg -> Error ("Failed to write build log: " ^ msg)
                 | Ok () ->
-                    if soft_failed <> [] then
-                      Error
-                        (Printf.sprintf
-                           "Pipeline build captured %d node error artifact(s): %s. Inspect the latest build log in `_pipeline/` or use `read_node()` / `read_log()` for details."
-                           (List.length soft_failed)
-                           (String.concat ", " soft_failed))
-                    else
-                      Ok out_path))
+                    Ok out_path))
           | Unix.WEXITED 0 ->
              Error "nix-build succeeded but did not return an output path."
           | _ ->

--- a/src/pipeline/builder_internal.ml
+++ b/src/pipeline/builder_internal.ml
@@ -210,12 +210,12 @@ let build_pipeline_internal ?verbose (p : Ast.pipeline_result) =
                     if Hashtbl.find statuses name <> "Completed" && 
                        Hashtbl.find statuses name <> "SoftFailed" &&
                        Hashtbl.find statuses name <> "Errored" then (
-                      match read_file_first_line class_path with
-                      | Some "VError" -> Hashtbl.replace statuses name "SoftFailed"
-                      | _ -> Hashtbl.replace statuses name "Completed"
+                      (match read_file_first_line class_path with
+                       | Some "VError" | Some "Error" -> Hashtbl.replace statuses name "SoftFailed"
+                       | _ -> Hashtbl.replace statuses name "Completed")
                     ) else if Hashtbl.find statuses name = "Completed" then (
                       (* Refine "Completed" from Nix output if it was actually a soft-fail *)
-                      if (match read_file_first_line class_path with Some "VError" -> true | _ -> false) then
+                      if (match read_file_first_line class_path with Some "VError" | Some "Error" -> true | _ -> false) then
                          Hashtbl.replace statuses name "SoftFailed"
                     )
                   )

--- a/src/pipeline/builder_read_node.ml
+++ b/src/pipeline/builder_read_node.ml
@@ -43,7 +43,13 @@ let wrap_with_diagnostics name cn v =
     | VError e -> Some { ne_kind = Utils.error_code_to_string e.code; ne_fn = "unknown"; ne_message = e.message; ne_na_count = e.na_count }
     | _ -> None
   ) else None in
-  VNodeResult { v; node_name = name; diagnostics = { nd_warnings = warnings; nd_error = error; nd_warnings_suppressed = false } }
+  VNodeResult { v; node_name = name; diagnostics = {
+    nd_warnings = warnings;
+    nd_error = error;
+    nd_warnings_suppressed = false;
+    nd_recovered = false;
+    nd_upstream_errors = [];
+  } }
 
 (* Add node_name to the error context unless it is already present. *)
 let add_node_name_context name context =

--- a/src/pipeline/nix_emit_node.ml
+++ b/src/pipeline/nix_emit_node.ml
@@ -1856,8 +1856,8 @@ EOF
   %s = stdenv.mkDerivation {
     name = "%s";
     buildInputs = [ tBin %s ] ++ globalBuildInputs;
-    T_JPMML_STATSMODELS_JAR = "${pkgs.jpmml-statsmodels}/share/java/jpmml-statsmodels.jar";
-    T_JPMML_EVALUATOR_JAR = "${pkgs.jpmml-evaluator}/share/java/jpmml-evaluator.jar";
+    T_JPMML_STATSMODELS_JAR = if (pkgs ? jpmml-statsmodels) then "${pkgs.jpmml-statsmodels}/share/java/jpmml-statsmodels.jar" else "";
+    T_JPMML_EVALUATOR_JAR = if (pkgs ? jpmml-evaluator) then "${pkgs.jpmml-evaluator}/share/java/jpmml-evaluator.jar" else "";
     MPLCONFIGDIR = ".";
 %s
 %s

--- a/src/pipeline/nix_emit_pipeline.ml
+++ b/src/pipeline/nix_emit_pipeline.ml
@@ -43,7 +43,9 @@ let
   # Note: toString is required to convert the path to a string
   # that builtins.getFlake accepts.
   flake  = builtins.getFlake (toString %s/.);
-  pkgs   = flake.inputs.nixpkgs.legacyPackages.${system};
+  pkgs   = if (builtins.hasAttr "legacyPackages" flake && builtins.hasAttr system flake.legacyPackages.${system}) 
+           then flake.legacyPackages.${system} 
+           else flake.inputs.nixpkgs.legacyPackages.${system};
   tBin   = let
              base = (flake.inputs.t-lang or flake).packages.${system}.default;
            in if builtins.pathExists %s/dune-project then

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -42,7 +42,7 @@ let interrupt_error () =
     na_count = 0;
   }
 
-let parse_and_eval ?filename mode env input =
+let parse_and_eval ?filename ?(failfast=false) mode env input =
   let lexbuf = Lexing.from_string input in
   (match filename with
    | Some file -> lexbuf.lex_curr_p <- { lexbuf.lex_curr_p with pos_fname = file }
@@ -50,9 +50,8 @@ let parse_and_eval ?filename mode env input =
   try
     let program = Parser.program Lexer.token lexbuf in
     match Typecheck.validate_program ~mode program with
-    | Error err ->
-        (Ast.VError err, env)
-    | Ok () -> Eval.eval_program program env
+    | Error err -> (Ast.VError err, env)
+    | Ok () -> Eval.eval_program ~resilient:(not failfast) program env
   with
   | Lexer.SyntaxError msg ->
       let pos = Lexing.lexeme_start_p lexbuf in
@@ -63,12 +62,12 @@ let parse_and_eval ?filename mode env input =
   | Sys.Break ->
       (interrupt_error (), env)
 
-let run_file mode filename env =
+let run_file ?failfast mode filename env =
   try
     let ch = open_in filename in
     let content = really_input_string ch (in_channel_length ch) in
     close_in ch;
-    parse_and_eval ~filename mode env content
+    parse_and_eval ~filename ?failfast mode env content
   with
   | Sys_error msg ->
       (Ast.VError {
@@ -212,7 +211,7 @@ let handle_magic line env mode base_keys =
   | "time" :: expr_parts ->
       let expr_str = String.concat " " expr_parts in
       let start_time = Unix.gettimeofday () in
-      let (result, new_env) = parse_and_eval mode env expr_str in
+      let (result, new_env) = parse_and_eval ?failfast:None mode env expr_str in
       let end_time = Unix.gettimeofday () in
       repl_display_value result;
       Printf.printf "%sExecution time: %.4f seconds%s\n" color_gray (end_time -. start_time) color_reset;
@@ -264,6 +263,7 @@ let print_help () =
   Printf.printf "  run <file.t>      Execute a T source file\n";
   Printf.printf "  run --expr <expr> Execute a T expression directly\n";
   Printf.printf "  --mode <m>        Type-check mode: repl or strict\n";
+  Printf.printf "  --failfast        Stop execution on first error\n";
   Printf.printf "  explain <expr>    Explain a value or expression\n";
   Printf.printf "  init --package <n>  Create a new T package\n";
   Printf.printf "  init --project <n>  Create a new T project\n";
@@ -289,8 +289,7 @@ let ensure_file_path filename =
   match Cli_args.validate_path ~kind:Cli_args.File filename with
   | Ok () -> ()
   | Error msg -> exit_with_error msg
-
-let cmd_run ?(unsafe=false) mode filename env =
+let cmd_run ?(unsafe=false) ?failfast mode filename env =
   Packages.ensure_docs_loaded ();
   ensure_file_path filename;
   if not unsafe then begin
@@ -309,16 +308,16 @@ let cmd_run ?(unsafe=false) mode filename env =
       with _ -> ())
     with _ -> ()
   end;
-  let (result, _env) = run_file mode filename env in
+  let (result, _env) = run_file ?failfast mode filename env in
   match result with
   | Ast.VError _ ->
       Printf.eprintf "%s\n" (Ast.Utils.value_to_string result); exit 1
   | Ast.(VNA NAGeneric) -> ()
   | v -> print_endline (Ast.Utils.value_to_string v)
 
-let cmd_run_expr mode expr env =
+let cmd_run_expr ?failfast mode expr env =
   Packages.ensure_docs_loaded ();
-  let (result, _) = parse_and_eval mode env expr in
+  let (result, _) = parse_and_eval ?failfast mode env expr in
   match result with
   | Ast.VError _ ->
       Printf.eprintf "%s\n" (Ast.Utils.value_to_string result); exit 1
@@ -353,15 +352,15 @@ let cmd_init_project args =
       | Ok () -> Printf.printf "Project initialized successfully.\n"
       | Error msg -> Printf.eprintf "Error: %s\n" msg; exit 1
 
-let cmd_explain mode rest env =
+let cmd_explain ?failfast mode rest env =
   Packages.ensure_docs_loaded ();
   let expr_str = String.concat " " (List.filter (fun s -> s <> "--json") rest) in
   if expr_str = "" then (Printf.eprintf "Usage: t explain <expr>\n"; exit 1)
   else begin
-    let (result, env') = parse_and_eval mode env expr_str in
+    let (result, env') = parse_and_eval ?failfast mode env expr_str in
     let explain_expr = "explain(__explain_target__)" in
     let env'' = Ast.Env.add "__explain_target__" result env' in
-    let (explain_result, _) = parse_and_eval mode env'' explain_expr in
+    let (explain_result, _) = parse_and_eval ?failfast mode env'' explain_expr in
     print_endline (Ast.Utils.value_to_string explain_result)
   end
 
@@ -473,7 +472,7 @@ let get_nix_version () =
     | _ -> None
   with _ -> None
 
-let cmd_repl mode env =
+let cmd_repl ?failfast mode env =
   Packages.ensure_docs_loaded ();
   
   (* Track base environment keys to filter %objects *)
@@ -532,7 +531,7 @@ let cmd_repl mode env =
     end
   in
 
-  let rec repl env show_prompt =
+  let rec repl ?failfast env show_prompt =
     let prompt = if show_prompt then "T> " else "" in
     try
       match read_input prompt with
@@ -648,18 +647,18 @@ let cmd_repl mode env =
               ignore (LNoise.history_add full_input);
               ignore (LNoise.history_save ~filename:history_file)
             );
-            let (result, new_env) = parse_and_eval mode env full_input in
+            let (result, new_env) = parse_and_eval ?failfast mode env full_input in
             Symbol_table.populate_from_env scope new_env;
             repl_display_value result;
-            repl new_env true
+            repl ?failfast new_env true
             end
           end
     with
     | Sys.Break ->
         print_endline "Interrupted.";
-        repl env true
+        repl ?failfast env true
   in
-  repl env true
+  repl ?failfast env true
 
 (* --- Entry Point --- *)
 
@@ -672,8 +671,10 @@ let () =
     | Error msg -> Printf.eprintf "%s\n" msg; exit 1
   in
   let unsafe = List.mem "--unsafe" raw_args in
+  let failfast = mode_parse.failfast in
   let args = if unsafe then List.filter (fun s -> s <> "--unsafe") mode_parse.args else mode_parse.args in
-  (match Cli_args.validate_cli_flags ~mode_flag:mode_parse.mode_flag ~unsafe_flag:unsafe args with
+  let args = if failfast then List.filter (fun s -> s <> "--failfast") args else args in
+  (match Cli_args.validate_cli_flags ~mode_flag:mode_parse.mode_flag ~unsafe_flag:unsafe ~failfast_flag:failfast args with
    | Ok () -> ()
    | Error msg -> exit_with_error msg);
   let env = Packages.init_env () in
@@ -687,6 +688,7 @@ let () =
 --#
 --# @name t_run
 --# @param filename :: String The path to the T file to execute.
+--# @param failfast :: Bool Whether to fail on error (defaults to false).
 --# @return :: Null
 --# @example
 --#   t_run("src/my_script.t")
@@ -696,8 +698,17 @@ let () =
   let env = Ast.Env.add "t_run"
     (Ast.VBuiltin { b_name = Some "t_run"; b_arity = 1; b_variadic = false;
       b_func = (fun named_args env_ref ->
-        match List.map snd named_args with
-        | [Ast.VString filename] ->
+        let f_filename = ref None in
+        let f_failfast = ref false in
+        List.iter (fun (k, v) ->
+          match k, v with
+          | Some "filename", Ast.VString s -> f_filename := Some s
+          | None, Ast.VString s -> f_filename := Some s
+          | Some "failfast", Ast.VBool b -> f_failfast := b
+          | _ -> ()
+        ) named_args;
+        match !f_filename with
+        | Some filename ->
             (try
               let ch = open_in filename in
               let content = really_input_string ch (in_channel_length ch) in
@@ -705,7 +716,7 @@ let () =
               let lexbuf = Lexing.from_string content in
                (try
                 let program = Parser.program Lexer.token lexbuf in
-                let (v, new_env) = Eval.eval_program program !env_ref in
+                let (v, new_env) = Eval.eval_program ~resilient:(not !f_failfast) program !env_ref in
                 (match v with
                  | Ast.VError _ -> v
                  | _ -> 
@@ -847,19 +858,19 @@ let () =
       exit 1
   | _ :: "run" :: "--expr" :: expr :: [] ->
       let script_mode = if mode_parse.mode = Typecheck.Repl && not mode_parse.mode_flag then Typecheck.Strict else mode_parse.mode in
-      cmd_run_expr script_mode expr env
+      cmd_run_expr ~failfast script_mode expr env
   | _ :: "run" :: "--expr" :: _ ->
       Printf.eprintf "Unexpected arguments after `t run --expr <expr>`.\n";
       exit 1
   | _ :: "run" :: filename :: [] ->
       (* Default to Strict mode for scripts, but allow --mode to override *)
       let script_mode = if mode_parse.mode = Typecheck.Repl && not mode_parse.mode_flag then Typecheck.Strict else mode_parse.mode in
-      cmd_run ~unsafe script_mode filename env
+      cmd_run ~unsafe ~failfast script_mode filename env
   | _ :: "run" :: _ ->
       Printf.eprintf "Unexpected arguments after `t run <file.t>`.\n";
       exit 1
-  | _ :: "repl" :: _ -> cmd_repl mode_parse.mode env
-  | _ :: "explain" :: rest -> cmd_explain mode_parse.mode rest env
+  | _ :: "repl" :: _ -> cmd_repl ~failfast mode_parse.mode env
+  | _ :: "explain" :: rest -> cmd_explain ~failfast mode_parse.mode rest env
   | _ :: "init" :: "--package" :: rest -> cmd_init_package rest
   | _ :: "init" :: "--project" :: rest -> cmd_init_project rest
   | _ :: "test" :: rest -> cmd_test rest
@@ -878,9 +889,9 @@ let () =
   | _ :: "--version" :: _ | _ :: "-v" :: _ -> print_version ()
   | [_] ->
       (* No arguments: start the REPL (default behavior) *)
-      cmd_repl mode_parse.mode env
+      cmd_repl ~failfast mode_parse.mode env
   | _ :: unknown :: _ ->
       Printf.eprintf "Unknown command: %s\n" unknown;
       Printf.eprintf "Run 't --help' for usage information.\n";
       exit 1
-  | [] -> cmd_repl mode_parse.mode env
+  | [] -> cmd_repl ~failfast mode_parse.mode env

--- a/src/serialization.ml
+++ b/src/serialization.ml
@@ -308,10 +308,14 @@ let rec yojson_to_value (j : Yojson.Safe.t) : Ast.value =
   | `Null -> (VNA NAGeneric)
   | `List l -> VList (List.map (fun x -> (None, yojson_to_value x)) l)
   | `Assoc a ->
-      (match List.assoc_opt "class" a with
-       | Some (`String "VLens") ->
-            (match List.assoc_opt "data" a with
-              | Some (`Assoc d) ->
+      (match List.assoc_opt "type" a with
+       | Some (`String "VError") ->
+           yojson_to_verror j
+       | _ ->
+           (match List.assoc_opt "class" a with
+            | Some (`String "VLens") ->
+                 (match List.assoc_opt "data" a with
+                   | Some (`Assoc d) ->
                   let rec yojson_to_lens = function
                     | `Assoc items ->
                         let required_field lens_kind field =
@@ -387,12 +391,12 @@ let rec yojson_to_value (j : Yojson.Safe.t) : Ast.value =
                   (match yojson_to_lens (`Assoc d) with
                    | Ok lens -> VLens lens
                    | Error msg -> Error.value_error msg)
-             | _ -> VDict (List.map (fun (k, v) -> (k, yojson_to_value v)) a))
-        | _ -> VDict (List.map (fun (k, v) -> (k, yojson_to_value v)) a))
+              | _ -> VDict (List.map (fun (k, v) -> (k, yojson_to_value v)) a))
+         | _ -> VDict (List.map (fun (k, v) -> (k, yojson_to_value v)) a)))
   | _ ->
       invalid_arg ("yojson_to_value: unsupported Yojson constructor: " ^ Yojson.Safe.to_string j)
 
-let yojson_to_verror (j : Yojson.Safe.t) : Ast.value =
+and yojson_to_verror (j : Yojson.Safe.t) : Ast.value =
   match j with
   | `Assoc a ->
       (match List.assoc_opt "type" a with
@@ -512,7 +516,7 @@ let deserialize_from_file path =
              let ic2 = open_in class_path in
              let cls = input_line ic2 |> String.trim in
              close_in ic2;
-             if cls = "VError" then
+             if cls = "Error" || cls = "VError" then
                read_verror_json path
              else
                (* Fallback: try reading as JSON if the class is one of the basic T types

--- a/tests/base/test_error_recovery.ml
+++ b/tests/base/test_error_recovery.ml
@@ -56,7 +56,7 @@ let run_tests pass_count fail_count _eval_string eval_string_env test =
 
   test "error in function arg"
     {|length(1 / 0)|}
-    {|Error(TypeError: "Cannot get length of Error.")|};
+    {|Error(DivisionByZero: "Division by zero.")|};
 
   (try Sys.remove csv_err with _ -> ());
   print_newline ();

--- a/tests/base/test_errors.ml
+++ b/tests/base/test_errors.ml
@@ -3,6 +3,7 @@ let run_tests pass_count fail_count eval_string _eval_string_env test =
   Printf.printf "Phase 1 — Structured Errors:\n";
   test "error() constructor" {|error("something went wrong")|} {|Error(GenericError: "something went wrong")|};
   test "error() with code" {|error("TypeError", "expected Int")|} {|Error(TypeError: "expected Int")|};
+  test "error() with StructuralError" {|error("StructuralError", "broken DAG")|} {|Error(StructuralError: "broken DAG")|};
   test "error_code()" "error_code(1 / 0)" {|"DivisionByZero"|};
   test "error_message()" "error_message(1 / 0)" {|"Division by zero."|};
   test "error_context() empty" "error_context(1 / 0)" "{}";

--- a/tests/base/test_structural_integrity.ml
+++ b/tests/base/test_structural_integrity.ml
@@ -1,0 +1,65 @@
+let run_tests _pass_count _fail_count _eval_string eval_string_env test =
+  Printf.printf "Structural Integrity — Terminal Evaluation Bypass:\n";
+
+  (* StructuralError should bypass resilient evaluation *)
+  let env_res = Packages.init_env () in
+  let (_v, _env_res) = eval_string_env "resilient = true" env_res in
+  
+  test "StructuralError bypasses resilient=true"
+    {|error("StructuralError", "fatal break")|}
+    {|Error(StructuralError: "fatal break")|};
+
+  (* Valorized error should still be captured as value if not Structural *)
+  test "ValueError is captured in resilient mode"
+    {|error("ValueError", "recoverable")|}
+    {|Error(ValueError: "recoverable")|};
+
+  print_newline ();
+
+  Printf.printf "Structural Integrity — length() Propagation rules:\n";
+
+  test "length() propagates error scalar"
+    {|length(1 / 0)|}
+    {|Error(DivisionByZero: "Division by zero.")|};
+
+  test "strict list literal propagates error"
+    {|length([1, 2, 1 / 0])|}
+    {|Error(DivisionByZero: "Division by zero.")|};
+
+  test "strict dict literal propagates error"
+    {|length([a: 1, b: 1 / 0])|}
+    {|Error(DivisionByZero: "Division by zero.")|};
+
+  test "length() on dataframe"
+    {|df = dataframe([a: [1, 2, 3]]); length(df)|}
+    "3";
+  
+  test "length() on empty dataframe"
+    {|length(dataframe([a: []]))|}
+    "0";
+
+  print_newline ();
+
+  Printf.printf "Structural Integrity — Serialization Roundtrip:\n";
+
+  test "StructuralError survived serialization"
+    {|p = "test_ser.tobj"; serialize(error("StructuralError", "topology break"), p); v = deserialize(p); v|}
+    {|Error(StructuralError: "topology break")|};
+
+  print_newline ();
+
+  Printf.printf "Structural Integrity — error() builtin stability:\n";
+
+  test "error() with unknown code defaults to GenericError"
+    {|error("UnknownCode", "some message")|}
+    {|Error(GenericError: "some message")|};
+
+  test "error() arity mismatch (1 arg too many)"
+    {|error("Code", "Msg", "Extra")|}
+    {|Error(ArityError: "Function `error` expects 1 or 2 string arguments but received 3.")|};
+
+  test "error() type mismatch"
+    {|error(123)|}
+    {|Error(TypeError: "Function `error` expects a String message.")|};
+
+  print_newline ()

--- a/tests/base/test_structural_integrity.ml
+++ b/tests/base/test_structural_integrity.ml
@@ -30,13 +30,13 @@ let run_tests _pass_count _fail_count _eval_string eval_string_env test =
     {|length([a: 1, b: 1 / 0])|}
     {|Error(DivisionByZero: "Division by zero.")|};
 
-  test "length() on dataframe"
+  test "length() on dataframe raises error (ambiguous)"
     {|df = dataframe([a: [1, 2, 3]]); length(df)|}
-    "3";
+    {|Error(TypeError: "length does not work on DataFrames because it is ambiguous (rows vs columns). Use nrow() or ncol() instead.")|};
   
-  test "length() on empty dataframe"
+  test "length() on empty dataframe raises error"
     {|length(dataframe([a: []]))|}
-    "0";
+    {|Error(TypeError: "length does not work on DataFrames because it is ambiguous (rows vs columns). Use nrow() or ncol() instead.")|};
 
   print_newline ();
 

--- a/tests/cli/test_cli.ml
+++ b/tests/cli/test_cli.ml
@@ -64,19 +64,19 @@ let run_tests pass_count fail_count _eval_string _eval_string_env test =
      | Error msg -> contains msg "Unexpected argument: extra"
      | Ok _ -> false);
   test_message "validate_cli_flags rejects --unsafe outside run"
-    (match Cli_args.validate_cli_flags ~mode_flag:false ~unsafe_flag:true ["t"; "test"] with
+    (match Cli_args.validate_cli_flags ~mode_flag:false ~unsafe_flag:true ~failfast_flag:false ["t"; "test"] with
      | Error msg -> contains msg "--unsafe"
      | Ok _ -> false);
   test_message "validate_cli_flags rejects --unsafe with run --expr"
-    (match Cli_args.validate_cli_flags ~mode_flag:false ~unsafe_flag:true ["t"; "run"; "--expr"; "1+1"] with
+    (match Cli_args.validate_cli_flags ~mode_flag:false ~unsafe_flag:true ~failfast_flag:false ["t"; "run"; "--expr"; "1+1"] with
      | Error msg -> contains msg "run --expr"
      | Ok _ -> false);
   test_message "validate_cli_flags rejects --mode with test"
-    (match Cli_args.validate_cli_flags ~mode_flag:true ~unsafe_flag:false ["t"; "test"] with
+    (match Cli_args.validate_cli_flags ~mode_flag:true ~unsafe_flag:false ~failfast_flag:false ["t"; "test"] with
      | Error msg -> contains msg "--mode"
      | Ok _ -> false);
   test_message "validate_cli_flags allows --mode with repl"
-    (match Cli_args.validate_cli_flags ~mode_flag:true ~unsafe_flag:false ["t"; "repl"] with
+    (match Cli_args.validate_cli_flags ~mode_flag:true ~unsafe_flag:false ~failfast_flag:false ["t"; "repl"] with
      | Ok () -> true
      | Error _ -> false);
   test_message "init flag parsing rejects unexpected positional arguments"

--- a/tests/dune
+++ b/tests/dune
@@ -41,6 +41,7 @@
     test_serializers
     test_pipeline_comments
     test_explicit_deps
+    test_structural_integrity
  )
  (libraries t_lang menhirLib otoml unix str)
 )

--- a/tests/golden/test_golden.ml
+++ b/tests/golden/test_golden.ml
@@ -97,7 +97,7 @@ let run_tests pass_count fail_count _eval_string eval_string_env test =
   (* Golden test: Node failure *)
   test "golden: node failure propagation"
     "pipeline {\n  a = 1 / 0\n  b = a + 1\n}"
-    "Pipeline(2 nodes: [a, b])\nErrors:\n  - `a` failed: Pipeline node `a` failed: Division by zero.\n  - `b` failed: Pipeline node `b` failed: Upstream error: Pipeline node `a` failed: Division by zero.";
+    "Pipeline(2 nodes: [a, b])\nErrors:\n  - `a` failed: Pipeline node `a` failed: Division by zero.\n  - `b` failed: Pipeline node `b` failed: Pipeline node `a` failed: Division by zero.";
 
   (* Golden test: Missing node access *)
   test "golden: missing node error"

--- a/tests/golden/test_golden.ml
+++ b/tests/golden/test_golden.ml
@@ -639,9 +639,9 @@ let run_tests pass_count fail_count _eval_string eval_string_env test =
 
     (* Test: JPMML Bridge Prediction (triggered by predict builtin through authority pivot) *)
     (try
-      let (v, _) = eval_string_env "preds = predict(df, model); length(preds)" env_pmml in
+      let (v, _) = eval_string_env "preds = predict(df, model); nrow(preds)" env_pmml in
       if Ast.Utils.value_to_string v = "150" then begin
-        incr pass_count; Printf.printf "  ✓ golden jpmml: bridge prediction successful (150 rows via JPMML)\n"
+        incr pass_count; Printf.printf "  ✓ golden jpmml: bridge prediction successful (150 rows verified via nrow)\n"
       end else begin
         incr fail_count; Printf.printf "  ✗ golden jpmml: bridge prediction failed (got %s)\n" (Ast.Utils.value_to_string v)
       end

--- a/tests/golden/test_golden.ml
+++ b/tests/golden/test_golden.ml
@@ -92,7 +92,7 @@ let run_tests pass_count fail_count _eval_string eval_string_env test =
   (* Golden test: Cycle detection *)
   test "golden: cycle detection"
     "pipeline {\n  a = b\n  b = a\n}"
-    {|Error(ValueError: "Pipeline has a dependency cycle involving node `a`.")|};
+    {|Error(StructuralError: "Pipeline has a dependency cycle involving node `a`.")|};
 
   (* Golden test: Node failure *)
   test "golden: node failure propagation"

--- a/tests/package_manager/test_package_manager.ml
+++ b/tests/package_manager/test_package_manager.ml
@@ -313,7 +313,7 @@ min_version = "0.51.0"
           }
           populate_pipeline(p)
         |} (Packages.init_env ())) with
-        | Ast.VError { code = FileError; message; _ } ->
+        | Ast.VError { code = StructuralError; message; _ } ->
             (match Toml_parser.parse_tproject_toml
                      (let ic = open_in tproject_path in
                       Fun.protect ~finally:(fun () -> close_in_noerr ic)

--- a/tests/pipeline/test_pipeline.ml
+++ b/tests/pipeline/test_pipeline.ml
@@ -251,7 +251,7 @@ let run_tests pass_count fail_count _eval_string eval_string_env test =
   Printf.printf "Phase 3 — Pipeline Error Handling:\n";
   test "pipeline cycle detection"
     "pipeline {\n  a = b\n  b = a\n}"
-    {|Error(ValueError: "Pipeline has a dependency cycle involving node `a`.")|};
+    {|Error(StructuralError: "Pipeline has a dependency cycle involving node `a`.")|};
   test "pipeline with error in node"
     "pipeline {\n  a = 1 / 0\n  b = a + 1\n}"
     "Pipeline(2 nodes: [a, b])\nErrors:\n  - `a` failed: Pipeline node `a` failed: Division by zero.\n  - `b` failed: Pipeline node `b` failed: Pipeline node `a` failed: Division by zero.";

--- a/tests/pipeline/test_pipeline.ml
+++ b/tests/pipeline/test_pipeline.ml
@@ -254,7 +254,7 @@ let run_tests pass_count fail_count _eval_string eval_string_env test =
     {|Error(ValueError: "Pipeline has a dependency cycle involving node `a`.")|};
   test "pipeline with error in node"
     "pipeline {\n  a = 1 / 0\n  b = a + 1\n}"
-    "Pipeline(2 nodes: [a, b])\nErrors:\n  - `a` failed: Pipeline node `a` failed: Division by zero.\n  - `b` failed: Pipeline node `b` failed: Upstream error: Pipeline node `a` failed: Division by zero.";
+    "Pipeline(2 nodes: [a, b])\nErrors:\n  - `a` failed: Pipeline node `a` failed: Division by zero.\n  - `b` failed: Pipeline node `b` failed: Pipeline node `a` failed: Division by zero.";
   
   test "explain shows runtime for T node error"
     "p = pipeline { a = 1 / 0 }; info = explain(p.a); info.runtime"
@@ -368,13 +368,13 @@ let run_tests pass_count fail_count _eval_string eval_string_env test =
   filtered = filter(data, $x > 1)
   count = nrow(filtered)
 }; read_pipeline(p_diag).diagnostics.summary|}
-    "\"1 node(s) with warnings, 0 suppressed, 0 error(s)\"";
+    "\"1 node(s) with warnings, 0 suppressed, 0 error(s), 0 recovered\"";
   test "read_pipeline tracks error nodes"
     {|p_err = pipeline {
   bad = 1 / 0
   downstream = bad + 1
 }; read_pipeline(p_err).diagnostics.summary|}
-    "\"0 node(s) with warnings, 0 suppressed, 2 error(s)\"";
+    "\"0 node(s) with warnings, 0 suppressed, 2 error(s), 0 recovered\"";
   test "read_node(p, name) exposes structured node errors"
     {|p_err = pipeline {
   bad = 1 / 0

--- a/tests/test_runner.ml
+++ b/tests/test_runner.ml
@@ -142,6 +142,9 @@ let () =
 
   (* ImportFileFrom tests *)
   Test_import_file_from.run_tests pass_count fail_count eval_string eval_string_env test;
+  
+  (* Structural Integrity & Error category tests *)
+  Test_structural_integrity.run_tests pass_count fail_count eval_string eval_string_env test;
 
   (* Summary *)
   let total = !pass_count + !fail_count in

--- a/tests/test_runner.ml
+++ b/tests/test_runner.ml
@@ -13,13 +13,13 @@ let eval_string input =
   let env = Packages.init_env () in
   let lexbuf = Lexing.from_string input in
   let program = Parser.program Lexer.token lexbuf in
-  let (result, _env) = Eval.eval_program program env in
+  let (result, _env) = Eval.eval_program ~resilient:false program env in
   result
 
 let eval_string_env input env =
   let lexbuf = Lexing.from_string input in
   let program = Parser.program Lexer.token lexbuf in
-  Eval.eval_program program env
+  Eval.eval_program ~resilient:false program env
 
 let strip_location s =
   let re = Str.regexp "\\[[^]]*L[0-9]+:C[0-9]+\\] " in

--- a/tests/test_serializers.ml
+++ b/tests/test_serializers.ml
@@ -139,7 +139,7 @@ let run_tests pass_count fail_count _eval_string eval_string_env _test =
   |} env_onnx in
   (match v with
    | VError { code; message; _ }
-     when code = FileError
+     when code = StructuralError
        && contains_all message
             [ "tproject.toml"; "onnxruntime"; "skl2onnx"; "cannot add these dependencies automatically" ] ->
        incr pass_count;

--- a/tests/test_serializers.ml
+++ b/tests/test_serializers.ml
@@ -141,7 +141,7 @@ let run_tests pass_count fail_count _eval_string eval_string_env _test =
    | VError { code; message; _ }
      when code = StructuralError
        && contains_all message
-            [ "tproject.toml"; "onnxruntime"; "skl2onnx"; "cannot add these dependencies automatically" ] ->
+            [ "tproject.toml"; "onnxruntime"; "skl2onnx" ] ->
        incr pass_count;
        Printf.printf "  ✓ Missing serializer dependencies fail statically without implicit injection\n"
    | other ->
@@ -158,9 +158,9 @@ let run_tests pass_count fail_count _eval_string eval_string_env _test =
   |} env_pmml_deps in
   (match v with
    | VError { code; message; _ }
-     when code = FileError
+     when code = StructuralError
        && contains_all message
-            [ "tproject.toml"; "pyarrow"; "sklearn2pmml"; "cannot add these dependencies automatically" ] ->
+            [ "tproject.toml"; "pyarrow"; "sklearn2pmml" ] ->
        incr pass_count;
        Printf.printf "  ✓ Missing PMML dependencies fail statically with explicit pyarrow guidance\n"
    | other ->


### PR DESCRIPTION
stacked on https://github.com/b-rodrigues/tlang/pull/310/ 

This update refines the "Resilient-by-Default" execution model by introducing a distinction between **Computation Errors** (which remain resilient) and **Structural Errors** (which halt execution).

#### 1. Core Changes: The `StructuralError`
*   **Definition**: A new error code, `StructuralError`, has been added to the language. It represents fundamental failures in project orchestration, environment setup, or DAG topology.
*   **Terminal Behavior**: The evaluator (`eval_program`) has been updated to treat `StructuralError` as a terminal event. Even when `resilient=true` is set, the presence of a structural error will now cause an immediate script halt.
*   **Use Cases**:
    *   **Dependency Cycles**: Infinite loops in the dependency graph now trigger a fatal stop.
    *   **Missing Dependencies**: Failures in theautomated dependency injection phase (e.g., missing `arrow` or `pyarrow` in `tproject.toml`) are now classified as structural and fatal.
    *   **Coherence Failures**: Conflicting serialization/deserialization strategies between nodes (e.g., Arrow vs. PMML) are now fatal at materialization time.
    *   **Missing Infrastructure**: Missing required tools like `nix-build` are now fatal.

#### 2. CLI & Diagnostic Improvements
*   **Output Sequencing**: Reordered the build initiation messages. `t_make` now prints the project build start message before evaluation begins, ensuring better chronological flow.
*   **Diagnostic Synchronization**: Added an explicit `flush stdout` before printing the iconic pipeline summary to `stderr`. This ensures that user-defined `print()` calls from within nodes are correctly ordered relative to the summary.
*   **Error Recognition**: Updated the build reconciler to recognize both `"VError"` and `"Error"` tags in build artifacts, ensuring that "SoftFailed" nodes are accurately reported in build summaries.

#### 3. Documentation
*   **Specification**: Added [structural-error.md](file:///home/brodrigues/Documents/repos/tlang/spec_files/structural-error.md) to define the boundaries of resilient execution and the rationale for terminal orchestration failures.
