### PR TITLE
feat(companion): add `pipeline_nodes` DAG tree view for R/Python/Julia packages

### DIFF
--- a/jl-package/src/tlang.jl
+++ b/jl-package/src/tlang.jl
@@ -3,7 +3,7 @@ module tlang
 using JSON
 using Serialization
 
-export read_node
+export read_node, pipeline_nodes
 
 const FIXTURE_LOGS = ["build_log_ocaml_mock.json", "build_log_legacy_version.json"]
 
@@ -53,6 +53,124 @@ function _find_node_entry(nodes::Vector{Any}, name::String, log_file::String)
     error("Node `$name` not found in build log `$log_file`.")
 end
 
+
+function _validate_node_entry(entry::Any, index::Int, dag_path::String)
+    if !(entry isa AbstractDict)
+        error("Entry $index in `$dag_path` must be an object.")
+    end
+
+    node_name = get(entry, "node_name", nothing)
+    depends = get(entry, "depends", String[])
+
+    if !(node_name isa String) || isempty(strip(node_name))
+        error("Entry $index in `$dag_path` has an invalid `node_name`.")
+    end
+
+    if !(depends isa Vector)
+        error("Node `$node_name` in `$dag_path` has an invalid `depends` list.")
+    end
+
+    dep_names = String[]
+    for dep in depends
+        if !(dep isa String) || isempty(strip(dep))
+            error("Node `$node_name` in `$dag_path` has an invalid `depends` list.")
+        end
+        push!(dep_names, dep)
+    end
+
+    return node_name, unique(sort(dep_names))
+end
+
+function _render_node_tree(node::String, children_map::Dict{String, Vector{String}}; prefix::String="", is_last::Bool=true, seen::Vector{String}=String[], depth::Int=0)
+    connector = depth == 0 ? "" : (is_last ? "└─ " : "├─ ")
+    line = string(prefix, connector, node)
+
+    if node in seen
+        cycle_prefix = string(prefix, is_last ? "   " : "│  ")
+        return [line, string(cycle_prefix, "↺ cycle detected")]
+    end
+
+    children = get(children_map, node, String[])
+    if isempty(children)
+        return [line]
+    end
+
+    next_prefix = string(prefix, is_last ? "   " : "│  ")
+    lines = String[line]
+    for (idx, child) in enumerate(children)
+        append!(lines, _render_node_tree(child, children_map; prefix=next_prefix, is_last=(idx == length(children)), seen=vcat(seen, [node]), depth=depth+1))
+    end
+
+    return lines
+end
+
+"""
+    pipeline_nodes(; pipeline_dir="_pipeline", dag_file="dag.json")
+
+List pipeline nodes from `_pipeline/dag.json` in a tree-like view.
+"""
+function pipeline_nodes(; pipeline_dir::String="_pipeline", dag_file::String="dag.json")
+    if !isdir(pipeline_dir)
+        error("Pipeline directory `$pipeline_dir` does not exist.")
+    end
+
+    dag_path = joinpath(pipeline_dir, dag_file)
+    if !isfile(dag_path)
+        error("DAG file `$dag_path` does not exist.")
+    end
+
+    dag = JSON.parsefile(dag_path)
+    if !(dag isa Vector)
+        error("DAG file `$dag_path` must decode to an array.")
+    end
+
+    normalized = [_validate_node_entry(entry, idx, dag_path) for (idx, entry) in enumerate(dag)]
+    node_names = [name for (name, _) in normalized]
+
+    duplicate_names = unique([name for name in node_names if count(==(name), node_names) > 1])
+    if !isempty(duplicate_names)
+        error("DAG file `$dag_path` has duplicate node_name values: $(join(sort(duplicate_names), ", "))")
+    end
+
+    unknown_deps = String[]
+    for (_, deps) in normalized
+        for dep in deps
+            if !(dep in node_names) && !(dep in unknown_deps)
+                push!(unknown_deps, dep)
+            end
+        end
+    end
+    if !isempty(unknown_deps)
+        error("DAG file `$dag_path` references unknown dependencies: $(join(sort(unknown_deps), ", "))")
+    end
+
+    children_map = Dict(name => String[] for name in node_names)
+    incoming_count = Dict(name => 0 for name in node_names)
+
+    for (name, deps) in normalized
+        for parent in deps
+            push!(children_map[parent], name)
+            incoming_count[name] += 1
+        end
+    end
+
+    for (key, children) in children_map
+        sort!(children)
+        children_map[key] = children
+    end
+
+    roots = sort([name for (name, count) in incoming_count if count == 0])
+    if isempty(roots)
+        roots = sort(node_names)
+    end
+
+    lines = String[]
+    for (idx, root) in enumerate(roots)
+        append!(lines, _render_node_tree(root, children_map; prefix="", is_last=(idx == length(roots))))
+    end
+
+    return join(lines, "\n")
+end
 function _resolve_artifact_path(path_val::String, pipeline_dir::String)
     if isabspath(path_val)
         return path_val

--- a/py-package/README.md
+++ b/py-package/README.md
@@ -36,3 +36,14 @@ You can also target a specific historical build log:
 ```python
 older_model = read_node("model", which_log="20260221")
 ```
+
+
+## Inspect pipeline DAG
+
+Render `_pipeline/dag.json` as a tree:
+
+```python
+from tlang import pipeline_nodes
+
+print(pipeline_nodes())
+```

--- a/py-package/src/tlang/__init__.py
+++ b/py-package/src/tlang/__init__.py
@@ -1,3 +1,4 @@
+from .pipeline_nodes import pipeline_nodes
 from .read_node import deserialize, read_node
 
-__all__ = ["deserialize", "read_node"]
+__all__ = ["deserialize", "read_node", "pipeline_nodes"]

--- a/py-package/src/tlang/pipeline_nodes.py
+++ b/py-package/src/tlang/pipeline_nodes.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _validate_non_empty_string(value: str, arg: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"`{arg}` must be a non-empty string.")
+
+
+def _validate_entry(entry: Any, index: int, dag_path: Path) -> tuple[str, list[str]]:
+    if not isinstance(entry, dict):
+        raise ValueError(f"Entry {index} in `{dag_path}` must be an object.")
+
+    node_name = entry.get("node_name")
+    depends = entry.get("depends", [])
+
+    if not isinstance(node_name, str) or not node_name.strip():
+        raise ValueError(f"Entry {index} in `{dag_path}` has an invalid `node_name`.")
+
+    if not isinstance(depends, list) or any(not isinstance(dep, str) or not dep.strip() for dep in depends):
+        raise ValueError(f"Node `{node_name}` in `{dag_path}` has an invalid `depends` list.")
+
+    return node_name, sorted(set(depends))
+
+
+def _render_tree(node: str, children_map: dict[str, list[str]], prefix: str = "", is_last: bool = True, seen: tuple[str, ...] = (), depth: int = 0) -> list[str]:
+    connector = "" if depth == 0 else ("└─ " if is_last else "├─ ")
+    line = f"{prefix}{connector}{node}"
+
+    if node in seen:
+        cycle_prefix = f"{prefix}{'   ' if is_last else '│  '}"
+        return [line, f"{cycle_prefix}↺ cycle detected"]
+
+    children = children_map.get(node, [])
+    if not children:
+        return [line]
+
+    next_prefix = f"{prefix}{'   ' if is_last else '│  '}"
+    lines = [line]
+    for idx, child in enumerate(children):
+        lines.extend(_render_tree(child, children_map, next_prefix, idx == len(children) - 1, (*seen, node), depth + 1))
+    return lines
+
+
+def pipeline_nodes(pipeline_dir: str | Path = "_pipeline", dag_file: str = "dag.json") -> str:
+    """List pipeline nodes from ``_pipeline/dag.json`` in a tree-like view."""
+    pipeline_path = Path(pipeline_dir)
+    _validate_non_empty_string(str(pipeline_path), "pipeline_dir")
+    _validate_non_empty_string(dag_file, "dag_file")
+
+    if not pipeline_path.is_dir():
+        raise FileNotFoundError(f"Pipeline directory `{pipeline_path}` does not exist.")
+
+    dag_path = pipeline_path / dag_file
+    if not dag_path.is_file():
+        raise FileNotFoundError(f"DAG file `{dag_path}` does not exist.")
+
+    try:
+        with dag_path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except OSError as err:
+        raise OSError(f"Failed to read DAG file `{dag_path}`: {err}") from err
+    except json.JSONDecodeError as err:
+        raise ValueError(f"Failed to read DAG file `{dag_path}`: {err}") from err
+
+    if not isinstance(data, list):
+        raise ValueError(f"DAG file `{dag_path}` must decode to an array.")
+
+    normalized = [_validate_entry(entry, idx + 1, dag_path) for idx, entry in enumerate(data)]
+    node_names = [name for name, _ in normalized]
+
+    duplicates = sorted({name for name in node_names if node_names.count(name) > 1})
+    if duplicates:
+        raise ValueError(
+            f"DAG file `{dag_path}` has duplicate node_name values: {', '.join(duplicates)}"
+        )
+
+    node_set = set(node_names)
+    unknown_deps = sorted({dep for _, deps in normalized for dep in deps if dep not in node_set})
+    if unknown_deps:
+        raise ValueError(
+            f"DAG file `{dag_path}` references unknown dependencies: {', '.join(unknown_deps)}"
+        )
+
+    children_map: dict[str, list[str]] = {name: [] for name in node_names}
+    incoming_count: dict[str, int] = {name: 0 for name in node_names}
+
+    for name, deps in normalized:
+        for parent in deps:
+            children_map[parent].append(name)
+            incoming_count[name] += 1
+
+    for key in children_map:
+        children_map[key] = sorted(children_map[key])
+
+    roots = sorted([name for name, count in incoming_count.items() if count == 0]) or sorted(node_names)
+
+    lines: list[str] = []
+    for idx, root in enumerate(roots):
+        lines.extend(_render_tree(root, children_map, "", idx == len(roots) - 1))
+
+    return "\n".join(lines)

--- a/r-package/NAMESPACE
+++ b/r-package/NAMESPACE
@@ -1,1 +1,2 @@
 export(read_node)
+export(pipeline_nodes)

--- a/r-package/R/pipeline_nodes.R
+++ b/r-package/R/pipeline_nodes.R
@@ -1,0 +1,130 @@
+validate_node_entry <- function(entry, index, dag_file) {
+  if (!is.list(entry)) {
+    stop(
+      sprintf("Entry %d in `%s` must be an object.", index, dag_file),
+      call. = FALSE
+    )
+  }
+
+  node_name <- entry$node_name
+  depends <- entry$depends
+
+  if (!is.character(node_name) || length(node_name) != 1L || is.na(node_name) || !nzchar(node_name)) {
+    stop(
+      sprintf("Entry %d in `%s` has an invalid `node_name`.", index, dag_file),
+      call. = FALSE
+    )
+  }
+
+  if (is.null(depends)) {
+    depends <- character(0)
+  }
+
+  if (!is.character(depends) || any(is.na(depends)) || any(!nzchar(depends))) {
+    stop(
+      sprintf("Node `%s` in `%s` has an invalid `depends` list.", node_name, dag_file),
+      call. = FALSE
+    )
+  }
+
+  list(node_name = node_name, depends = unique(depends))
+}
+
+render_node_tree <- function(node, children_map, prefix = "", is_last = TRUE, seen = character(0), depth = 0L) {
+  connector <- if (depth == 0L) "" else if (is_last) "└─ " else "├─ "
+  line <- paste0(prefix, connector, node)
+
+  if (node %in% seen) {
+    return(c(line, paste0(prefix, if (is_last) "   " else "│  ", "↺ cycle detected")))
+  }
+
+  children <- children_map[[node]]
+  if (is.null(children) || length(children) == 0L) {
+    return(line)
+  }
+
+  next_prefix <- paste0(prefix, if (is_last) "   " else "│  ")
+  rendered_children <- unlist(
+    lapply(seq_along(children), function(i) {
+      render_node_tree(children[[i]], children_map, next_prefix, i == length(children), c(seen, node), depth + 1L)
+    }),
+    use.names = FALSE
+  )
+
+  c(line, rendered_children)
+}
+
+#' List pipeline nodes from `_pipeline/dag.json` in a tree-like view
+#'
+#' Reads a pipeline DAG definition from `_pipeline/dag.json` and returns a
+#' character vector representing the pipeline structure as an ASCII tree.
+#'
+#' @param pipeline_dir Path to the pipeline build directory. Defaults to
+#'   `"_pipeline"`.
+#' @param dag_file Name of the DAG JSON file inside `pipeline_dir`.
+#'   Defaults to `"dag.json"`.
+#'
+#' @return Character vector with one line per rendered tree node.
+#' @export
+pipeline_nodes <- function(pipeline_dir = "_pipeline", dag_file = "dag.json") {
+  validate_scalar_string(pipeline_dir, "pipeline_dir")
+  validate_scalar_string(dag_file, "dag_file")
+
+  if (!dir.exists(pipeline_dir)) {
+    stop(sprintf("Pipeline directory `%s` does not exist.", pipeline_dir), call. = FALSE)
+  }
+
+  dag_path <- file.path(pipeline_dir, dag_file)
+  if (!file.exists(dag_path)) {
+    stop(sprintf("DAG file `%s` does not exist.", dag_path), call. = FALSE)
+  }
+
+  dag <- tryCatch(
+    jsonlite::fromJSON(dag_path, simplifyVector = FALSE),
+    error = function(err) {
+      stop(sprintf("Failed to read DAG file `%s`: %s", dag_path, conditionMessage(err)), call. = FALSE)
+    }
+  )
+
+  if (!is.list(dag)) {
+    stop(sprintf("DAG file `%s` must decode to an array.", dag_path), call. = FALSE)
+  }
+
+  normalized <- lapply(seq_along(dag), function(i) validate_node_entry(dag[[i]], i, dag_path))
+  node_names <- vapply(normalized, `[[`, character(1), "node_name")
+
+  if (any(duplicated(node_names))) {
+    duplicated_names <- unique(node_names[duplicated(node_names)])
+    stop(sprintf("DAG file `%s` has duplicate node_name values: %s", dag_path, paste(duplicated_names, collapse = ", ")), call. = FALSE)
+  }
+
+  unknown_dependencies <- unique(unlist(lapply(normalized, function(entry) setdiff(entry$depends, node_names)), use.names = FALSE))
+  if (length(unknown_dependencies) > 0L) {
+    stop(sprintf("DAG file `%s` references unknown dependencies: %s", dag_path, paste(unknown_dependencies, collapse = ", ")), call. = FALSE)
+  }
+
+  children_map <- stats::setNames(vector("list", length(node_names)), node_names)
+  incoming_count <- stats::setNames(integer(length(node_names)), node_names)
+
+  for (entry in normalized) {
+    for (parent in entry$depends) {
+      children_map[[parent]] <- c(children_map[[parent]], entry$node_name)
+      incoming_count[[entry$node_name]] <- incoming_count[[entry$node_name]] + 1L
+    }
+  }
+
+  children_map <- lapply(children_map, sort)
+  roots <- sort(names(incoming_count[incoming_count == 0L]))
+  if (length(roots) == 0L) {
+    roots <- sort(node_names)
+  }
+
+  lines <- unlist(
+    lapply(seq_along(roots), function(i) {
+      render_node_tree(roots[[i]], children_map, prefix = "", is_last = i == length(roots))
+    }),
+    use.names = FALSE
+  )
+
+  lines
+}

--- a/r-package/README.md
+++ b/r-package/README.md
@@ -35,3 +35,12 @@ You can also target a specific historical build log:
 ```r
 older_model <- read_node("model", which_log = "20260221")
 ```
+
+
+## Inspect pipeline DAG
+
+Render `_pipeline/dag.json` as a tree:
+
+```r
+cat(pipeline_nodes(), sep = "\n")
+```

--- a/r-package/man/pipeline_nodes.Rd
+++ b/r-package/man/pipeline_nodes.Rd
@@ -1,0 +1,25 @@
+\name{pipeline_nodes}
+\alias{pipeline_nodes}
+\title{List pipeline nodes from _pipeline/dag.json in a tree-like view}
+\usage{
+pipeline_nodes(pipeline_dir = "_pipeline", dag_file = "dag.json")
+}
+\arguments{
+  \item{pipeline_dir}{Path to the pipeline build directory. Defaults to
+  \code{"_pipeline"}.}
+
+  \item{dag_file}{Name of the DAG JSON file inside \code{pipeline_dir}.
+  Defaults to \code{"dag.json"}.}
+}
+\value{
+Character vector with one line per rendered tree node.
+}
+\description{
+Reads a pipeline DAG definition from \code{_pipeline/dag.json} and returns a
+character vector representing the pipeline structure as an ASCII tree.
+}
+\examples{
+\dontrun{
+cat(pipeline_nodes(), sep = "\n")
+}
+}


### PR DESCRIPTION
### Motivation
- Provide companion-package users a simple way to inspect pipeline structure when the pipeline runtime is out of scope by parsing `_pipeline/dag.json` and rendering a tree view.
- Keep the helper small and safe with explicit validation and clear errors for malformed DAGs, duplicate names, unknown deps, and missing pipeline files.

### Description
- Added `pipeline_nodes` helpers that parse `*_pipeline/dag.json*` and render node relationships as an ASCII tree in R (`r-package/R/pipeline_nodes.R`), Python (`py-package/src/tlang/pipeline_nodes.py`), and Julia (`jl-package/src/tlang.jl`).
- Each implementation normalizes entries (`node_name`, `depends`), validates input (array shape, types, duplicates, unknown dependencies), builds a parent→children map, and renders a stable sorted tree with cycle detection markers (`↺ cycle detected`).
- Exported the helper from package surfaces by updating `r-package/NAMESPACE`, `py-package/src/tlang/__init__.py`, and adding the `Julia` export; added R man page `r-package/man/pipeline_nodes.Rd` and README usage examples for R/Python.
- The change is additive to companion packages only and does not alter parser/REPL/core language behavior.

### Testing
- Ran `python -m compileall py-package/src/tlang` to validate Python package modules compiled successfully (passed).
- Performed a manual Python smoke test by creating a temporary `_pipeline/dag.json` and asserting `pipeline_nodes()` output matched expected tree rendering (passed).
- Attempted a quick Julia runtime include test but the `julia` executable is not available in the environment, so the Julia runtime smoke check was not executed (warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0737242ad08326a7d1ed2970c2bf4b)