### PR TITLE
docs(spec): revalidate finalizing-julia-support status

### DIFF
--- a/spec_files/finalizing-julia-support.md
+++ b/spec_files/finalizing-julia-support.md
@@ -8,34 +8,48 @@ This document outlines the remaining gaps and required implementations to bring 
 - [x] Nix generator handles `JULIA_LOAD_PATH` and companion package provisioning.
 - [x] Cross-language dependency wiring via `T_NODE_<name>` environment variables.
 
-## Remaining Gaps
+## Remaining Gaps (Revalidated)
 
 ### 1. Robust Native Serialization
-Unlike Python (which uses `dill`/`cloudpickle` fallbacks) or R (`saveRDS`), Julia currently relies on standard `Serialization.serialize`.
-- **Issue**: Complex objects and models often hit "World Age" or method-caching issues across process boundaries.
-- **Goal**: Implement a `jl_serialize` helper in `nix_emit_node.ml` that provides a more stable serialization path for models.
+**Status:** Partially implemented.
+
+Julia runtime injection now includes `jl_serialize(obj, path)` in `nix_emit_node.ml`, and it is wired into serialization dispatch for Julia nodes.
+
+- **Still open:** `jl_serialize` currently delegates directly to `Serialization.serialize(path, obj)`.
+- **Potential risk:** complex objects and models may still hit world-age/method-cache issues across process boundaries.
+- **Next step:** harden `jl_serialize` with a more robust model-safe strategy (or explicitly document unsupported object classes).
 
 ### 2. PMML & ONNX Export Support
-Julia currently lacks the automated model export logic available to R and Python.
-- **Requirement**: Implement `t_pmml_jl_code` and `t_onnx_jl_code` in `nix_emit_node.ml`.
-- **Target Libraries**: Support `GLM.jl`, `DecisionTree.jl`, and `Flux.jl` for standardized model interchange.
+**Status:** Largely implemented in `nix_emit_node.ml`.
+
+- `t_pmml_jl_code` is implemented, including a GLM-focused PMML writer and a JPMML-backed reader.
+- `t_onnx_jl_code` is implemented with ONNX/ONNXRunTime based read/write helpers.
+- **Remaining gap:** model-family coverage and interoperability hardening (e.g., validate end-to-end support expectations for non-GLM models such as `DecisionTree.jl` and `Flux.jl`).
 
 ### 3. Runtime Diagnostics (`t doctor`)
-Diagnostic health checks for Julia environments are missing.
+**Status:** Still a gap.
+
+`t doctor` exists, but `package_doctor.ml` does not yet perform Julia-specific runtime diagnostics.
 - **Goal**: Add checks to `package_doctor.ml` to verify:
     - `JULIA_LOAD_PATH` correctness.
     - Presence of mandatory packages (`JSON`, `DataFrames`, `CSV`, `Arrow`).
     - Basic Julia binary availability and version compatibility.
 
 ### 4. Visual Metadata Extraction
-The T-Lang REPL cannot currently display rich previews for Julia plots.
-- **Goal**: Add metadata extraction logic for `Makie.jl` and `Plots.jl` to enable interactive plot previews in the REPL.
+**Status:** Implemented for core Julia plot cases.
+
+Metadata extraction and preview plumbing for Julia plot classes (including Makie-focused handling) exists in pipeline emission, and `show_plot` includes Julia rendering logic with explicit `CairoMakie` requirements for Makie.
+
+- **Possible follow-up:** expand extraction coverage and metadata richness for additional plotting packages/types.
 
 ### 5. CI/CD Integration Testing
-Native integration tests for Julia are currently sparse in the main test suite.
-- **Goal**: Add `tests/julia/test_julia_integration.ml` to ensure cross-language interchange and Julia node stability in the CI pipeline.
+**Status:** Partially addressed through existing suite coverage.
 
-## Implementation Priority
-1. **PMML Export**: Essential for model interoperability.
-2. **Diagnostics**: Crucial for onboarding and troubleshooting.
-3. **Robust Serialization**: Prevents brittle pipeline failures for complex models.
+There is already Julia-related coverage in the pipeline and CLI test suites (including Julia plot metadata/renderer behavior), but a dedicated `tests/julia/test_julia_integration.ml` target still does not exist.
+
+- **Goal:** optionally add a dedicated Julia integration test file if clearer ownership/isolation is desired in CI.
+
+## Updated Implementation Priority
+1. **Diagnostics (`t doctor`)**: still missing Julia-specific checks and is the clearest operational gap.
+2. **Serialization hardening**: `jl_serialize` exists but is still thin and should be made more robust/documented.
+3. **Interoperability hardening for PMML/ONNX**: core helpers exist; prioritize broader model-family validation and tests.


### PR DESCRIPTION
### Motivation
- Align the `spec_files/finalizing-julia-support.md` document with the current implementation to avoid stale or misleading action items.
- Surface the precise remaining work (diagnostics and serialization hardening) so engineering effort can be prioritized correctly.
- Ensure maintainers and CI owners have an accurate spec for Julia runtime support and interoperability work.

### Description
- Updated `spec_files/finalizing-julia-support.md` to mark `jl_serialize` as **partially implemented** and note it currently delegates to `Serialization.serialize` and needs hardening or documentation for unsupported classes.
- Marked `t_pmml_jl_code` and `t_onnx_jl_code` as implemented in `src/pipeline/nix_emit_node.ml` while calling out remaining model-family coverage and interoperability hardening for non-GLM models.
- Left `t doctor` Julia-specific checks as an open gap and recorded that `show_plot` / Makie rendering and core Julia plot metadata extraction are present; updated the implementation priority accordingly.
- This PR is documentation/spec-only and modifies `spec_files/finalizing-julia-support.md` (commit message: `docs(spec): revalidate julia support status`).

### Testing
- No automated test suite was executed for this change (documentation-only update).
- Performed static code inspections to validate statements: searched and spot-checked `src/pipeline/nix_emit_node.ml`, `src/package_manager/package_doctor.ml`, `src/packages/core/show_plot.ml`, and relevant tests using `rg`, `sed`, and `nl`; the inspected files corroborate the updated spec statements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0823766e008326b301a39a15d1b3bb)