### PR TITLE
feat(doctor): add Julia runtime diagnostics to `t doctor`

### DIFF
--- a/spec_files/finalizing-julia-support.md
+++ b/spec_files/finalizing-julia-support.md
@@ -27,7 +27,7 @@ Julia runtime injection now includes `jl_serialize(obj, path)` in `nix_emit_node
 - **Remaining gap:** model-family coverage and interoperability hardening (e.g., validate end-to-end support expectations for non-GLM models such as `DecisionTree.jl` and `Flux.jl`).
 
 ### 3. Runtime Diagnostics (`t doctor`)
-**Status:** Still a gap.
+**Status:** ~~Still a gap~~.
 
 `t doctor` exists, but `package_doctor.ml` does not yet perform Julia-specific runtime diagnostics.
 - **Goal**: Add checks to `package_doctor.ml` to verify:
@@ -50,6 +50,6 @@ There is already Julia-related coverage in the pipeline and CLI test suites (inc
 - **Goal:** optionally add a dedicated Julia integration test file if clearer ownership/isolation is desired in CI.
 
 ## Updated Implementation Priority
-1. **Diagnostics (`t doctor`)**: still missing Julia-specific checks and is the clearest operational gap.
+~~1. **Diagnostics (`t doctor`)**: still missing Julia-specific checks and is the clearest operational gap.~~
 2. **Serialization hardening**: `jl_serialize` exists but is still thin and should be made more robust/documented.
 3. **Interoperability hardening for PMML/ONNX**: core helpers exist; prioritize broader model-family validation and tests.

--- a/src/package_manager/package_doctor.ml
+++ b/src/package_manager/package_doctor.ml
@@ -113,6 +113,93 @@ let check_nix_installation () =
     }
   else None
 
+let check_julia_binary () =
+  let code = Sys.command "command -v julia >/dev/null 2>&1" in
+  if code <> 0 then
+    Some {
+      level = Warning;
+      message = "Julia binary is not installed or not in PATH";
+      suggestion = Some "Install Julia and ensure `julia` is available on PATH";
+    }
+  else None
+
+let check_julia_version () =
+  if Sys.command "command -v julia >/dev/null 2>&1" <> 0 then None
+  else
+    let ic = Unix.open_process_in "julia --version 2>/dev/null" in
+    let line = try input_line ic with End_of_file -> "" in
+    let status = Unix.close_process_in ic in
+    let parse_major_minor version =
+      try
+        match String.split_on_char '.' version with
+        | major :: minor :: _ -> Some (int_of_string major, int_of_string minor)
+        | _ -> None
+      with _ -> None
+    in
+    match status with
+    | Unix.WEXITED 0 ->
+        let version =
+          match String.split_on_char ' ' line with
+          | _prefix :: v :: _ -> v
+          | _ -> ""
+        in
+        begin match parse_major_minor version with
+        | Some (major, minor) when major > 1 || (major = 1 && minor >= 6) -> None
+        | Some _ ->
+            Some {
+              level = Warning;
+              message = Printf.sprintf "Julia version %s may be too old; expected Julia >= 1.6" version;
+              suggestion = Some "Upgrade Julia to version 1.6 or newer";
+            }
+        | None ->
+            Some {
+              level = Suggestion;
+              message = Printf.sprintf "Could not parse Julia version output: %s" line;
+              suggestion = Some "Run `julia --version` and verify it reports a version >= 1.6";
+            }
+        end
+    | _ ->
+        Some {
+          level = Suggestion;
+          message = "Could not determine Julia version";
+          suggestion = Some "Run `julia --version` manually";
+        }
+
+let check_julia_load_path () =
+  match Sys.getenv_opt "JULIA_LOAD_PATH" with
+  | None ->
+      Some {
+        level = Suggestion;
+        message = "JULIA_LOAD_PATH is not set";
+        suggestion = Some "Set JULIA_LOAD_PATH so Julia can discover required companion packages";
+      }
+  | Some load_path when String.trim load_path = "" ->
+      Some {
+        level = Warning;
+        message = "JULIA_LOAD_PATH is empty";
+        suggestion = Some "Set JULIA_LOAD_PATH to include Julia project/package paths";
+      }
+  | Some _ -> None
+
+let check_julia_packages () =
+  if Sys.command "command -v julia >/dev/null 2>&1" <> 0 then []
+  else
+    let required_packages = [ "JSON"; "DataFrames"; "CSV"; "Arrow" ] in
+    List.filter_map (fun pkg ->
+      let cmd =
+        Printf.sprintf
+          "julia -e 'import Pkg; has = any(d->d.name==\"%s\", values(Pkg.dependencies())); exit(has ? 0 : 1)' >/dev/null 2>&1"
+          pkg
+      in
+      if Sys.command cmd = 0 then None
+      else
+        Some {
+          level = Warning;
+          message = Printf.sprintf "Missing Julia package `%s`" pkg;
+          suggestion = Some (Printf.sprintf "Install it with Julia Pkg: `julia -e \"import Pkg; Pkg.add(\\\"%s\\\")\"`" pkg);
+        }
+    ) required_packages
+
 (*
 --# Run Package/Project Doctor
 --#
@@ -159,6 +246,12 @@ let run_doctor () =
          [{ level = Warning; message = msg; suggestion = Some "Run `t docs` to debug or create docs/index.md" }]
   in
   let issues = doc_issues @ issues in
+  let julia_issues =
+    let base_checks = [ check_julia_binary (); check_julia_version (); check_julia_load_path () ] in
+    let base_issues = List.filter_map (fun x -> x) base_checks in
+    base_issues @ check_julia_packages ()
+  in
+  let issues = issues @ julia_issues in
 
   if issues = [] then
     Printf.printf "\n✓ Everything looks good!\n"

--- a/tests/test_arrow_native_runner.ml
+++ b/tests/test_arrow_native_runner.ml
@@ -36,8 +36,8 @@ let test name input expected =
 let () =
   Printf.printf "\n=== Arrow Native Validation ===\n\n";
 
-  Test_arrow_integration.run_tests pass_count fail_count eval_string eval_string_env test;
-  Test_arrow_performance.run_tests pass_count fail_count eval_string eval_string_env test;
+  Test_arrow_integration.run_tests pass_count fail_count (ref []) eval_string eval_string_env test;
+  Test_arrow_performance.run_tests pass_count fail_count (ref []) eval_string eval_string_env test;
 
   let total = !pass_count + !fail_count in
   Printf.printf "=== Results: %d/%d passed ===\n" !pass_count total;

--- a/tests/test_misc_coverage.ml
+++ b/tests/test_misc_coverage.ml
@@ -786,6 +786,34 @@ min_version = "0.51.0"
       in
       missing_file_ok && wrong_dir_ok && empty_dir_ok && project_ok && nix_ok)
   );
+  test_case "package_doctor julia diagnostics helpers handle env and missing binary" (fun () ->
+    let original_load_path = Sys.getenv_opt "JULIA_LOAD_PATH" in
+    Unix.putenv "JULIA_LOAD_PATH" "";
+    let empty_load_path_warns =
+      match Package_doctor.check_julia_load_path () with
+      | Some { Package_doctor.level = Package_doctor.Warning; _ } -> true
+      | _ -> false
+    in
+    let missing_or_present_binary_ok =
+      match Package_doctor.check_julia_binary () with
+      | None -> true
+      | Some { Package_doctor.level = Package_doctor.Warning; _ } -> true
+      | _ -> false
+    in
+    let version_check_ok =
+      match Package_doctor.check_julia_version () with
+      | None -> true
+      | Some _ -> true
+    in
+    let package_check_ok =
+      let issues = Package_doctor.check_julia_packages () in
+      List.for_all (fun i -> i.Package_doctor.level = Package_doctor.Warning) issues
+    in
+    (match original_load_path with
+    | Some v -> Unix.putenv "JULIA_LOAD_PATH" v
+    | None -> Unix.putenv "JULIA_LOAD_PATH" "");
+    empty_load_path_warns && missing_or_present_binary_ok && version_check_ok && package_check_ok)
+  );
   print_newline ();
 
   Printf.printf "Coverage — Pipeline helpers:\n";

--- a/tests/test_misc_coverage.ml
+++ b/tests/test_misc_coverage.ml
@@ -809,10 +809,11 @@ min_version = "0.51.0"
       let issues = Package_doctor.check_julia_packages () in
       List.for_all (fun i -> i.Package_doctor.level = Package_doctor.Warning) issues
     in
-    (match original_load_path with
+    begin match original_load_path with
     | Some v -> Unix.putenv "JULIA_LOAD_PATH" v
-    | None -> Unix.putenv "JULIA_LOAD_PATH" "");
-    empty_load_path_warns && missing_or_present_binary_ok && version_check_ok && package_check_ok)
+    | None -> Unix.putenv "JULIA_LOAD_PATH" ""
+    end;
+    empty_load_path_warns && missing_or_present_binary_ok && version_check_ok && package_check_ok
   );
   print_newline ();
 


### PR DESCRIPTION
### Motivation
- Finalize Julia support by surfacing runtime misconfiguration early via `t doctor`, as identified in the Julia support spec.
- Provide deterministic guidance for common Julia setup issues (binary, version, load path, and required packages).

### Description
- Added Julia checks to the package doctor: `check_julia_binary`, `check_julia_version`, `check_julia_load_path`, and `check_julia_packages` in `src/package_manager/package_doctor.ml`.
- Wired the Julia checks into `run_doctor` so Julia diagnostics are reported alongside existing project/package, Nix, and docs checks.
- Implemented version parsing and a compatibility warning for Julia versions older than `1.6`.
- Added a regression test in `tests/test_misc_coverage.ml` covering the new Julia helper behavior and environment handling.

### Testing
- Added automated coverage test in `tests/test_misc_coverage.ml` to exercise the new Julia doctor helpers (tests included in the repo change set).
- Attempted to run `dune build` but it failed in the current environment because `dune` is not installed (`dune: command not found`).
- Attempted to run `nix develop -c dune build` but it failed because `nix` is not available in the environment (`nix: command not found`).
- No project/unit tests were executed to completion due to the missing `dune`/`nix` toolchain in this runner; the new tests are present and expected to pass when run inside the recommended Nix development shell (`nix develop` then `dune runtest`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a082680c04883269ab4ede1ed83fa8f)