### PR TITLE
fix: add parentheses to exit command

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -143,7 +143,7 @@ T>
 > type(42)
 "Int"
 
-> exit
+> exit()
 ```
 
 If all commands work, installation is successful! 🎉


### PR DESCRIPTION
I was able to follow the installation instructions on my NixOS server and everything compiled correctly. I noticed when I type `exit` in the REPL I would get the following output:

```bash
T> exit
<builtin_function>
```

Which reminds me of when I type a bare function name in R. Once I added the parentheses, the REPL returned back to my default shell. 