### PR TITLE
build(flake): ship agent templates for `t --init` scaffolding

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -168,6 +168,8 @@
               cp _build/default/src/lsp_server.exe $out/bin/.t-lsp-unwrapped
               mkdir -p $out/share/tlang
               cp -r src $out/share/tlang/
+              mkdir -p $out/share/tlang/agents
+              cp -r agents/* $out/share/tlang/agents/
               # Copy generated source files so coverage reports can find them
               cp _build/default/src/nixpkgs_date.ml $out/share/tlang/src/
               cp _build/default/src/version.ml $out/share/tlang/src/
@@ -182,6 +184,7 @@
                 --prefix LD_LIBRARY_PATH : "${pkgs.lib.makeLibraryPath [ pkgs.arrow-glib pkgs.glib pkgs.arrow-cpp pkgs.onnxruntime ]}" \
                 --prefix DYLD_LIBRARY_PATH : "${pkgs.lib.makeLibraryPath [ pkgs.arrow-glib pkgs.glib pkgs.arrow-cpp pkgs.onnxruntime ]}" \
                 --set TLANG_DOCS_PATH "$out/share/tlang/help/docs.json" \
+                --set TLANG_AGENTS_DIR "$out/share/tlang/agents" \
                 --set T_JPMML_STATSMODELS_JAR "${pkgs.jpmml-statsmodels}/share/java/jpmml-statsmodels.jar" \
                 --set T_JPMML_EVALUATOR_JAR "${pkgs.jpmml-evaluator}/share/java/jpmml-evaluator.jar"
 

--- a/flake.nix
+++ b/flake.nix
@@ -418,6 +418,7 @@ chmod +x $out/bin/bisect-ppx-report
             # 6. Local Project Binaries (Wrappers for development)
             (pkgs.writeShellScriptBin "t" ''
               repo_root="''${TLANG_REPO_ROOT:-$PWD}"
+              export TLANG_AGENTS_DIR="''${TLANG_AGENTS_DIR:-$repo_root/agents}"
               if [[ -f "$repo_root/_build/default/src/repl.exe" ]]; then
                 exec "$repo_root/_build/default/src/repl.exe" "$@"
               elif [[ -L "$repo_root/result" && -f "$repo_root/result/bin/t" ]]; then
@@ -458,6 +459,7 @@ chmod +x $out/bin/bisect-ppx-report
 
             export T_JPMML_EVALUATOR_JAR="${pkgs.jpmml-evaluator}/share/java/jpmml-evaluator.jar"
             export T_JPMML_STATSMODELS_JAR="${pkgs.jpmml-statsmodels}/share/java/jpmml-statsmodels.jar"
+            export TLANG_AGENTS_DIR="$TLANG_REPO_ROOT/agents"
 
             # Make local companion language packages importable in nix develop
             export PYTHONPATH="$TLANG_REPO_ROOT/py-package/src''${PYTHONPATH:+:$PYTHONPATH}"


### PR DESCRIPTION
### Motivation
- Ensure `t --init project` and `t --init --package` can reliably copy `AGENTS.md` and `T-LANGUAGE-REFERENCE.md` when T is installed via Nix by shipping the agent templates with the installed output and making them discoverable at runtime.

### Description
- Update `flake.nix` to install the repository `agents/` files into `$out/share/tlang/agents` and to export `TLANG_AGENTS_DIR` in the wrapped `t` executable so `src/package_manager/scaffold.ml` can find templates in packaged installs (change in `flake.nix`).

### Testing
- Attempted automated tests: `nix develop -c dune runtest tests/package_manager/test_agent_scaffold.exe` and `dune runtest tests/package_manager/test_agent_scaffold.exe`, but both could not run in this environment because `nix` and `dune` are unavailable, so no tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ac60635a08326ac5132e6cf85be56)