### PR TITLE
docs: add 'Your First Pipeline' quick-start tutorial

### DIFF
--- a/docs/first-pipeline.md
+++ b/docs/first-pipeline.md
@@ -1,0 +1,155 @@
+# Your First Pipeline
+
+> A quick, end-to-end tutorial for declaring R, Python, and Julia dependencies,
+> syncing the reproducible environment, and running a small polyglot pipeline.
+
+This guide assumes you have already completed the [Getting Started](getting-started.md)
+setup and are inside a T project created with `t init --project`.
+
+## 1. Enter the project environment
+
+From the project root, enter the reproducible development shell:
+
+```bash
+nix develop
+```
+
+All commands below should be run inside that shell. This ensures `t`, the
+project-specific runtimes, and the dependency guards are all on `PATH`.
+
+## 2. Declare runtime packages in `tproject.toml`
+
+T projects are explicit: R, Python, and Julia packages belong in
+`tproject.toml`, not in ad hoc `install.packages()`, `pip install`, or
+`Pkg.add()` calls. Open `tproject.toml` and make sure the runtime dependency
+sections contain the packages you plan to use:
+
+```toml
+[r-dependencies]
+packages = ["stringr"]
+
+[py-dependencies]
+version = "python313"
+packages = ["numpy"]
+
+[jl-dependencies]
+version = "lts"
+packages = ["DataFrames"]
+```
+
+A few rules of thumb:
+
+- Add R packages under `[r-dependencies].packages`.
+- Add Python packages under `[py-dependencies].packages` and keep the Python
+  version explicit.
+- Add Julia packages under `[jl-dependencies].packages`; `version = "lts"` is
+  the recommended default unless you need a specific Julia release.
+- If your project was scaffolded with empty lists already present, edit those
+  lists instead of creating duplicate sections.
+
+## 3. Sync the project after editing dependencies
+
+After changing `tproject.toml`, regenerate the project environment:
+
+```bash
+t update
+```
+
+Then re-enter the development shell so the updated package set is active:
+
+```bash
+exit
+nix develop
+```
+
+If T reports that a package used by a pipeline node is missing, add it to the
+matching dependency section, run `t update`, and enter `nix develop` again.
+
+## 4. Write a hello-world polyglot pipeline
+
+Replace `src/pipeline.t` with this small pipeline:
+
+```t
+p = pipeline {
+  r_hello = rn(
+    command = <{
+      library(stringr)
+      str_to_upper("hello from R")
+    }>,
+    serializer = ^text
+  )
+
+  python_hello = pyn(
+    command = <{
+import numpy as np
+f"hello from Python; numpy sum = {np.array([1, 2, 3]).sum()}"
+    }>,
+    serializer = ^text
+  )
+
+  julia_hello = jln(
+    command = <{
+      using DataFrames
+      df = DataFrame(language = ["Julia"], nodes = [1])
+      "hello from $(df.language[1]); rows = $(nrow(df))"
+    }>,
+    serializer = ^text
+  )
+}
+
+build_pipeline(p, verbose = 1)
+
+print(read_node(p.r_hello))
+print(read_node(p.python_hello))
+print(read_node(p.julia_hello))
+```
+
+This file defines three independent nodes:
+
+- `r_hello` runs in R via `rn()` and uses the declared `stringr` package.
+- `python_hello` runs in Python via `pyn()` and uses the declared `numpy`
+  package.
+- `julia_hello` runs in Julia via `jln()` and uses the declared `DataFrames`
+  package.
+
+Each node uses `serializer = ^text`, which is enough for a first hello-world
+pipeline because every node returns a string.
+
+## 5. Run the pipeline
+
+From the project root, run:
+
+```bash
+t run src/pipeline.t
+```
+
+T will materialize the pipeline under `_pipeline/`, build each node in a
+Nix-managed sandbox, and write a timestamped build log. The first run may take
+longer because Nix may need to fetch or build packages; later runs are cached.
+
+## 6. Inspect the result
+
+The final three lines in `src/pipeline.t` read the built artifacts back through
+T and print them:
+
+```t
+print(read_node(p.r_hello))
+print(read_node(p.python_hello))
+print(read_node(p.julia_hello))
+```
+
+Use `read_node(p.node_name)` when you want the value materialized for a specific
+pipeline node. You should see the text values produced by the three runtimes.
+
+## 7. What to read next
+
+Once this quick pipeline works, continue in this order:
+
+1. [Configure Editors](editors.md) — Set up syntax highlighting, LSP support,
+   and formatting conveniences.
+2. [Language Overview](language_overview.md) — Learn T expressions, data types,
+   functions, and pipes.
+3. [Pipeline Tutorial](pipeline_tutorial.md) — Go deeper into dependency graphs,
+   serializers, materialization, error handling, and larger DAGs.
+4. [Project Development](project_development.md) — Learn more about
+   `tproject.toml`, Nix environments, tests, and project structure.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -174,9 +174,10 @@ t run scripts/main.t
 
 ## Next Steps
 
-Now that you have your first project set up and understand the folder structure, you are ready to explore the language features and build reproducible data pipelines!
+Now that you have your first project set up and understand the folder structure, the best next step is to run a tiny reproducible pipeline before configuring editor integrations or reading the deeper reference material.
 
-1. **[Configure Editors](editors.md)** — Configure your editor to play well with T.
-2. **[Language Overview](language_overview.md)** — Explore T's syntax, types, and standard library functions.
-3. **[Pipeline Tutorial](pipeline_tutorial.md)** — Learn how to build reproducible, DAG-based data analysis workflows (the core feature of T).
-4. **[Project Development](project_development.md)** — Dive deeper into managing your `tproject.toml` and Nix environments.
+1. **[Your First Pipeline](first-pipeline.md)** — Add R, Python, and Julia packages to `tproject.toml`, run `t update`, and build a small hello-world polyglot pipeline.
+2. **[Configure Editors](editors.md)** — Configure your editor to play well with T.
+3. **[Language Overview](language_overview.md)** — Explore T's syntax, types, and standard library functions.
+4. **[Pipeline Tutorial](pipeline_tutorial.md)** — Learn how to build reproducible, DAG-based data analysis workflows (the core feature of T).
+5. **[Project Development](project_development.md)** — Dive deeper into managing your `tproject.toml` and Nix environments.

--- a/docs/index.md
+++ b/docs/index.md
@@ -161,6 +161,7 @@ resolution and deserialization from within those environments.
 
 ### Getting Started
 - [Getting Started Guide](getting-started.html) — first steps with T
+- [Your First Pipeline](first-pipeline.html) — declare R, Python, and Julia packages, run `t update`, and build a hello-world pipeline
 - [Installation Guide](installation.html) — detailed setup with Nix
 - [Language Overview](language_overview.html) — types, syntax, functions, and standard library
 - [Type System](type-system.html) — detailed guide to T's type hierarchy and semantics


### PR DESCRIPTION
### Motivation

- Provide a focused, runnable next-step for new users that shows how to declare R/Python/Julia packages in `tproject.toml`, run `t update`, and build a tiny polyglot pipeline so they can see a complete end-to-end cycle quickly.
- Surface this short tutorial earlier in the onboarding flow so users run a small reproducible pipeline before configuring editors or diving into deeper references.

### Description

- Add a new guide `docs/first-pipeline.md` that walks through `nix develop`, editing `tproject.toml` (`[r-dependencies]`, `[py-dependencies]`, `[jl-dependencies]`), running `t update`, creating a simple `src/pipeline.t` with `rn()`, `pyn()`, and `jln()` nodes, and building/reading the results with `build_pipeline`/`read_node`.
- Update `docs/getting-started.md` to recommend the new "Your First Pipeline" tutorial as the first follow-up step in the Next Steps section.
- Add the new tutorial to `docs/index.md` under the Getting Started section so it appears in the main docs index.
- All changes are documentation-only and do not change language/runtime behavior or source code.

### Testing

- Ran a lightweight Python readability check that verified `docs/getting-started.md`, `docs/index.md`, and `docs/first-pipeline.md` are present and non-empty, and it succeeded.
- Attempted to run `nix develop -c dune build` and `dune build` to validate the repository build but both were not executed because `nix`/`dune` are not available in the current environment; no runtime/tests were changed by this PR.
- Manual inspection of the generated docs files and diffs was performed to ensure links and the example pipeline snippet are syntactically consistent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20307e27f883268a16c1ab3bb585ce)