### PR TITLE
fix: narrow exception handling, robust regex splitting, and safe sorting in Arrow/table and helpers

### DIFF
--- a/src/arrow/arrow_table.ml
+++ b/src/arrow/arrow_table.ml
@@ -697,11 +697,11 @@ let materialize (t : t) : t =
           | Some ptr -> create_from_native ptr t.schema t.nrows
           | None -> t
         with
-        | Invalid_argument msg ->
-            Printf.eprintf "Warning: Native materialization failed (%s). Keeping OCaml representation.\n%!" msg;
-            t
-        | _ ->
-            Printf.eprintf "Warning: Native materialization failed due to unexpected exception. Keeping OCaml representation.\n%!";
+        | Out_of_memory | Stack_overflow as exn -> raise exn
+        | exn ->
+            Printf.eprintf
+              "Warning: Native materialization failed (%s). Keeping OCaml representation.\n%!"
+              (Printexc.to_string exn);
             t
 
 (** Prepare a table for transfer across processes (e.g. via Marshal).
@@ -933,13 +933,20 @@ let take_rows (t : t) (indices : int list) : t =
 
 (** Reorder rows by index array *)
 let sort_by_indices (t : t) (indices : int array) : t =
-  let valid_indices = Array.of_list (List.filter (fun idx -> idx >= 0 && idx < t.nrows) (Array.to_list indices)) in
+  let invalid_index = Array.find_opt (fun idx -> idx < 0 || idx >= t.nrows) indices in
+  match invalid_index with
+  | Some idx ->
+      Printf.eprintf
+        "Warning: sort_by_indices received out-of-bounds index %d for table with %d rows; leaving row order unchanged.\n%!"
+        idx t.nrows;
+      t
+  | None ->
   match t.native_handle with
   | Some handle when not handle.freed ->
-      (match Arrow_ffi.arrow_table_take handle.ptr valid_indices with
+      (match Arrow_ffi.arrow_table_take handle.ptr indices with
        | Some new_ptr ->
            let schema = schema_from_native_ptr new_ptr in
-           create_from_native new_ptr schema (Array.length valid_indices)
+           create_from_native new_ptr schema (Array.length indices)
        | None -> 
            (* Fallback: Materialize native columns if needed, then sort *)
            let source_columns =
@@ -949,32 +956,32 @@ let sort_by_indices (t : t) (indices : int array) : t =
                | None -> (n, NAColumn t.nrows)
              ) t.schema
            in
-           let n = Array.length valid_indices in
+           let n = Array.length indices in
            let sort_col = function
-             | IntColumn a -> IntColumn (Array.init n (fun i -> a.(valid_indices.(i))))
-             | FloatColumn a -> FloatColumn (Array.init n (fun i -> a.(valid_indices.(i))))
-             | BoolColumn a -> BoolColumn (Array.init n (fun i -> a.(valid_indices.(i))))
-             | StringColumn a -> StringColumn (Array.init n (fun i -> a.(valid_indices.(i))))
-             | DateColumn a -> DateColumn (Array.init n (fun i -> a.(valid_indices.(i))))
-             | DatetimeColumn (a, tz) -> DatetimeColumn (Array.init n (fun i -> a.(valid_indices.(i))), tz)
+             | IntColumn a -> IntColumn (Array.init n (fun i -> a.(indices.(i))))
+             | FloatColumn a -> FloatColumn (Array.init n (fun i -> a.(indices.(i))))
+             | BoolColumn a -> BoolColumn (Array.init n (fun i -> a.(indices.(i))))
+             | StringColumn a -> StringColumn (Array.init n (fun i -> a.(indices.(i))))
+             | DateColumn a -> DateColumn (Array.init n (fun i -> a.(indices.(i))))
+             | DatetimeColumn (a, tz) -> DatetimeColumn (Array.init n (fun i -> a.(indices.(i))), tz)
              | NAColumn _ -> NAColumn n
-             | DictionaryColumn (a, levels, ordered) -> DictionaryColumn (Array.init n (fun i -> a.(valid_indices.(i))), levels, ordered)
-             | ListColumn a -> ListColumn (Array.init n (fun i -> a.(valid_indices.(i))))
+             | DictionaryColumn (a, levels, ordered) -> DictionaryColumn (Array.init n (fun i -> a.(indices.(i))), levels, ordered)
+             | ListColumn a -> ListColumn (Array.init n (fun i -> a.(indices.(i))))
            in
            let columns = List.map (fun (name, col) -> (name, sort_col col)) source_columns in
            { schema = t.schema; columns; nrows = n; native_handle = None } |> materialize)
   | _ ->
-    let n = Array.length valid_indices in
+    let n = Array.length indices in
     let sort_col = function
-      | IntColumn a -> IntColumn (Array.init n (fun i -> a.(valid_indices.(i))))
-      | FloatColumn a -> FloatColumn (Array.init n (fun i -> a.(valid_indices.(i))))
-      | BoolColumn a -> BoolColumn (Array.init n (fun i -> a.(valid_indices.(i))))
-      | StringColumn a -> StringColumn (Array.init n (fun i -> a.(valid_indices.(i))))
-      | DateColumn a -> DateColumn (Array.init n (fun i -> a.(valid_indices.(i))))
-      | DatetimeColumn (a, tz) -> DatetimeColumn (Array.init n (fun i -> a.(valid_indices.(i))), tz)
+      | IntColumn a -> IntColumn (Array.init n (fun i -> a.(indices.(i))))
+      | FloatColumn a -> FloatColumn (Array.init n (fun i -> a.(indices.(i))))
+      | BoolColumn a -> BoolColumn (Array.init n (fun i -> a.(indices.(i))))
+      | StringColumn a -> StringColumn (Array.init n (fun i -> a.(indices.(i))))
+      | DateColumn a -> DateColumn (Array.init n (fun i -> a.(indices.(i))))
+      | DatetimeColumn (a, tz) -> DatetimeColumn (Array.init n (fun i -> a.(indices.(i))), tz)
       | NAColumn _ -> NAColumn n
-      | DictionaryColumn (a, levels, ordered) -> DictionaryColumn (Array.init n (fun i -> a.(valid_indices.(i))), levels, ordered)
-      | ListColumn a -> ListColumn (Array.init n (fun i -> a.(valid_indices.(i))))
+      | DictionaryColumn (a, levels, ordered) -> DictionaryColumn (Array.init n (fun i -> a.(indices.(i))), levels, ordered)
+      | ListColumn a -> ListColumn (Array.init n (fun i -> a.(indices.(i))))
     in
     let columns = List.map (fun (name, col) -> (name, sort_col col)) t.columns in
     { schema = t.schema; columns; nrows = n; native_handle = None } |> materialize

--- a/src/package_manager/test_discovery.ml
+++ b/src/package_manager/test_discovery.ml
@@ -94,8 +94,10 @@ let run_test_file (file : string) : test_result =
                       eval_imports new_env rest
                 in
                 eval_imports env program
-              with _ -> env (* Ignore errors in src for now, or maybe report? *)
-            with _ -> env
+              with
+              | Out_of_memory | Stack_overflow as exn -> raise exn
+              | _ -> env (* Ignore errors in src for now, or maybe report? *)
+            with Sys_error _ -> env
           end else env
         ) env entries
       end else env

--- a/src/packages/base/error_utils.ml
+++ b/src/packages/base/error_utils.ml
@@ -38,7 +38,9 @@ let find_logged_error node_name =
            match found with
            | Some res -> Some res
            | None -> find_in_logs tail
-         with _ -> find_in_logs tail)
+         with
+         | Out_of_memory | Stack_overflow as exn -> raise exn
+         | Sys_error _ | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> find_in_logs tail)
   in
   find_in_logs logs
 
@@ -90,7 +92,9 @@ let resolve_warning_val = function
                  let warns = Builder_read_node.parse_node_warnings warnings_path in
                  let warn_msgs = List.map (fun w -> w.nw_message) warns in
                  if warn_msgs <> [] then Some (String.concat "\n" warn_msgs) else None
-               with _ -> None
+               with
+               | Out_of_memory | Stack_overflow as exn -> raise exn
+               | Sys_error _ -> None
              ) else None
            else None)
   | _ -> None

--- a/src/packages/colcraft/separate.ml
+++ b/src/packages/colcraft/separate.ml
@@ -87,17 +87,25 @@ let register env =
                  | Error err -> err
                  | Ok sep_re ->
                      let n_into = List.length into_cols in
-                     let split_vals = Array.init orig_nrows (fun i ->
-                       match val_to_str values.(i) with
-                       | Some s ->
-                           let parts = Str.split sep_re s in
-                           let n_parts = List.length parts in
-                           if n_parts >= n_into then
-                             List.filteri (fun i _ -> i < n_into) parts
-                           else
-                             parts @ (List.init (n_into - n_parts) (fun _ -> ""))
-                       | None -> List.init n_into (fun _ -> "NA")
-                     ) in
+                     let split_vals_res =
+                       try
+                         Ok (Array.init orig_nrows (fun i ->
+                           match val_to_str values.(i) with
+                           | Some s ->
+                               let parts = Str.split sep_re s in
+                               let n_parts = List.length parts in
+                               if n_parts >= n_into then
+                                 List.filteri (fun i _ -> i < n_into) parts
+                               else
+                                 parts @ (List.init (n_into - n_parts) (fun _ -> ""))
+                           | None -> List.init n_into (fun _ -> "NA")
+                         ))
+                       with Failure msg ->
+                         Error (Error.value_error (Printf.sprintf "Function `separate` failed while splitting values: %s" msg))
+                     in
+                     (match split_vals_res with
+                      | Error err -> err
+                      | Ok split_vals ->
                      
                      (* Create new columns *)
                      let new_cols_data = List.mapi (fun i name ->
@@ -124,6 +132,6 @@ let register env =
                      let final_columns = List.rev !final_columns in
                      
                      let new_schema = List.map (fun (n, c) -> (n, Arrow_table.column_type_of c)) final_columns in
-                     VDataFrame { arrow_table = { schema = new_schema; columns = final_columns; nrows = orig_nrows; native_handle = None } |> Arrow_table.materialize; group_keys = df.group_keys })
+                     VDataFrame { arrow_table = { schema = new_schema; columns = final_columns; nrows = orig_nrows; native_handle = None } |> Arrow_table.materialize; group_keys = df.group_keys }))
     ))
     env

--- a/src/packages/colcraft/separate_rows.ml
+++ b/src/packages/colcraft/separate_rows.ml
@@ -22,10 +22,18 @@ let separate_rows_impl (named_args : (string option * value) list) _env =
                (match re_res with
                 | Error err -> err
                 | Ok re ->
-                    let tokens = Array.map (function 
-                      | Some s -> Str.split re s
-                      | None -> [""]
-                    ) data in
+                    let tokens_res =
+                      try
+                        Ok (Array.map (function 
+                          | Some s -> Str.split re s
+                          | None -> [""]
+                        ) data)
+                      with Failure msg ->
+                        Error (Error.value_error (Printf.sprintf "Function `separate_rows` failed while splitting values: %s" msg))
+                    in
+                    (match tokens_res with
+                     | Error err -> err
+                     | Ok tokens ->
                     
                     let final_nrows = Array.fold_left (fun acc t -> acc + List.length t) 0 tokens in
                     
@@ -49,7 +57,7 @@ let separate_rows_impl (named_args : (string option * value) list) _env =
                         | None -> (name, Arrow_table.NAColumn final_nrows)
                     ) df.arrow_table.schema in
                     
-                    VDataFrame { df with arrow_table = { df.arrow_table with columns = new_columns; nrows = final_nrows; native_handle = None } })
+                    VDataFrame { df with arrow_table = { df.arrow_table with columns = new_columns; nrows = final_nrows; native_handle = None } }))
            | _ -> Error.type_error (Printf.sprintf "Column `%s` is not a String column." col_name))
   | _ :: _ -> Error.type_error "Function `separate_rows` expects a DataFrame as first argument."
   | [] -> Error.make_error ArityError "Function `separate_rows` requires a DataFrame."

--- a/src/packages/core/show_plot.ml
+++ b/src/packages/core/show_plot.ml
@@ -180,9 +180,9 @@ let open_rendered_plot viewer path =
                   | _ -> Printexc.to_string exn
                 in
                 let msg = Bytes.of_string err_msg in
-                (try ignore (Unix.write write_fd msg 0 (Bytes.length msg)) with _ -> ());
-                (try Unix.close write_fd with _ -> ());
-                (try Unix.close devnull with _ -> ());
+                (try ignore (Unix.write write_fd msg 0 (Bytes.length msg)) with Unix.Unix_error _ -> ());
+                (try Unix.close write_fd with Unix.Unix_error _ -> ());
+                (try Unix.close devnull with Unix.Unix_error _ -> ());
                 Stdlib.exit 1)
          | fork_pid ->
              Unix.close write_fd;

--- a/src/packages/dataframe/t_read_csv.ml
+++ b/src/packages/dataframe/t_read_csv.ml
@@ -218,7 +218,7 @@ let register env =
                   match Arrow_io.download_url path with
                   | Ok temp_path ->
                       let c = read_content_from_path temp_path in
-                      (try Sys.remove temp_path with _ -> ());
+                      (try Sys.remove temp_path with Sys_error _ -> ());
                       c
                   | Error msg -> failwith msg
                 else

--- a/src/packages/math/signif.ml
+++ b/src/packages/math/signif.ml
@@ -18,7 +18,7 @@ let register env =
     (* signif needs a local helper because the transformation depends on the
        caller-supplied number of significant digits. *)
     let signif_f x digits =
-      if Float.abs x < 1e-15 then 0.0
+      if Float.equal x 0.0 then 0.0
       else
         let d = float_of_int digits in
         let scale = Float.pow 10.0 (d -. 1.0 -. Float.floor (Float.log10 (Float.abs x))) in
@@ -32,9 +32,9 @@ let register env =
         | [x; VInt digits] when digits > 0 ->
             Math_common.map_numeric_unary ~fname:"signif" ~na_ignore (fun v -> signif_f v digits) [x]
         | [_; VInt _] -> Error.value_error "Function `signif` expects positive integer digits."
-        | [x; VFloat d] when d > 0.0 ->
+        | [x; VFloat d] when d > 0.0 && Float.is_finite d ->
             let digits = int_of_float d in
-            if Float.abs (float_of_int digits -. d) < 1e-9 && digits > 0 then
+            if Float.equal (float_of_int digits) d && digits > 0 then
               Math_common.map_numeric_unary ~fname:"signif" ~na_ignore (fun v -> signif_f v digits) [x]
             else
               Error.value_error "Function `signif` expects positive integer digits."


### PR DESCRIPTION
### Motivation
- Harden FFI and IO boundaries so catastrophic exceptions are not silently swallowed while preserving benign fallbacks.  
- Prevent silent data corruption/truncation when invalid sort indices are provided.  
- Convert runtime regex split failures into structured `ValueError`s instead of allowing exceptions to escape.  
- Eliminate broad catch-alls in a few housekeeping places and restore precise float checks in `signif` to avoid semantic drift.

### Description
- Arrow materialization: re-raise `Out_of_memory` and `Stack_overflow` and log other exceptions with `Printexc.to_string` instead of a catch-all that swallowed everything. (src/arrow/arrow_table.ml)  
- sort_by_indices: detect out-of-bounds indices up-front, warn and return the original table rather than silently dropping indices, and remove the inefficient array→list→array round-trip; native and fallback paths now use the original `indices` array. (src/arrow/arrow_table.ml)  
- Regex splitting: wrap `Str.split` calls in `separate` and `separate_rows` in `try/with Failure` and return structured `ValueError`s on split-time failures. (src/packages/colcraft/separate.ml, src/packages/colcraft/separate_rows.ml)  
- Test discovery/source preloading: narrow catch-alls so `Sys_error` is used for file I/O failures and dangerous runtime exceptions are re-raised. (src/package_manager/test_discovery.ml)  
- Logged-warnings parsing: narrow JSON / IO catch clauses to expected exceptions and re-raise fatal runtime exceptions. (src/packages/base/error_utils.ml)  
- Child-process cleanup and temp-file removal: replace catch-all `with _ ->` with `Unix.Unix_error` and `Sys_error` where appropriate. (src/packages/core/show_plot.ml, src/packages/dataframe/t_read_csv.ml)  
- signif: restore precise semantics by using `Float.equal x 0.0` for zero check, require `Float.is_finite` on float `digits` input, and use `Float.equal` for the integer-equality test to avoid unintentional epsilon-based behavior. (src/packages/math/signif.ml)

Files changed: src/arrow/arrow_table.ml; src/package_manager/test_discovery.ml; src/packages/base/error_utils.ml; src/packages/colcraft/separate.ml; src/packages/colcraft/separate_rows.ml; src/packages/core/show_plot.ml; src/packages/dataframe/t_read_csv.ml; src/packages/math/signif.ml.

### Testing
- Attempted `nix develop --command dune build` but `nix` is not available in this environment, so the build was not executed.  
- Attempted `dune build` directly but `dune` is not installed in this environment, so the build was not executed.  
- Attempted `make golden-quick` but it failed due to the missing build artifacts/tools (`dune` / `./result/bin/t`), so golden tests were not executed.  
- No automated tests were run in this environment; changes were kept small and focused on exception handling and local logic to minimize behavioral risk, but please run `nix develop && dune build && dune runtest && make golden-quick` in CI or a developer shell before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a227642710c8326886136703e06e6b7)