### PR TITLE
feat(top): seed live pipeline monitor with cache status

### DIFF
--- a/docs/pipeline_tutorial.md
+++ b/docs/pipeline_tutorial.md
@@ -2187,9 +2187,10 @@ t top run my_pipeline.t
 This command:
 1. **Evaluates** your `.t` file to extract the `VPipeline` value.
 2. **Forks** a child process that runs `populate_pipeline(p, build = true)`.
-3. **Monitors** the build in real-time via a JSON status file written by the build engine.
-4. **Renders** a live-updating TUI table showing every node's status, duration, runtime, and dependencies.
-5. **Exits** when the build completes and waits for you to press `q`.
+3. **Seeds** the monitor from Nix dry-run information so the interface appears before the real build starts, with nodes marked as cached, fetching, or pending rebuild work.
+4. **Monitors** the build in real-time via a JSON status file written by the build engine.
+5. **Renders** a live-updating fixed-width TUI table showing every node's status, duration, runtime, and dependencies, trimming long names and dependency lists for readability.
+6. **Exits** when the build completes and waits for you to press `q`.
 
 ### Live TUI Display
 
@@ -2198,19 +2199,19 @@ While the build is running, the terminal shows:
 ```
 ┌── T Pipeline Monitor 14:30:22 ──────────────────────────────────────────────┐
 │ Total: 5    │ Built: 2      │ Building: 1   │ Errored: 0   │ Warnings: 0   │
-├──────────────┬──────────┬──────────┬───────────┬────────────────────┤
-│ Node         │ Status   │ Duration │ Runtime   │ Dependencies       │
-├──────────────┼──────────┼──────────┼───────────┼────────────────────┤
-│ raw_data     │ ✓ Completed │ 2.3s     │ T         │ —                  │
-│ clean        │ ✓ Completed │ 1.1s     │ T         │ raw_data           │
-│ model        │ ⟳ Building  │ 5.7s     │ R         │ clean              │
-│ predictions  │ · Pending   │ —        │ T         │ model,clean        │
-│ report       │ · Pending   │ —        │ T         │ predictions        │
-└──────────────┴──────────┴──────────┴───────────┴────────────────────┘
+├────────────────────┬────────────────┬──────────┬──────────┬────────────────────────┤
+│ Node               │ Status         │ Duration │ Runtime  │ Dependencies           │
+├────────────────────┼────────────────┼──────────┼──────────┼────────────────────────┤
+│ raw_data           │ ✓ Cached       │        — │ T        │ —                      │
+│ clean              │ ✓ Completed    │     1.1s │ T        │ raw_data               │
+│ model              │ ⟳ Building     │     5.7s │ R        │ clean                  │
+│ predictions        │ · Pending      │        — │ T        │ model,clean            │
+│ report             │ · Pending      │        — │ T        │ predictions            │
+└────────────────────┴────────────────┴──────────┴──────────┴────────────────────────┘
 Monitoring (Ctrl-C to quit)
 ```
 
-The display updates every second. Completed nodes are shown in **green**, building nodes in **cyan**, errored nodes in **red**, and pending nodes in **gray**.
+The display updates every second. Completed and cached nodes are shown in **green**, building and fetching nodes in **cyan**, errored nodes in **red**, and pending nodes in **gray**. Long node names, runtimes, and dependency lists are clipped to keep the table columns stable while the build streams.
 
 ### How It Works
 
@@ -2218,8 +2219,9 @@ The display updates every second. Completed nodes are shown in **green**, buildi
 
 1. The parent process forks, spawning a child that runs `populate_pipeline(p, build = true)` with a `~status_file` argument pointing to `_pipeline/build_status.json`.
 2. The child redirects stdout/stderr to `/dev/null`, evaluates the `.t` file, extracts the pipeline, and runs the build.
-3. After each node status transition (Pending → Building → Completed/Errored), the build engine writes an atomic JSON status file via a temp-file + rename strategy.
-4. The parent polls this file every second, parses the JSON, and re-renders the TUI.
+3. Before the real build starts, the build engine runs a Nix dry-run for the same targets and writes an initial atomic JSON status file with `Cached`, `Fetching`, or `Pending` statuses.
+4. After each node status transition (Pending/Fetching → Building → Completed/Errored), the build engine writes an atomic JSON status file via a temp-file + rename strategy.
+5. The parent polls this file every second, parses the JSON, and re-renders the TUI.
 
 ### Status File Format
 

--- a/src/cmd_top.ml
+++ b/src/cmd_top.ml
@@ -101,15 +101,34 @@ let read_status_file path =
 let node_color = function
   | "Completed" -> ansi_green
   | "Completed with warning" -> ansi_yellow
+  | "Cached" -> ansi_green
+  | "Fetching" -> ansi_cyan
   | "Building" -> ansi_cyan
   | "Pending" -> ansi_gray
   | "Errored" -> ansi_red
   | "SoftFailed" -> ansi_yellow
   | _ -> ansi_reset
 
+
+let ellipsize width s =
+  if width <= 0 then ""
+  else if String.length s <= width then s
+  else if width = 1 then "…"
+  else String.sub s 0 (width - 1) ^ "…"
+
+let pad_right width s =
+  let clipped = ellipsize width s in
+  clipped ^ String.make (max 0 (width - String.length clipped)) ' '
+
+let pad_left width s =
+  let clipped = ellipsize width s in
+  String.make (max 0 (width - String.length clipped)) ' ' ^ clipped
+
 let node_icon = function
   | "Completed" -> "✓"
   | "Completed with warning" -> "⚠"
+  | "Cached" -> "✓"
+  | "Fetching" -> "⇣"
   | "Building" -> "⟳"
   | "Pending" -> "·"
   | "Errored" -> "✗"
@@ -135,28 +154,28 @@ let render_tui data =
     ansi_red data.sd_errored ansi_reset
     ansi_yellow data.sd_soft_failed ansi_reset;
 
-  Buffer.add_string buf "├──────────────┬──────────┬──────────┬───────────┬────────────────────┤\n";
-  Buffer.add_string buf "│ Node         │ Status   │ Duration │ Runtime   │ Dependencies       │\n";
-  Buffer.add_string buf "├──────────────┼──────────┼──────────┼───────────┼────────────────────┤\n";
+  Buffer.add_string buf "├────────────────────┬────────────────┬──────────┬──────────┬────────────────────────┤\n";
+  Buffer.add_string buf "│ Node               │ Status         │ Duration │ Runtime  │ Dependencies           │\n";
+  Buffer.add_string buf "├────────────────────┼────────────────┼──────────┼──────────┼────────────────────────┤\n";
 
   List.iter (fun (name, status, duration, runtime, deps) ->
     let color = node_color status in
     let icon = node_icon status in
-    let display_status = Printf.sprintf "%s %s" icon status in
-    let name_trunc =
-      if String.length name > 12 then String.sub name 0 10 ^ ".."
-      else name
-    in
+    let display_status = pad_right 14 (Printf.sprintf "%s %s" icon status) in
+    let name_cell = pad_right 18 name in
     let duration_str =
       if duration > 0.0 then Printf.sprintf "%.1fs" duration
       else "—"
     in
+    let duration_cell = pad_left 8 duration_str in
+    let runtime_cell = pad_right 8 runtime in
     let deps_str = match deps with [] -> "—" | d -> String.concat "," d in
-    Printf.ksprintf (Buffer.add_string buf) "│ %-12s │ %s%-8s%s │ %8s │ %-9s │ %-18s │\n"
-      name_trunc color display_status ansi_reset duration_str runtime deps_str
+    let deps_cell = pad_right 22 deps_str in
+    Printf.ksprintf (Buffer.add_string buf) "│ %s │ %s%s%s │ %s │ %s │ %s │\n"
+      name_cell color display_status ansi_reset duration_cell runtime_cell deps_cell
   ) data.sd_nodes;
 
-  Buffer.add_string buf "└──────────────┴──────────┴──────────┴───────────┴────────────────────┘\n";
+  Buffer.add_string buf "└────────────────────┴────────────────┴──────────┴──────────┴────────────────────────┘\n";
 
   if not data.sd_done then begin
     Buffer.add_string buf ansi_gray;

--- a/src/pipeline/builder_internal.ml
+++ b/src/pipeline/builder_internal.ml
@@ -95,9 +95,9 @@ let write_build_status_file ?pipeline_name ?(done_=false) status_file_path p sta
     let soft_failed = ref 0 in
     let node_entries = List.map (fun name ->
       let status = match Hashtbl.find_opt statuses name with Some s -> s | None -> "Pending" in
-      if status = "Completed" then incr built
+      if status = "Completed" || status = "Cached" then incr built
       else if status = "Errored" then incr errored
-      else if status = "Building" then incr building
+      else if status = "Building" || status = "Fetching" then incr building
       else if status = "SoftFailed" then incr soft_failed;
       let duration = match Hashtbl.find_opt durations name with Some d -> d | None -> 0.0 in
       let runtime = match List.assoc_opt name p.p_runtimes with Some r -> r | None -> "T" in
@@ -408,6 +408,50 @@ let build_pipeline_internal ?verbose ?pipeline_name ?status_file ?(nix_options :
       let node_durations = Hashtbl.create (List.length node_names) in
       let node_was_built = Hashtbl.create (List.length node_names) in
       let started_building = ref false in
+
+      let seed_statuses_from_dry_run () =
+        let lines = ref [] in
+        let collect line = lines := line :: !lines in
+        let dry_args = ["--dry-run"] @ all_args in
+        let dry_argv = Array.of_list (["nix-build"; "--impure"; pipeline_nix_path] @ target_args @ ["--no-out-link"] @ dry_args) in
+        match run_command_stream_argv dry_argv collect with
+        | Error _ -> ()
+        | Ok status ->
+            let exit_code =
+              match status with
+              | Unix.WEXITED n -> n
+              | Unix.WSIGNALED n | Unix.WSTOPPED n -> n
+            in
+            if exit_code = 0 then begin
+              let dry_builds = Hashtbl.create (List.length node_names) in
+              let dry_fetches = Hashtbl.create (List.length node_names) in
+              let current_action = ref "build" in
+              List.iter (fun line ->
+                let trimmed = String.trim line in
+                if contains_substring trimmed "will be built:" then
+                  current_action := "build"
+                else if contains_substring trimmed "will be fetched" then
+                  current_action := "fetch"
+                else if String.starts_with ~prefix:"/nix/store/" trimmed then
+                  match List.find_opt (fun name -> contains_substring trimmed ("-" ^ name ^ ".drv") || contains_substring trimmed ("-" ^ name)) sorted_node_names with
+                  | Some name ->
+                      if !current_action = "fetch" then Hashtbl.replace dry_fetches name true
+                      else Hashtbl.replace dry_builds name true
+                  | None -> ()
+              ) (List.rev !lines);
+              List.iter (fun name ->
+                if Hashtbl.mem dry_fetches name then Hashtbl.replace statuses name "Fetching"
+                else if Hashtbl.mem dry_builds name then Hashtbl.replace statuses name "Pending"
+                else Hashtbl.replace statuses name "Cached"
+              ) node_names
+            end
+      in
+      (match status_file with
+       | Some sf ->
+           write_build_status_file ?pipeline_name sf p statuses node_durations;
+           seed_statuses_from_dry_run ();
+           write_build_status_file ?pipeline_name sf p statuses node_durations
+       | None -> ());
       
       let callback line =
         Buffer.add_string captured_output line;
@@ -437,7 +481,7 @@ let build_pipeline_internal ?verbose ?pipeline_name ?status_file ?(nix_options :
               in
               if drv_path <> "" then Hashtbl.replace drv_paths name drv_path;
 
-              if Hashtbl.find statuses name = "Pending" then (
+              if Hashtbl.find statuses name = "Pending" || Hashtbl.find statuses name = "Fetching" then (
                 Hashtbl.replace statuses name "Building";
                 Printf.eprintf "  + %s building\n%!" name;
                 (match status_file with

--- a/summary.md
+++ b/summary.md
@@ -210,6 +210,7 @@ T supports higher-order composition of pipelines:
   }
   ```
 - **Automatic Namespacing & Flattening**: Sub-pipeline node names are automatically namespaced (e.g. `etl.raw_data`, `stats.summary`) and meta-pipelines are flattened transparently on access — `meta_flatten` is an internal implementation detail, not a user-facing function.
+- **Live Pipeline Monitoring**: `t top run <file.t>` opens an immediate fixed-width terminal monitor seeded from Nix dry-run cache status (`Cached`, `Fetching`, `Pending`) before streaming real-time build updates.
 - **Pipeline Visualization**: `pipeline_to_dot(p, title = na())` and `pipeline_to_mermaid(p, title = na(), flatten = false)` generate Graphviz DOT and Mermaid flowchart representations of any pipeline or meta-pipeline topology. Meta-pipeline sub-pipelines render as grouped subgraph blocks by default (`flatten = true` for flat output). `show_plot(p)` renders the DAG as an interactive browser visualization using the Mermaid output.
 - **Lambda Parameters**: Pipelines can be parameterized using standard lambda functions: `\(input) pipeline { ... }`. Outer variables referenced inside the pipeline nodes are automatically substituted with their concrete values during compilation.
 


### PR DESCRIPTION
### Motivation
- The `t top` TUI only populated after the build produced first outputs, so users lacked an immediate overview of which nodes were cached or would be fetched; the monitor should appear immediately and surface cache/dry-run info.
- Long node names and dependency lists made the live table jumpy and hard to read; the TUI needs fixed-width columns and clipped cells for stable, visually-appealing output.

### Description
- Seed the live monitor from a Nix dry-run by parsing `nix-build --dry-run` output and marking nodes as `Cached`, `Fetching`, or `Pending` before the real build starts, and write the seeded JSON status to the status file (changes in `src/pipeline/builder_internal.ml`).
- Treat `Cached` nodes as built and `Fetching` nodes as active in summary counts, and allow `Fetching` to transition to `Building` when the real build log indicates the node is being built (changes in `src/pipeline/builder_internal.ml`).
- Add `Cached`/`Fetching` color/icon mappings and introduce `ellipsize`, `pad_right`, and `pad_left` helpers, and rework the TUI into a fixed-width table that trims/pads node, status, duration, runtime, and dependency cells for consistent layout (changes in `src/cmd_top.ml`).
- Update documentation and repository summary to describe the seeded cache-aware monitor and the fixed-width display (changes in `docs/pipeline_tutorial.md` and `summary.md`).

### Testing
- Ran `git diff --check` which reported no whitespace or diff-check issues and passed.
- Attempted `dune build` in this environment but it could not run because `dune` is not available here (failure due to missing tool, not the code change).
- Attempted `nix develop -c dune build` but it could not run because `nix` is not available in this environment (failure due to missing tool, not the code change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a313de24bd483269ecf58e098a93efc)