### PR TITLE
feat(pipeline): lazy branch expansion, node name validation, branch-a…

### DIFF
--- a/agents/t-reference-huge.md
+++ b/agents/t-reference-huge.md
@@ -6544,7 +6544,45 @@ The output file contains the full `pipeline { ... }` definition with all branche
 
 `populate_pipeline()`, `build_pipeline()`, `chain()`, `parallel()`, `union()`, `intersect()`, `difference()`, and `patch()` all automatically expand any unexpanded patterns in their pipeline inputs before proceeding. You only need to call `expand_pipeline()` explicitly when you want to inspect the branch structure before building.
 
-### 11.8 Complete Example: Polyglot Dynamic Branching Pipeline
+### 11.8 Lazy Branch Access
+
+Even before calling `expand_pipeline()`, you can inspect and interact with the branch structure of a patterned pipeline directly:
+
+**List branch names** with `pipeline_nodes(p)`:
+
+```t
+p = pipeline {
+  a = [10, 20, 30]
+  b = map_pattern(a) ~> a * 2
+}
+pipeline_nodes(p)
+-- Result: ["a", "b_branch_1", "b_branch_2", "b_branch_3"]
+```
+
+**Inspect branch structure** with `inspect_pipeline(p)`:
+
+```t
+inspect_pipeline(p)
+-- DataFrame with one row per branch, including auto-generated branch names
+```
+
+**Access a branch by name** with dot notation — `p.b_branch_1` lazily synthesizes a `VComputedNode` without triggering expansion:
+
+```t
+b1 = p.b_branch_1
+-- b1 is a computed node that will be resolved when built
+```
+
+**Helpful error on the parent node**: if you try `read_node(p.b)` on a patterned node before building, instead of a generic "not built yet" error you get a message listing the available branches:
+
+```
+Error(ValueError): Node `b` has a pattern and expands into b_branch_1, b_branch_2, b_branch_3.
+  Use read_node(p.<branch_name>) to access individual branches directly.
+```
+
+**Reserved naming**: node names ending in `_branch_N` (e.g. `x_branch_1`) are reserved for auto-generated branch nodes. Using such a name at pipeline construction produces a `NameError`.
+
+### 11.9 Complete Example: Polyglot Dynamic Branching Pipeline
 
 This demo (from `t_demos/dynamic_branching_t`) combines `cross_pattern`, `map_pattern`, and cross-runtime (T ↔ R) serialization into a single end-to-end pipeline. It generates spirograph data points in T and plots them with R `ggplot2` — one plot per parameter combination.
 

--- a/docs/advanced-pipeline-tutorial.html
+++ b/docs/advanced-pipeline-tutorial.html
@@ -1779,7 +1779,38 @@ Auto-Expand</h3>
 their pipeline inputs before proceeding. You only need to call
 <code>expand_pipeline()</code> explicitly when you want to inspect the
 branch structure before building.</p>
-<h3 id="complete-example-polyglot-dynamic-branching-pipeline">11.8
+<h3 id="lazy-branch-access">11.8 Lazy Branch Access</h3>
+<p>Even before calling <code>expand_pipeline()</code>, you can inspect
+and interact with the branch structure of a patterned pipeline
+directly:</p>
+<p><strong>List branch names</strong> with
+<code>pipeline_nodes(p)</code>:</p>
+<pre class="t"><code>p = pipeline {
+  a = [10, 20, 30]
+  b = map_pattern(a) ~&gt; a * 2
+}
+pipeline_nodes(p)
+-- Result: [&quot;a&quot;, &quot;b_branch_1&quot;, &quot;b_branch_2&quot;, &quot;b_branch_3&quot;]</code></pre>
+<p><strong>Inspect branch structure</strong> with
+<code>inspect_pipeline(p)</code>:</p>
+<pre class="t"><code>inspect_pipeline(p)
+-- DataFrame with one row per branch, including auto-generated branch names</code></pre>
+<p><strong>Access a branch by name</strong> with dot notation —
+<code>p.b_branch_1</code> lazily synthesizes a
+<code>VComputedNode</code> without triggering expansion:</p>
+<pre class="t"><code>b1 = p.b_branch_1
+-- b1 is a computed node that will be resolved when built</code></pre>
+<p><strong>Helpful error on the parent node</strong>: if you try
+<code>read_node(p.b)</code> on a patterned node before building, instead
+of a generic “not built yet” error you get a message listing the
+available branches:</p>
+<pre><code>Error(ValueError): Node `b` has a pattern and expands into b_branch_1, b_branch_2, b_branch_3.
+  Use read_node(p.&lt;branch_name&gt;) to access individual branches directly.</code></pre>
+<p><strong>Reserved naming</strong>: node names ending in
+<code>_branch_N</code> (e.g. <code>x_branch_1</code>) are reserved for
+auto-generated branch nodes. Using such a name at pipeline construction
+produces a <code>NameError</code>.</p>
+<h3 id="complete-example-polyglot-dynamic-branching-pipeline">11.9
 Complete Example: Polyglot Dynamic Branching Pipeline</h3>
 <p>This demo (from <code>t_demos/dynamic_branching_t</code>) combines
 <code>cross_pattern</code>, <code>map_pattern</code>, and cross-runtime
@@ -1854,17 +1885,17 @@ spirograph function called by each data branch:</p>
 }</code></pre>
 <p><strong><code>src/spirograph.R</code></strong> — renders a faceted
 ggplot for one parameter combination:</p>
-<div class="sourceCode" id="cb82"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb82-1"><a href="#cb82-1" aria-hidden="true" tabindex="-1"></a><span class="fu">library</span>(ggplot2)</span>
-<span id="cb82-2"><a href="#cb82-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb82-3"><a href="#cb82-3" aria-hidden="true" tabindex="-1"></a>plot_spirographs <span class="ot">&lt;-</span> <span class="cf">function</span>(points) {</span>
-<span id="cb82-4"><a href="#cb82-4" aria-hidden="true" tabindex="-1"></a>  label <span class="ot">&lt;-</span> <span class="st">&quot;fixed_radius = %s, cycling_radius = %s&quot;</span></span>
-<span id="cb82-5"><a href="#cb82-5" aria-hidden="true" tabindex="-1"></a>  points<span class="sc">$</span>parameters <span class="ot">&lt;-</span> <span class="fu">sprintf</span>(label, points<span class="sc">$</span>fixed_radius, points<span class="sc">$</span>cycling_radius)</span>
-<span id="cb82-6"><a href="#cb82-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">ggplot</span>(points) <span class="sc">+</span></span>
-<span id="cb82-7"><a href="#cb82-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">geom_point</span>(<span class="fu">aes</span>(<span class="at">x =</span> x, <span class="at">y =</span> y, <span class="at">color =</span> parameters), <span class="at">size =</span> <span class="fl">0.1</span>) <span class="sc">+</span></span>
-<span id="cb82-8"><a href="#cb82-8" aria-hidden="true" tabindex="-1"></a>    <span class="fu">facet_wrap</span>(<span class="sc">~</span>parameters) <span class="sc">+</span></span>
-<span id="cb82-9"><a href="#cb82-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">theme_gray</span>(<span class="dv">16</span>) <span class="sc">+</span></span>
-<span id="cb82-10"><a href="#cb82-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">guides</span>(<span class="at">color =</span> <span class="st">&quot;none&quot;</span>)</span>
-<span id="cb82-11"><a href="#cb82-11" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb86"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb86-1"><a href="#cb86-1" aria-hidden="true" tabindex="-1"></a><span class="fu">library</span>(ggplot2)</span>
+<span id="cb86-2"><a href="#cb86-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb86-3"><a href="#cb86-3" aria-hidden="true" tabindex="-1"></a>plot_spirographs <span class="ot">&lt;-</span> <span class="cf">function</span>(points) {</span>
+<span id="cb86-4"><a href="#cb86-4" aria-hidden="true" tabindex="-1"></a>  label <span class="ot">&lt;-</span> <span class="st">&quot;fixed_radius = %s, cycling_radius = %s&quot;</span></span>
+<span id="cb86-5"><a href="#cb86-5" aria-hidden="true" tabindex="-1"></a>  points<span class="sc">$</span>parameters <span class="ot">&lt;-</span> <span class="fu">sprintf</span>(label, points<span class="sc">$</span>fixed_radius, points<span class="sc">$</span>cycling_radius)</span>
+<span id="cb86-6"><a href="#cb86-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">ggplot</span>(points) <span class="sc">+</span></span>
+<span id="cb86-7"><a href="#cb86-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">geom_point</span>(<span class="fu">aes</span>(<span class="at">x =</span> x, <span class="at">y =</span> y, <span class="at">color =</span> parameters), <span class="at">size =</span> <span class="fl">0.1</span>) <span class="sc">+</span></span>
+<span id="cb86-8"><a href="#cb86-8" aria-hidden="true" tabindex="-1"></a>    <span class="fu">facet_wrap</span>(<span class="sc">~</span>parameters) <span class="sc">+</span></span>
+<span id="cb86-9"><a href="#cb86-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">theme_gray</span>(<span class="dv">16</span>) <span class="sc">+</span></span>
+<span id="cb86-10"><a href="#cb86-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">guides</span>(<span class="at">color =</span> <span class="st">&quot;none&quot;</span>)</span>
+<span id="cb86-11"><a href="#cb86-11" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <p>Note the <code>functions = ["src/spirograph.R"]</code> argument on
 the R node — this propagates the script into the Nix sandbox so it is
 available at build time.</p>

--- a/docs/advanced-pipeline-tutorial.md
+++ b/docs/advanced-pipeline-tutorial.md
@@ -1561,7 +1561,45 @@ The output file contains the full `pipeline { ... }` definition with all branche
 
 `populate_pipeline()`, `build_pipeline()`, `chain()`, `parallel()`, `union()`, `intersect()`, `difference()`, and `patch()` all automatically expand any unexpanded patterns in their pipeline inputs before proceeding. You only need to call `expand_pipeline()` explicitly when you want to inspect the branch structure before building.
 
-### 11.8 Complete Example: Polyglot Dynamic Branching Pipeline
+### 11.8 Lazy Branch Access
+
+Even before calling `expand_pipeline()`, you can inspect and interact with the branch structure of a patterned pipeline directly:
+
+**List branch names** with `pipeline_nodes(p)`:
+
+```t
+p = pipeline {
+  a = [10, 20, 30]
+  b = map_pattern(a) ~> a * 2
+}
+pipeline_nodes(p)
+-- Result: ["a", "b_branch_1", "b_branch_2", "b_branch_3"]
+```
+
+**Inspect branch structure** with `inspect_pipeline(p)`:
+
+```t
+inspect_pipeline(p)
+-- DataFrame with one row per branch, including auto-generated branch names
+```
+
+**Access a branch by name** with dot notation — `p.b_branch_1` lazily synthesizes a `VComputedNode` without triggering expansion:
+
+```t
+b1 = p.b_branch_1
+-- b1 is a computed node that will be resolved when built
+```
+
+**Helpful error on the parent node**: if you try `read_node(p.b)` on a patterned node before building, instead of a generic "not built yet" error you get a message listing the available branches:
+
+```
+Error(ValueError): Node `b` has a pattern and expands into b_branch_1, b_branch_2, b_branch_3.
+  Use read_node(p.<branch_name>) to access individual branches directly.
+```
+
+**Reserved naming**: node names ending in `_branch_N` (e.g. `x_branch_1`) are reserved for auto-generated branch nodes. Using such a name at pipeline construction produces a `NameError`.
+
+### 11.9 Complete Example: Polyglot Dynamic Branching Pipeline
 
 This demo (from `t_demos/dynamic_branching_t`) combines `cross_pattern`, `map_pattern`, and cross-runtime (T ↔ R) serialization into a single end-to-end pipeline. It generates spirograph data points in T and plots them with R `ggplot2` — one plot per parameter combination.
 

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -2526,7 +2526,18 @@ and try_lazy_expand_branch (p : Ast.pipeline_result) (env : value Env.t) (field 
                           validate_deps deps (branch_num - 1)
                       | _ -> None)
                  | _ -> None)
-            | Ast.PatternCross _ -> None
+            | Ast.PatternCross subs ->
+                let sub_lengths = List.filter_map (fun sub ->
+                  match sub with
+                  | Ast.PatternMap deps ->
+                      let lens = List.filter_map eval_dep_len deps in
+                      (match lens with [] -> None | _ -> Some (List.fold_left min max_int lens))
+                  | _ -> None
+                ) subs in
+                if List.length sub_lengths <> List.length subs then None
+                else
+                  let total = List.fold_left ( * ) 1 sub_lengths in
+                  if branch_num <= total then mk_cn orig_name else None
             | Ast.PatternSlice (dep, indices) ->
                 if branch_num <= List.length indices then
                   validate_deps [dep] (List.nth indices (branch_num - 1))
@@ -2572,7 +2583,16 @@ and pattern_branch_names_for_error p field pattern =
         (match deps with
          | [dep] -> eval_dep_len dep
          | _ -> None)
-    | Ast.PatternCross _ -> None
+    | Ast.PatternCross subs ->
+        let sub_lengths = List.filter_map (fun sub ->
+          match sub with
+          | Ast.PatternMap deps ->
+              let lens = List.filter_map eval_dep_len deps in
+              (match lens with [] -> None | _ -> Some (List.fold_left min max_int lens))
+          | _ -> None
+        ) subs in
+        if List.length sub_lengths <> List.length subs then None
+        else Some (List.fold_left ( * ) 1 sub_lengths)
     | Ast.PatternSlice (_, indices) -> Some (List.length indices)
     | Ast.PatternHead (dep, n) | Ast.PatternTail (dep, n) | Ast.PatternSample (dep, n) ->
         (match eval_dep_len dep with

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -2543,6 +2543,9 @@ and try_lazy_expand_branch (p : Ast.pipeline_result) (env : value Env.t) (field 
                      validate_deps [dep] (offset + branch_num - 1)
                  | _ -> None)
             | Ast.PatternSample (dep, n) ->
+                (* Note: positional index (branch_num - 1), not Fisher-Yates shuffle.
+                   The actual sampled value on expansion may differ — that's fine for
+                   validation/display; the full shuffle happens in pipeline_expand.ml. *)
                 (match eval_dep_len dep with
                  | Some len when branch_num <= min n len ->
                      validate_deps [dep] (branch_num - 1)

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -1710,6 +1710,25 @@ and eval_pipeline_of env_ref (nodes : (string * Ast.expr) list) : value =
 
 (** Evaluate a pipeline definition *)
 and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : value =
+  (match List.find_opt (fun (name, _) ->
+    let parts = String.split_on_char '_' name in
+    List.length parts >= 3
+    && List.nth parts (List.length parts - 2) = "branch"
+    && let last = List.nth parts (List.length parts - 1) in
+       String.length last > 0
+       && String.for_all (fun c -> c >= '0' && c <= '9') last
+  ) nodes with
+  | Some (bad_name, _) ->
+    Error.make_error NameError
+      (Printf.sprintf "Node name `%s` ends with `_branch_N` which is reserved for auto-generated branch nodes from pattern expansion. Choose a different name." bad_name)
+  | None ->
+  (match List.find_opt (fun (n, _) ->
+    List.length (List.filter (fun (n', _) -> n' = n) nodes) > 1
+  ) nodes with
+  | Some (dup_name, _) ->
+    Error.make_error NameError
+      (Printf.sprintf "Duplicate node name `%s` in pipeline." dup_name)
+  | None ->
   let rec substitute_env_vars env node_names expr =
     let sub = substitute_env_vars env node_names in
     let new_node = match expr.node with
@@ -2040,6 +2059,7 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
     } in
     result
   end
+  ))
 
 (** Deserialize dependencies for a node during eager evaluation.
     Resolves deserialization strategy from the node's deserializer expression,
@@ -2423,6 +2443,145 @@ and eval_dot_access env_ref target_expr field =
       | _ -> eval_dot_access_val env_ref (Utils.unwrap_value target_val) field)
   | _ -> eval_dot_access_val env_ref target_val field
 
+and try_lazy_expand_branch (p : Ast.pipeline_result) (env : value Env.t) (field : string) : value option =
+  let parse_branch_suffix s =
+    let branch_marker = "_branch_" in
+    let bm_len = String.length branch_marker in
+    let s_len = String.length s in
+    let rec find_marker pos =
+      if pos < 0 then None
+      else if String.sub s pos bm_len = branch_marker then
+        let orig = String.sub s 0 pos in
+        let suffix = String.sub s (pos + bm_len) (s_len - pos - bm_len) in
+        (match int_of_string_opt suffix with
+         | Some n when n > 0 -> Some (orig, n)
+         | _ -> None)
+      else find_marker (pos - 1)
+    in
+    find_marker (s_len - bm_len)
+  in
+  let eval_dep_len dep =
+    match List.assoc_opt dep p.Ast.p_exprs with
+    | Some expr ->
+        (try
+           match eval_expr (ref env) expr with
+           | Ast.VList items -> Some (List.length items)
+           | Ast.VVector arr -> Some (Array.length arr)
+           | Ast.VDataFrame df -> Some (Arrow_table.num_rows df.Ast.arrow_table)
+           | _ -> None
+         with _ -> None)
+    | None -> None
+  in
+  let eval_dep_at_index dep index =
+    match List.assoc_opt dep p.Ast.p_exprs with
+    | Some expr ->
+        (try
+           match eval_expr (ref env) expr with
+           | Ast.VList items ->
+               if index >= 0 && index < List.length items then snd (List.nth items index)
+               else Ast.VNA Ast.NAGeneric
+           | Ast.VVector arr ->
+               if index >= 0 && index < Array.length arr then Array.get arr index
+               else Ast.VNA Ast.NAGeneric
+           | Ast.VDataFrame df ->
+               let n = Arrow_table.num_rows df.Ast.arrow_table in
+               if index >= 0 && index < n then
+                 Ast.VDataFrame { df with Ast.arrow_table = Arrow_table.slice df.Ast.arrow_table index 1 }
+               else Ast.VNA Ast.NAGeneric
+           | _ -> Ast.VNA Ast.NAGeneric
+         with _ -> Ast.VNA Ast.NAGeneric)
+    | None -> Ast.VNA Ast.NAGeneric
+  in
+  let mk_cn orig_name =
+    let cn_runtime = match List.assoc_opt orig_name p.Ast.p_runtimes with Some r -> r | None -> "T" in
+    let cn_serializer = match List.assoc_opt orig_name p.Ast.p_serializers with
+      | Some e -> Nix_unparse.expr_to_string e | None -> "default"
+    in
+    let cn_dependencies = match List.assoc_opt orig_name p.Ast.p_deps with Some d -> d | None -> [] in
+    Some (Ast.VComputedNode {
+      Ast.cn_name = field;
+      Ast.cn_runtime;
+      Ast.cn_path = "<unbuilt>";
+      Ast.cn_serializer;
+      Ast.cn_class = "Unknown";
+      Ast.cn_dependencies;
+      Ast.cn_p_exprs = Some p.Ast.p_exprs;
+    })
+  in
+  match parse_branch_suffix field with
+  | Some (orig_name, branch_num) ->
+      (match List.assoc_opt orig_name p.Ast.p_patterns with
+       | Some pattern ->
+           let validate_deps deps index =
+             let dep_values = List.map (fun dep -> eval_dep_at_index dep index) deps in
+             if List.exists (fun v -> match v with Ast.VNA _ -> true | _ -> false) dep_values then None
+             else mk_cn orig_name
+           in
+           (match pattern with
+            | Ast.PatternMap deps ->
+                (match deps with
+                 | dep :: _ ->
+                     (match eval_dep_len dep with
+                      | Some len when branch_num <= len ->
+                          validate_deps deps (branch_num - 1)
+                      | _ -> None)
+                 | _ -> None)
+            | Ast.PatternCross _ -> None
+            | Ast.PatternSlice (dep, indices) ->
+                if branch_num <= List.length indices then
+                  validate_deps [dep] (List.nth indices (branch_num - 1))
+                else None
+            | Ast.PatternHead (dep, n) ->
+                (match eval_dep_len dep with
+                 | Some len when branch_num <= min n len ->
+                     validate_deps [dep] (branch_num - 1)
+                 | _ -> None)
+            | Ast.PatternTail (dep, n) ->
+                (match eval_dep_len dep with
+                 | Some len when branch_num <= min n len ->
+                     let offset = max 0 (len - n) in
+                     validate_deps [dep] (offset + branch_num - 1)
+                 | _ -> None)
+            | Ast.PatternSample (dep, n) ->
+                (match eval_dep_len dep with
+                 | Some len when branch_num <= min n len ->
+                     validate_deps [dep] (branch_num - 1)
+                 | _ -> None))
+       | None -> None)
+  | _ -> None
+
+and pattern_branch_names_for_error p field pattern =
+  let eval_dep_len dep =
+    match List.assoc_opt dep p.Ast.p_exprs with
+    | Some expr ->
+        (try
+           match eval_expr (ref Ast.Env.empty) expr with
+           | Ast.VList items -> Some (List.length items)
+           | Ast.VVector arr -> Some (Array.length arr)
+           | Ast.VDataFrame df -> Some (Arrow_table.num_rows df.Ast.arrow_table)
+           | _ -> None
+         with _ -> None)
+    | None -> None
+  in
+  let branch_count =
+    match pattern with
+    | Ast.PatternMap deps ->
+        (match deps with
+         | [dep] -> eval_dep_len dep
+         | _ -> None)
+    | Ast.PatternCross _ -> None
+    | Ast.PatternSlice (_, indices) -> Some (List.length indices)
+    | Ast.PatternHead (dep, n) | Ast.PatternTail (dep, n) | Ast.PatternSample (dep, n) ->
+        (match eval_dep_len dep with
+         | Some len -> Some (min n len)
+         | None -> None)
+  in
+  match branch_count with
+  | Some count ->
+      let branches = List.init count (fun i -> field ^ "_branch_" ^ string_of_int (i + 1)) in
+      Some branches
+  | None -> None
+
 and get_pipeline_member p field =
   let resolved_cn p cn =
     match Hashtbl.find_opt Ast.pipeline_build_logs p.p_exprs with
@@ -2460,16 +2619,40 @@ and get_pipeline_member p field =
            if is_noop then
              Some (VSymbol (Printf.sprintf "<noop:%s>" field))
            else
-              Some (VComputedNode (resolved_cn p {
-                cn_name = field;
-                cn_runtime;
-                cn_path = "<unbuilt>";
-                cn_serializer;
-                cn_class = "Unknown";
-                cn_dependencies;
-                cn_p_exprs = Some p.p_exprs;
-              }))
-       | None -> None)
+               Some (VComputedNode (resolved_cn p {
+                 cn_name = field;
+                 cn_runtime;
+                 cn_path = "<unbuilt>";
+                 cn_serializer;
+                 cn_class = "Unknown";
+                 cn_dependencies;
+                 cn_p_exprs = Some p.p_exprs;
+               }))
+        | None ->
+            (* Check if this is a patterned node that expands into branches *)
+            (match List.assoc_opt field p.p_patterns with
+             | Some pattern ->
+                 let pattern_str = match pattern with
+                   | Ast.PatternMap deps -> "map_pattern(" ^ String.concat ", " deps ^ ")"
+                   | Ast.PatternCross _ -> "cross_pattern(...)"
+                   | Ast.PatternSlice (dep, indices) ->
+                       "slice_pattern(" ^ dep ^ ", [" ^ String.concat ", " (List.map string_of_int indices) ^ "])"
+                   | Ast.PatternHead (dep, n) -> "head_pattern(" ^ dep ^ ", " ^ string_of_int n ^ ")"
+                   | Ast.PatternTail (dep, n) -> "tail_pattern(" ^ dep ^ ", " ^ string_of_int n ^ ")"
+                   | Ast.PatternSample (dep, n) -> "sample_pattern(" ^ dep ^ ", " ^ string_of_int n ^ ")"
+                 in
+                 (match pattern_branch_names_for_error p field pattern with
+                  | Some branches ->
+                      Some (Error.make_error ValueError
+                        (Printf.sprintf "Node `%s` has pattern %s and expands into %s.\n\
+                          Use read_node(p.<branch_name>) to access individual branches directly."
+                          field pattern_str (String.concat ", " branches)))
+                  | None ->
+                      Some (Error.make_error ValueError
+                        (Printf.sprintf "Node `%s` has pattern %s.\n\
+                          Build the pipeline first, or use expand_pipeline(p) and access individual branches."
+                          field pattern_str)))
+              | None -> None))
 
 and pipeline_get_node_value _env_ref p field =
   match get_pipeline_member p field with
@@ -2574,10 +2757,14 @@ and eval_dot_access_val env_ref target_val field =
        (match get_pipeline_member p field with
         | Some v -> v
         | None ->
-            if has_node_prefix p field
-            then VDict [("__partial_dot_pipeline__", VPipeline p);
-                        ("__partial_dot_prefix__", VString field)]
-            else Error.make_error KeyError (Printf.sprintf "Node `%s` not found in Pipeline." field))
+            (* Try lazy branch expansion for patterned nodes *)
+            (match try_lazy_expand_branch p !env_ref field with
+             | Some v -> v
+             | None ->
+                 if has_node_prefix p field
+                 then VDict [("__partial_dot_pipeline__", VPipeline p);
+                             ("__partial_dot_prefix__", VString field)]
+                 else Error.make_error KeyError (Printf.sprintf "Node `%s` not found in Pipeline." field)))
   | VMetaPipeline mp ->
       (match Pipeline_composition.flatten_meta (VMetaPipeline mp) with
        | VPipeline flat_p -> eval_dot_access_val env_ref (VPipeline flat_p) field

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -2460,17 +2460,47 @@ and try_lazy_expand_branch (p : Ast.pipeline_result) (env : value Env.t) (field 
     in
     find_marker (s_len - bm_len)
   in
-  let eval_dep_len dep =
-    match List.assoc_opt dep p.Ast.p_exprs with
-    | Some expr ->
-        (try
-           match eval_expr (ref env) expr with
-           | Ast.VList items -> Some (List.length items)
-           | Ast.VVector arr -> Some (Array.length arr)
-           | Ast.VDataFrame df -> Some (Arrow_table.num_rows df.Ast.arrow_table)
-           | _ -> None
-         with _ -> None)
-    | None -> None
+  let rec eval_dep_len dep =
+    let from_expr =
+      match List.assoc_opt dep p.Ast.p_exprs with
+      | Some expr ->
+          (try
+             match eval_expr (ref env) expr with
+             | Ast.VList items -> Some (List.length items)
+             | Ast.VVector arr -> Some (Array.length arr)
+             | Ast.VDataFrame df -> Some (Arrow_table.num_rows df.Ast.arrow_table)
+             | _ -> None
+           with _ -> None)
+      | None -> None
+    in
+    match from_expr with
+    | Some _ -> from_expr
+    | None ->
+        (match List.assoc_opt dep p.Ast.p_patterns with
+         | Some pattern ->
+             (match pattern with
+              | Ast.PatternMap deps ->
+                  (match deps with
+                   | _ :: _ ->
+                       let lens = List.filter_map eval_dep_len deps in
+                       (match lens with [] -> None | _ -> Some (List.fold_left min max_int lens))
+                   | _ -> None)
+              | Ast.PatternCross subs ->
+                  let sub_lengths = List.filter_map (fun sub ->
+                    match sub with
+                    | Ast.PatternMap sub_deps ->
+                        let lens = List.filter_map eval_dep_len sub_deps in
+                        (match lens with [] -> None | _ -> Some (List.fold_left min max_int lens))
+                    | _ -> None
+                  ) subs in
+                  if List.length sub_lengths <> List.length subs then None
+                  else Some (List.fold_left ( * ) 1 sub_lengths)
+              | Ast.PatternSlice (_, indices) -> Some (List.length indices)
+              | Ast.PatternHead (d, n) | Ast.PatternTail (d, n) | Ast.PatternSample (d, n) ->
+                  (match eval_dep_len d with
+                   | Some len -> Some (min n len)
+                   | None -> None))
+         | None -> None)
   in
   let eval_dep_at_index dep index =
     match List.assoc_opt dep p.Ast.p_exprs with
@@ -2512,10 +2542,11 @@ and try_lazy_expand_branch (p : Ast.pipeline_result) (env : value Env.t) (field 
   | Some (orig_name, branch_num) ->
       (match List.assoc_opt orig_name p.Ast.p_patterns with
        | Some pattern ->
-           let validate_deps deps index =
-             let dep_values = List.map (fun dep -> eval_dep_at_index dep index) deps in
-             if List.exists (fun v -> match v with Ast.VNA _ -> true | _ -> false) dep_values then None
-             else mk_cn orig_name
+            let validate_deps deps index =
+              let concrete = List.filter (fun d -> List.mem_assoc d p.Ast.p_exprs) deps in
+              let dep_values = List.map (fun dep -> eval_dep_at_index dep index) concrete in
+              if List.exists (fun v -> match v with Ast.VNA _ -> true | _ -> false) dep_values then None
+              else mk_cn orig_name
            in
            (match pattern with
             | Ast.PatternMap deps ->
@@ -2565,17 +2596,47 @@ and try_lazy_expand_branch (p : Ast.pipeline_result) (env : value Env.t) (field 
   | _ -> None
 
 and pattern_branch_names_for_error p field pattern =
-  let eval_dep_len dep =
-    match List.assoc_opt dep p.Ast.p_exprs with
-    | Some expr ->
-        (try
-           match eval_expr (ref Ast.Env.empty) expr with
-           | Ast.VList items -> Some (List.length items)
-           | Ast.VVector arr -> Some (Array.length arr)
-           | Ast.VDataFrame df -> Some (Arrow_table.num_rows df.Ast.arrow_table)
-           | _ -> None
-         with _ -> None)
-    | None -> None
+  let rec eval_dep_len dep =
+    let from_expr =
+      match List.assoc_opt dep p.Ast.p_exprs with
+      | Some expr ->
+          (try
+             match eval_expr (ref Ast.Env.empty) expr with
+             | Ast.VList items -> Some (List.length items)
+             | Ast.VVector arr -> Some (Array.length arr)
+             | Ast.VDataFrame df -> Some (Arrow_table.num_rows df.Ast.arrow_table)
+             | _ -> None
+           with _ -> None)
+      | None -> None
+    in
+    match from_expr with
+    | Some _ -> from_expr
+    | None ->
+        (match List.assoc_opt dep p.Ast.p_patterns with
+         | Some pattern ->
+             (match pattern with
+              | Ast.PatternMap deps ->
+                  (match deps with
+                   | _ :: _ ->
+                       let lens = List.filter_map eval_dep_len deps in
+                       (match lens with [] -> None | _ -> Some (List.fold_left min max_int lens))
+                   | _ -> None)
+              | Ast.PatternCross subs ->
+                  let sub_lengths = List.filter_map (fun sub ->
+                    match sub with
+                    | Ast.PatternMap sub_deps ->
+                        let lens = List.filter_map eval_dep_len sub_deps in
+                        (match lens with [] -> None | _ -> Some (List.fold_left min max_int lens))
+                    | _ -> None
+                  ) subs in
+                  if List.length sub_lengths <> List.length subs then None
+                  else Some (List.fold_left ( * ) 1 sub_lengths)
+              | Ast.PatternSlice (_, indices) -> Some (List.length indices)
+              | Ast.PatternHead (d, n) | Ast.PatternTail (d, n) | Ast.PatternSample (d, n) ->
+                  (match eval_dep_len d with
+                   | Some len -> Some (min n len)
+                   | None -> None))
+         | None -> None)
   in
   let branch_count =
     match pattern with

--- a/src/packages/pipeline/inspect_pipeline.ml
+++ b/src/packages/pipeline/inspect_pipeline.ml
@@ -54,10 +54,40 @@ let register env =
             | _ -> None
           with _ -> None
         in
-        let eval_dep_len dep =
-          match List.assoc_opt dep p.p_exprs with
-          | Some expr -> eval_dep_len_expr expr
-          | None -> None
+        let rec eval_dep_len dep =
+          let from_expr =
+            match List.assoc_opt dep p.p_exprs with
+            | Some expr -> eval_dep_len_expr expr
+            | None -> None
+          in
+          match from_expr with
+          | Some _ -> from_expr
+          | None ->
+              (match List.assoc_opt dep p.p_patterns with
+               | Some pattern ->
+                   (match pattern with
+                    | PatternMap deps ->
+                        (match deps with
+                         | _ :: _ ->
+                             let lens = List.filter_map eval_dep_len deps in
+                             (match lens with [] -> None | _ -> Some (List.fold_left min max_int lens))
+                         | _ -> None)
+                    | PatternCross subs ->
+                        let sub_lengths = List.filter_map (fun sub ->
+                          match sub with
+                          | PatternMap sub_deps ->
+                              let lens = List.filter_map eval_dep_len sub_deps in
+                              (match lens with [] -> None | _ -> Some (List.fold_left min max_int lens))
+                          | _ -> None
+                        ) subs in
+                        if List.length sub_lengths <> List.length subs then None
+                        else Some (List.fold_left ( * ) 1 sub_lengths)
+                    | PatternSlice (_, indices) -> Some (List.length indices)
+                    | PatternHead (d, n) | PatternTail (d, n) | PatternSample (d, n) ->
+                        (match eval_dep_len d with
+                         | Some len -> Some (min n len)
+                         | None -> None))
+               | None -> None)
         in
         let branch_entries = List.concat_map (fun (name, pattern) ->
           let count_opt = match pattern with

--- a/src/packages/pipeline/inspect_pipeline.ml
+++ b/src/packages/pipeline/inspect_pipeline.ml
@@ -63,7 +63,16 @@ let register env =
           let count_opt = match pattern with
             | PatternMap deps ->
                 (match deps with [dep] -> eval_dep_len dep | _ -> None)
-            | PatternCross _ -> None
+            | PatternCross subs ->
+                let sub_lengths = List.filter_map (fun sub ->
+                  match sub with
+                  | PatternMap deps ->
+                      let lens = List.filter_map eval_dep_len deps in
+                      (match lens with [] -> None | _ -> Some (List.fold_left min max_int lens))
+                  | _ -> None
+                ) subs in
+                if List.length sub_lengths <> List.length subs then None
+                else Some (List.fold_left ( * ) 1 sub_lengths)
             | PatternSlice (_, indices) -> Some (List.length indices)
             | PatternHead (dep, n) | PatternTail (dep, n) | PatternSample (dep, n) ->
                 (match eval_dep_len dep with Some len -> Some (min n len) | None -> None)

--- a/src/packages/pipeline/inspect_pipeline.ml
+++ b/src/packages/pipeline/inspect_pipeline.ml
@@ -36,29 +36,58 @@ let register env =
     in
     match p_val with
     | VPipeline p ->
-        let nodes_arr = Array.of_list p.p_nodes in
-        let nrows = Array.length nodes_arr in
-        let arr_nodes = Array.init nrows (fun i -> let (name, _) = nodes_arr.(i) in Some name) in
-        let arr_runtimes = Array.init nrows (fun i ->
-          let (name, _) = nodes_arr.(i) in
-          Some (match List.assoc_opt name p.p_runtimes with Some r -> r | None -> "Unknown")
-        ) in
-        let arr_serializers = Array.init nrows (fun i ->
-          let (name, _) = nodes_arr.(i) in
-          Some (match List.assoc_opt name p.p_serializers with
-                | Some expr -> Nix_unparse.unparse_expr expr
-                | None -> "Unknown")
-        ) in
-        let arr_dependencies = Array.init nrows (fun i ->
-          let (name, _) = nodes_arr.(i) in
-          let deps = match List.assoc_opt name p.p_deps with Some ds -> ds | None -> [] in
-          Some (String.concat ", " deps)
-        ) in
-        let arr_has_script = Array.init nrows (fun i ->
-          let (name, _) = nodes_arr.(i) in
+        let base_entries = List.map (fun (name, _) ->
+          let runtime = match List.assoc_opt name p.p_runtimes with Some r -> r | None -> "Unknown" in
+          let serializer_str = match List.assoc_opt name p.p_serializers with
+            | Some expr -> Nix_unparse.unparse_expr expr | None -> "Unknown"
+          in
+          let deps_str = match List.assoc_opt name p.p_deps with Some ds -> String.concat ", " ds | None -> "" in
           let has_sc = match List.assoc_opt name p.p_scripts with Some (Some _) -> true | _ -> false in
-          Some has_sc
-        ) in
+          (name, runtime, serializer_str, deps_str, has_sc)
+        ) p.p_nodes in
+        let eval_dep_len_expr expr =
+          try
+            match Eval.eval_expr (ref env) expr with
+            | VList items -> Some (List.length items)
+            | VVector arr -> Some (Array.length arr)
+            | VDataFrame df -> Some (Arrow_table.num_rows df.arrow_table)
+            | _ -> None
+          with _ -> None
+        in
+        let eval_dep_len dep =
+          match List.assoc_opt dep p.p_exprs with
+          | Some expr -> eval_dep_len_expr expr
+          | None -> None
+        in
+        let branch_entries = List.concat_map (fun (name, pattern) ->
+          let count_opt = match pattern with
+            | PatternMap deps ->
+                (match deps with [dep] -> eval_dep_len dep | _ -> None)
+            | PatternCross _ -> None
+            | PatternSlice (_, indices) -> Some (List.length indices)
+            | PatternHead (dep, n) | PatternTail (dep, n) | PatternSample (dep, n) ->
+                (match eval_dep_len dep with Some len -> Some (min n len) | None -> None)
+          in
+          let runtime = match List.assoc_opt name p.p_runtimes with Some r -> r | None -> "Unknown" in
+          let serializer_str = match List.assoc_opt name p.p_serializers with
+            | Some expr -> Nix_unparse.unparse_expr expr | None -> "Unknown"
+          in
+          let deps_str = match List.assoc_opt name p.p_deps with Some ds -> String.concat ", " ds | None -> "" in
+          match count_opt with
+          | Some n when n > 0 ->
+              List.init n (fun i ->
+                let branch_name = name ^ "_branch_" ^ string_of_int (i + 1) in
+                (branch_name, runtime, serializer_str, deps_str, false))
+          | _ -> []
+        ) p.p_patterns in
+        let all_entries = base_entries @ branch_entries in
+        let nrows = List.length all_entries in
+        let entries_arr = Array.of_list all_entries in
+        let arr_nodes = Array.init nrows (fun i -> let (name, _, _, _, _) = entries_arr.(i) in Some name) in
+        let arr_runtimes = Array.init nrows (fun i -> let (_, r, _, _, _) = entries_arr.(i) in Some r) in
+        let arr_serializers = Array.init nrows (fun i -> let (_, _, s, _, _) = entries_arr.(i) in Some s) in
+        let arr_dependencies = Array.init nrows (fun i -> let (_, _, _, d, _) = entries_arr.(i) in Some d) in
+        let arr_has_script = Array.init nrows (fun i -> let (_, _, _, _, h) = entries_arr.(i) in Some h) in
         let columns = [
           ("node", Arrow_table.StringColumn arr_nodes);
           ("runtime", Arrow_table.StringColumn arr_runtimes);

--- a/src/packages/pipeline/pipeline_expand.ml
+++ b/src/packages/pipeline/pipeline_expand.ml
@@ -198,6 +198,13 @@ let make_branch (name : string) (orig_name : string) (i : int) (dep_indices : (s
     un_iteration = "vector";
   }}
 
+let value_length (v : value) : int =
+  match v with
+  | VList items -> List.length items
+  | VVector arr -> Array.length arr
+  | VDataFrame df -> Arrow_table.num_rows df.arrow_table
+  | _ -> 1
+
 let process_map
     ?(expanded_map : (string * string list) list = [])
     (p : pipeline_result) (env : value Env.t) (name : string) (dep_names : string list)

--- a/src/packages/pipeline/pipeline_nodes.ml
+++ b/src/packages/pipeline/pipeline_nodes.ml
@@ -32,7 +32,16 @@ let compute_branch_names env p =
           (match deps with
            | [dep] -> eval_dep_len env p.p_exprs dep
            | _ -> None)
-      | PatternCross _ -> None
+      | PatternCross subs ->
+          let sub_lengths = List.filter_map (fun sub ->
+            match sub with
+            | PatternMap deps ->
+                let lens = List.filter_map (eval_dep_len env p.p_exprs) deps in
+                (match lens with [] -> None | _ -> Some (List.fold_left min max_int lens))
+            | _ -> None
+          ) subs in
+          if List.length sub_lengths <> List.length subs then None
+          else Some (List.fold_left ( * ) 1 sub_lengths)
       | PatternSlice (_, indices) -> Some (List.length indices)
       | PatternHead (dep, n) | PatternTail (dep, n) | PatternSample (dep, n) ->
           (match eval_dep_len env p.p_exprs dep with

--- a/src/packages/pipeline/pipeline_nodes.ml
+++ b/src/packages/pipeline/pipeline_nodes.ml
@@ -13,30 +13,60 @@ open Ast
 --# @export
 *)
 
-let eval_dep_len env exprs dep_name =
-  match List.assoc_opt dep_name exprs with
-  | Some expr ->
-      (try
-         match Eval.eval_expr (ref env) expr with
-         | VList items -> Some (List.length items)
-         | VVector arr -> Some (Array.length arr)
-         | VDataFrame df -> Some (Arrow_table.num_rows df.arrow_table)
-         | _ -> None
-       with _ -> None)
-  | None -> None
+let rec eval_dep_len env exprs patterns dep_name =
+  let from_expr =
+    match List.assoc_opt dep_name exprs with
+    | Some expr ->
+        (try
+           match Eval.eval_expr (ref env) expr with
+           | VList items -> Some (List.length items)
+           | VVector arr -> Some (Array.length arr)
+           | VDataFrame df -> Some (Arrow_table.num_rows df.arrow_table)
+           | _ -> None
+         with _ -> None)
+    | None -> None
+  in
+  match from_expr with
+  | Some _ -> from_expr
+  | None ->
+      (match List.assoc_opt dep_name patterns with
+       | Some pattern ->
+           (match pattern with
+            | PatternMap deps ->
+                (match deps with
+                 | _ :: _ ->
+                     let lens = List.filter_map (eval_dep_len env exprs patterns) deps in
+                     (match lens with [] -> None | _ -> Some (List.fold_left min max_int lens))
+                 | _ -> None)
+            | PatternCross subs ->
+                let sub_lengths = List.filter_map (fun sub ->
+                  match sub with
+                  | PatternMap sub_deps ->
+                      let lens = List.filter_map (eval_dep_len env exprs patterns) sub_deps in
+                      (match lens with [] -> None | _ -> Some (List.fold_left min max_int lens))
+                  | _ -> None
+                ) subs in
+                if List.length sub_lengths <> List.length subs then None
+                else Some (List.fold_left ( * ) 1 sub_lengths)
+            | PatternSlice (_, indices) -> Some (List.length indices)
+            | PatternHead (d, n) | PatternTail (d, n) | PatternSample (d, n) ->
+                (match eval_dep_len env exprs patterns d with
+                 | Some len -> Some (min n len)
+                 | None -> None))
+       | None -> None)
 
 let compute_branch_names env p =
   List.concat_map (fun (name, pattern) ->
     let count_opt = match pattern with
       | PatternMap deps ->
           (match deps with
-           | [dep] -> eval_dep_len env p.p_exprs dep
+           | [dep] -> eval_dep_len env p.p_exprs p.p_patterns dep
            | _ -> None)
       | PatternCross subs ->
           let sub_lengths = List.filter_map (fun sub ->
             match sub with
             | PatternMap deps ->
-                let lens = List.filter_map (eval_dep_len env p.p_exprs) deps in
+                let lens = List.filter_map (eval_dep_len env p.p_exprs p.p_patterns) deps in
                 (match lens with [] -> None | _ -> Some (List.fold_left min max_int lens))
             | _ -> None
           ) subs in
@@ -44,7 +74,7 @@ let compute_branch_names env p =
           else Some (List.fold_left ( * ) 1 sub_lengths)
       | PatternSlice (_, indices) -> Some (List.length indices)
       | PatternHead (dep, n) | PatternTail (dep, n) | PatternSample (dep, n) ->
-          (match eval_dep_len env p.p_exprs dep with
+          (match eval_dep_len env p.p_exprs p.p_patterns dep with
            | Some len -> Some (min n len)
            | None -> None)
     in

--- a/src/packages/pipeline/pipeline_nodes.ml
+++ b/src/packages/pipeline/pipeline_nodes.ml
@@ -12,12 +12,47 @@ open Ast
 --# @seealso pipeline_node, pipeline_deps
 --# @export
 *)
+
+let eval_dep_len env exprs dep_name =
+  match List.assoc_opt dep_name exprs with
+  | Some expr ->
+      (try
+         match Eval.eval_expr (ref env) expr with
+         | VList items -> Some (List.length items)
+         | VVector arr -> Some (Array.length arr)
+         | VDataFrame df -> Some (Arrow_table.num_rows df.arrow_table)
+         | _ -> None
+       with _ -> None)
+  | None -> None
+
+let compute_branch_names env p =
+  List.concat_map (fun (name, pattern) ->
+    let count_opt = match pattern with
+      | PatternMap deps ->
+          (match deps with
+           | [dep] -> eval_dep_len env p.p_exprs dep
+           | _ -> None)
+      | PatternCross _ -> None
+      | PatternSlice (_, indices) -> Some (List.length indices)
+      | PatternHead (dep, n) | PatternTail (dep, n) | PatternSample (dep, n) ->
+          (match eval_dep_len env p.p_exprs dep with
+           | Some len -> Some (min n len)
+           | None -> None)
+    in
+    match count_opt with
+    | Some n when n > 0 -> List.init n (fun i -> name ^ "_branch_" ^ string_of_int (i + 1))
+    | _ -> []
+  ) p.p_patterns
+
 let register env =
   Env.add "pipeline_nodes"
-    (make_builtin ~name:"pipeline_nodes" 1 (fun args _env ->
+    (make_builtin ~name:"pipeline_nodes" 1 (fun args env ->
       match args with
-      | [VPipeline { p_nodes; _ }] ->
-          VList (List.map (fun (name, _) -> (None, VString name)) p_nodes)
+      | [VPipeline p] ->
+          let base_names = List.map fst p.p_nodes in
+          let branch_names = compute_branch_names env p in
+          let all_names = base_names @ branch_names in
+          VList (List.map (fun name -> (None, VString name)) all_names)
       | [other] ->
           Error.type_error
             (Printf.sprintf "Function `pipeline_nodes` expects a Pipeline, but got %s."

--- a/src/packages/pipeline/read_node.ml
+++ b/src/packages/pipeline/read_node.ml
@@ -452,11 +452,20 @@ let read_fn named_args _env =
           | Some v when not is_built && not (is_in_memory_placeholder v) -> v
           | _ ->
             (match resolved_cn with
-             | cn when cn.cn_path = "<unbuilt>" ->
-                 (match Ast.get_in_memory_node_value_for_cn cn with
-                   | Some v when not (is_in_memory_placeholder v) -> v
-                   | _ ->
-                       Error.make_error FileError (Printf.sprintf "read_node: node `%s` has not been built yet. Build the pipeline first with build_pipeline(p), or use read_past_node(p.%s, which_log = ...) to read from a past build log." cn.cn_name cn.cn_name))
+              | cn when cn.cn_path = "<unbuilt>" ->
+                  (match Ast.get_in_memory_node_value_for_cn cn with
+                    | Some v when not (is_in_memory_placeholder v) -> v
+                    | _ ->
+                        let branch_names = Builder.branch_names_in_latest_log cn.cn_name in
+                        (match branch_names with
+                         | [] ->
+                             Error.make_error FileError (Printf.sprintf "read_node: node `%s` has not been built yet. Build the pipeline first with build_pipeline(p), or use read_past_node(p.%s, which_log = ...) to read from a past build log." cn.cn_name cn.cn_name)
+                         | _ ->
+                             let branches_str = String.concat ", " branch_names in
+                             Error.make_error ValueError
+                               (Printf.sprintf "Node `%s` has a pattern and expands into %s.\n\
+                                 Use read_node(p.<branch_name>) to access individual branches directly."
+                                cn.cn_name branches_str)))
              | cn ->
                  let raw_val = Builder.logged_node_value cn.cn_name cn in
                  match Ast.get_in_memory_node_value_for_cn cn with

--- a/src/pipeline/builder_read_node.ml
+++ b/src/pipeline/builder_read_node.ml
@@ -470,6 +470,19 @@ let latest_logged_computed_node ?log_name_pattern (name : string) =
 let () = latest_logged_computed_node_forward := (fun name ->
   latest_logged_computed_node name)
 
+let branch_names_in_latest_log prefix =
+  let branch_prefix = prefix ^ "_branch_" in
+  match candidate_logs () with
+  | [] -> []
+  | log_file :: _ ->
+      match read_log (Filename.concat pipeline_dir log_file) with
+      | Ok entries ->
+          entries |> List.filter_map (fun (name, _) ->
+            if String.starts_with ~prefix:branch_prefix name then Some name
+            else None
+          ) |> List.sort String.compare
+      | Error _ -> []
+
 let read_node ?which_log name =
   let env_name = "T_NODE_" ^ name in
   match Sys.getenv_opt env_name with

--- a/tests/pipeline/test_pipeline.ml
+++ b/tests/pipeline/test_pipeline.ml
@@ -182,6 +182,12 @@ let run_tests pass_count fail_count _failures _eval_string eval_string_env test 
   test "pipeline_node missing key"
     {|p = pipeline { a = 1 }; pipeline_node(p, "b")|}
     {|Error(KeyError: "Node `b` not found in Pipeline.")|};
+  test "reserved _branch_N node name rejected"
+    {|pipeline { a_branch_1 = 1 }|}
+    {|Error(NameError: "Node name `a_branch_1` ends with `_branch_N` which is reserved for auto-generated branch nodes from pattern expansion. Choose a different name.")|};
+  test "duplicate node name rejected"
+    {|pipeline { a = 1; a = 2 }|}
+    {|Error(NameError: "Duplicate node name `a` in pipeline.")|};
 
   let (v, _) = eval_string_env "p_drv = pipeline { a = 1 }; pipeline_to_drv(p_drv)" env_p3 in
   let result = Ast.Utils.value_to_string v in


### PR DESCRIPTION
…ware read_node errors

- Add branch_names_in_latest_log to read node names from build logs
- read_node on unbuilt patterned node gives helpful error listing branches
- pipeline_nodes/inspect_pipeline compute branch names from p_exprs
- pipeline_expand exports value_length utility
- Forbid node names matching _branch_N pattern at pipeline construction
- Reject duplicate node names in pipeline construction