### PR TITLE
feat(chrono): add timezone offset conversion via POSIX localtime_r FFI

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -34,9 +34,9 @@
  (wrapped false)
  (instrumentation
   (backend bisect_ppx))
- (foreign_stubs
-  (language c)
-  (names arrow_stubs stats_stubs onnx_stubs)
+(foreign_stubs
+   (language c)
+   (names arrow_stubs stats_stubs onnx_stubs chrono_stubs)
   (flags (:include arrow_cflags.sexp)))
  (c_library_flags (:include arrow_libs.sexp))
  (modules

--- a/src/ffi/chrono_stubs.c
+++ b/src/ffi/chrono_stubs.c
@@ -1,0 +1,71 @@
+/* src/ffi/chrono_stubs.c                                       */
+/* C FFI stubs for the chrono package.                          */
+/*                                                              */
+/* Provides caml_tz_offset: computes the UTC offset (in seconds */
+/* EAST of UTC) for a given UNIX microsecond timestamp and IANA */
+/* timezone name using POSIX localtime_r with TZ= override.     */
+/*                                                              */
+/* THREAD-SAFETY NOTE: setenv/tzset/localtime_r operate on      */
+/* global process state (the TZ environment variable and         */
+/* tzset()'s internal cache). This is safe under OCaml 4.x      */
+/* (single-domain runtime — the equivalent of the GIL holds     */
+/* the runtime lock across C stubs). If the runtime is ever      */
+/* upgraded to OCaml 5 with multiple Domains calling this        */
+/* simultaneously, a data race will occur. Revisit this          */
+/* function before enabling multicore.                          */
+
+#include <caml/mlvalues.h>
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <caml/fail.h>
+#include <time.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+CAMLprim value caml_tz_offset(value v_micros, value v_tz_name)
+{
+  CAMLparam2(v_micros, v_tz_name);
+
+  int64_t micros = Int64_val(v_micros);
+
+  /* Extract tz_name immediately — String_val returns a pointer
+     into the OCaml heap; any subsequent allocation
+     (malloc, setenv, etc.) could trigger GC compaction. */
+  const char *tz_name_raw = String_val(v_tz_name);
+  size_t name_len = strlen(tz_name_raw);
+  char *tz_buf = (char *)malloc(name_len + 2);
+  snprintf(tz_buf, name_len + 2, ":%s", tz_name_raw);
+
+  /* Save TZ before changing it — getenv returns a pointer into
+     environ which setenv invalidates, so strdup immediately. */
+  char *orig_tz = getenv("TZ");
+  char *saved_tz = orig_tz ? strdup(orig_tz) : NULL;
+
+  setenv("TZ", tz_buf, 1);
+  free(tz_buf);
+  tzset();
+
+  /* Floor division for negative timestamps (pre-1970) */
+  int64_t secs = micros >= 0
+    ? micros / 1000000
+    : (micros - 999999) / 1000000;
+
+  time_t t = (time_t)secs;
+  struct tm tm;
+  localtime_r(&t, &tm);
+  int64_t offset_sec = (int64_t)tm.tm_gmtoff;
+
+  /* Restore original TZ */
+  if (saved_tz) {
+    setenv("TZ", saved_tz, 1);
+    free(saved_tz);
+  } else {
+    unsetenv("TZ");
+  }
+  tzset();
+
+  CAMLlocal1(result);
+  result = caml_copy_int64(offset_sec);
+  CAMLreturn(result);
+}

--- a/src/ffi/chrono_stubs.c
+++ b/src/ffi/chrono_stubs.c
@@ -22,6 +22,47 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+
+static int find_zoneinfo_path(const char *tz_name, char *out, size_t out_size)
+{
+  /* Probe order: TZDIR env var, then known platform paths. */
+  static const char *candidates[] = {
+    NULL,                    /* slot 0 = TZDIR env var (filled at runtime) */
+    "/etc/zoneinfo",         /* Nix */
+    "/usr/share/zoneinfo",   /* standard Linux */
+    "/usr/lib/zoneinfo",     /* macOS / non-Nix Linux */
+  };
+  static const int n_candidates = sizeof(candidates) / sizeof(candidates[0]);
+
+  size_t name_len = strlen(tz_name);
+
+  for (int i = 0; i < n_candidates; i++) {
+    const char *dir;
+    if (i == 0) {
+      dir = getenv("TZDIR");
+      if (!dir) continue;
+    } else {
+      dir = candidates[i];
+    }
+
+    size_t dir_len = strlen(dir);
+    /* path = dir / tz_name + NUL */
+    size_t path_len = dir_len + 1 + name_len + 1;
+    if (path_len > out_size) continue;
+
+    if (access(dir, R_OK) != 0) continue;
+
+    memcpy(out, dir, dir_len);
+    out[dir_len] = '/';
+    memcpy(out + dir_len + 1, tz_name, name_len + 1);
+
+    if (access(out, R_OK) == 0) return 0;
+  }
+
+  return -1;
+}
 
 CAMLprim value caml_tz_offset(value v_micros, value v_tz_name)
 {
@@ -33,9 +74,24 @@ CAMLprim value caml_tz_offset(value v_micros, value v_tz_name)
      into the OCaml heap; any subsequent allocation
      (malloc, setenv, etc.) could trigger GC compaction. */
   const char *tz_name_raw = String_val(v_tz_name);
-  size_t name_len = strlen(tz_name_raw);
-  char *tz_buf = (char *)malloc(name_len + 2);
-  snprintf(tz_buf, name_len + 2, ":%s", tz_name_raw);
+
+  /* Resolve the full zoneinfo path for this tz_name. */
+  char zone_path[512];
+  if (find_zoneinfo_path(tz_name_raw, zone_path, sizeof(zone_path)) != 0) {
+    char err_msg[1024];
+    snprintf(err_msg, sizeof(err_msg),
+      "caml_tz_offset: cannot find zoneinfo file for '%s' "
+      "(searched: TZDIR, /etc/zoneinfo, /usr/share/zoneinfo, "
+      "/usr/lib/zoneinfo)",
+      tz_name_raw);
+    caml_failwith(err_msg);
+  }
+
+  size_t zone_path_len = strlen(zone_path);
+  /* TZ value = ":" + zone_path + NUL */
+  char *tz_buf = (char *)malloc(zone_path_len + 2);
+  tz_buf[0] = ':';
+  memcpy(tz_buf + 1, zone_path, zone_path_len + 1);
 
   /* Save TZ before changing it — getenv returns a pointer into
      environ which setenv invalidates, so strdup immediately. */

--- a/src/packages/chrono/chrono.ml
+++ b/src/packages/chrono/chrono.ml
@@ -5,6 +5,8 @@ let micros_per_minute = 60_000_000L
 let micros_per_hour = 3_600_000_000L
 let micros_per_day = 86_400_000_000L
 
+external tz_offset : int64 -> string -> int64 = "caml_tz_offset"
+
 let month_abbrevs = [|"Jan"; "Feb"; "Mar"; "Apr"; "May"; "Jun"; "Jul"; "Aug"; "Sep"; "Oct"; "Nov"; "Dec"|]
 let month_names = [|"January"; "February"; "March"; "April"; "May"; "June"; "July"; "August"; "September"; "October"; "November"; "December"|]
 let weekday_abbrevs = [|"Sun"; "Mon"; "Tue"; "Wed"; "Thu"; "Fri"; "Sat"|]
@@ -474,7 +476,14 @@ let date_diff_period left right =
   | _ -> Error.type_error "Date subtraction expects Date or Datetime values."
 
 let format_datetime_value micros tz format =
-  let year, month, day, hour, minute, second, micro = split_datetime_micros micros in
+  let adjusted_micros =
+    match tz with
+    | Some label ->
+        let offset_sec = tz_offset micros label in
+        Int64.add micros (Int64.mul offset_sec 1_000_000L)
+    | None -> micros
+  in
+  let year, month, day, hour, minute, second, micro = split_datetime_micros adjusted_micros in
   let wday = sunday_wday_from_days (days_from_civil year month day) in
   let replace = function
     | "%Y" -> Printf.sprintf "%04d" year
@@ -654,23 +663,41 @@ let round_date_impl function_name kind args _env =
         (Printf.sprintf "Function `%s` expects (Date|Datetime, String)." function_name)
   | values -> Error.arity_error_named function_name 2 (List.length values)
 
-let rec relabel_timezone function_name timezone = function
+let rec with_tz_scalar ~timezone = function
   | VDatetime (micros, _) -> VDatetime (micros, Some timezone)
-  | VVector arr -> VVector (Array.map (relabel_timezone function_name timezone) arr)
+  | VVector arr -> VVector (Array.map (with_tz_scalar ~timezone) arr)
   | VNA _ -> (VNA NAGeneric)
   | _ ->
       Error.type_error
         (Printf.sprintf
-           "Function `%s` expects a Datetime or Vector of datetimes."
-           function_name)
+           "Function `with_tz` expects a Datetime or Vector of datetimes.")
 
-let timezone_impl function_name args _env =
+let with_tz_impl args _env =
   match args with
-  | [value; VString timezone] -> relabel_timezone function_name timezone value
+  | [value; VString timezone] -> with_tz_scalar ~timezone value
   | [_; _] ->
       Error.type_error
-        (Printf.sprintf "Function `%s` expects (Datetime, String)." function_name)
-  | values -> Error.arity_error_named function_name 2 (List.length values)
+        "Function `with_tz` expects (Datetime, String)."
+  | values -> Error.arity_error_named "with_tz" 2 (List.length values)
+
+let rec force_tz_scalar ~timezone = function
+  | VDatetime (micros, _) ->
+      let offset_sec = tz_offset micros timezone in
+      let offset_micros = Int64.mul offset_sec 1_000_000L in
+      VDatetime (Int64.sub micros offset_micros, Some timezone)
+  | VVector arr -> VVector (Array.map (force_tz_scalar ~timezone) arr)
+  | VNA _ -> (VNA NAGeneric)
+  | _ ->
+      Error.type_error
+        "Function `force_tz` expects a Datetime or Vector of datetimes."
+
+let force_tz_impl args _env =
+  match args with
+  | [value; VString timezone] -> force_tz_scalar ~timezone value
+  | [_; _] ->
+      Error.type_error
+        "Function `force_tz` expects (Datetime, String)."
+  | values -> Error.arity_error_named "force_tz" 2 (List.length values)
 
 let leap_year_impl args _env =
   let rec apply = function
@@ -1573,8 +1600,8 @@ let register env =
   let env = Env.add "floor_date" (make_builtin ~name:"floor_date" 2 (round_date_impl "floor_date" `Floor)) env in
   let env = Env.add "ceiling_date" (make_builtin ~name:"ceiling_date" 2 (round_date_impl "ceiling_date" `Ceiling)) env in
   let env = Env.add "round_date" (make_builtin ~name:"round_date" 2 (round_date_impl "round_date" `Round)) env in
-  let env = Env.add "with_tz" (make_builtin ~name:"with_tz" 2 (timezone_impl "with_tz")) env in
-  let env = Env.add "force_tz" (make_builtin ~name:"force_tz" 2 (timezone_impl "force_tz")) env in
+  let env = Env.add "with_tz" (make_builtin ~name:"with_tz" 2 with_tz_impl) env in
+  let env = Env.add "force_tz" (make_builtin ~name:"force_tz" 2 force_tz_impl) env in
   let env = Env.add "interval" (make_builtin ~name:"interval" 2 interval_impl) env in
   let env = Env.add "%within%" (make_builtin ~name:"%within%" 2 within_impl) env in
   let env = Env.add "is_leap_year" (make_builtin ~name:"is_leap_year" 1 leap_year_impl) env in

--- a/tests/core/test_chrono.ml
+++ b/tests/core/test_chrono.ml
@@ -14,7 +14,7 @@ let run_tests _pass_count _fail_count _failures _eval_string _eval_string_env te
   test "ceiling_date rounds up hour" {|ceiling_date(ymd_hms("2024-01-15 09:37:42"), "hour")|} "Datetime(2024-01-15T10:00:00Z[UTC])";
   test "round_date rounds to nearest hour" {|round_date(ymd_hms("2024-01-15 09:37:42"), "hour")|} "Datetime(2024-01-15T10:00:00Z[UTC])";
   test "with_tz updates timezone label" {|with_tz(ymd_hms("2024-01-15 09:30:00"), "Europe/Paris")|} "Datetime(2024-01-15T09:30:00Z[Europe/Paris])";
-  test "force_tz updates timezone label" {|force_tz(ymd_hms("2024-01-15 09:30:00"), "Europe/Paris")|} "Datetime(2024-01-15T09:30:00Z[Europe/Paris])";
+  test "force_tz adjusts micros and updates timezone label" {|force_tz(ymd_hms("2024-01-15 09:30:00"), "Europe/Paris")|} "Datetime(2024-01-15T08:30:00Z[Europe/Paris])";
   test "is_leap_year on integer" {|is_leap_year(2024)|} "true";
   test "days_in_month on integers" {|days_in_month(2024, 2)|} "29";
   test "within interval" {|`%within%`(ymd("2024-01-15"), interval(ymd("2024-01-01"), ymd("2024-01-31")))|} "true";


### PR DESCRIPTION
- Add src/ffi/chrono_stubs.c — C stub caml_tz_offset using localtime_r with TZ= override, strdup save/restore, thread-safety note.
- Add external tz_offset declaration in chrono.ml.
- Split with_tz (relabel only) from force_tz (adjusts micros via new_micros = old_micros - offset_seconds * 1_000_000).
- Make format_datetime_value offset-aware — when tz label is present, add offset to micros before splitting into civil components for correct wall-clock display.
- Update force_tz test expectation to reflect micros adjustment.