### PR TITLE
fix(arrow): preserve DictionaryColumn type for all-NA factor output

### DIFF
--- a/src/arrow/arrow_bridge.ml
+++ b/src/arrow/arrow_bridge.ml
@@ -132,7 +132,8 @@ let values_to_column (values : value array) : Arrow_table.column_data =
       ) values)
   else if !has_factor && not !factor_inconsistent then
     Arrow_table.DictionaryColumn (Array.map (function
-      | VFactor (i, _, _) -> Some i
+      | VFactor (i, _, _) when i >= 0 -> Some i
+      | VFactor (_, _, _) -> None
       | VNA _ -> None
       | _ -> None
     ) values, !factor_levels, !factor_ordered)

--- a/src/packages/colcraft/factors.ml
+++ b/src/packages/colcraft/factors.ml
@@ -77,6 +77,16 @@ let to_factor_impl (args : (string option * value) list) _env =
              | Some idx -> VFactor (idx, levels, ordered)
              | None -> VNA Ast.NAGeneric (* NA if value is not in levels *))
       ) in
+      let factor_arr =
+        if Array.length factor_arr > 0
+           && Array.for_all (function VNA _ -> true | _ -> false) factor_arr
+        then
+          let arr = Array.copy factor_arr in
+          arr.(Array.length arr - 1) <- VFactor (-1, levels, ordered);
+          arr
+        else
+          factor_arr
+      in
       
       match x_val with
       | VVector _ | VList _ -> VVector factor_arr


### PR DESCRIPTION
to_factor with all-NA input was emitting VVector of all VNA values, which values_to_column converted to NAColumn, losing factor type metadata (levels, ordered). This broke the native Arrow path through mutate pipelines using to_factor on NA-bearing columns.

Fix: inject a VFactor (-1, levels, ordered) sentinel at the last position when the output is all-NA. In values_to_column, guard the DictionaryColumn builder with i >= 0; VFactor with negative index produces None (null) in the indices array, preserving the null bitmap. The sentinel is invisible on read-back (None -> VNA).

Closes the Arrow native column gap for factor columns created via to_factor with all-NA input.