### PR TITLE
feat(arrow): add NADatetime variant, fix all-NA type erasure in nativ…

### DIFF
--- a/src/arrow/arrow_bridge.ml
+++ b/src/arrow/arrow_bridge.ml
@@ -244,6 +244,19 @@ let row_to_dict (table : Arrow_table.t) (row_idx : int) : (string * value) list 
       (name, v)
     ) table.schema
 
+(** Map an Arrow column type to the corresponding T NA variant.
+    Used to preserve column type information when all values in a group
+    key column are absent (e.g. empty groups in group_by+summarize). *)
+let na_for_column_type (col : Arrow_table.column_data) : na_type =
+  match col with
+  | Arrow_table.IntColumn _ -> NAInt
+  | Arrow_table.FloatColumn _ -> NAFloat
+  | Arrow_table.BoolColumn _ -> NABool
+  | Arrow_table.StringColumn _ -> NAString
+  | Arrow_table.DateColumn _ -> NADate
+  | Arrow_table.DatetimeColumn _ -> NADatetime
+  | _ -> NAGeneric
+
 (** Create an Arrow table from T-Lang value column structures.
     
     @param columns List of column name to value array pairs.

--- a/src/arrow/arrow_bridge.ml
+++ b/src/arrow/arrow_bridge.ml
@@ -23,7 +23,7 @@ let column_to_values (col : Arrow_table.column_data) : value array =
   | Arrow_table.DateColumn a ->
       Array.map (fun v -> match v with Some d -> VDate d | None -> VNA NADate) a
   | Arrow_table.DatetimeColumn (a, tz) ->
-      Array.map (fun v -> match v with Some ts -> VDatetime (ts, tz) | None -> VNA NADate) a
+      Array.map (fun v -> match v with Some ts -> VDatetime (ts, tz) | None -> VNA NADatetime) a
   | Arrow_table.NAColumn n ->
       Array.make n ((VNA NAGeneric))
   | Arrow_table.DictionaryColumn (a, levels, ordered) ->
@@ -61,8 +61,8 @@ let value_at (col : Arrow_table.column_data) (row : int) : value =
       else VNA NADate
   | Arrow_table.DatetimeColumn (a, tz) ->
       if in_bounds (Array.length a) then
-        (match a.(row) with Some ts -> VDatetime (ts, tz) | None -> VNA NADate)
-      else VNA NADate
+        (match a.(row) with Some ts -> VDatetime (ts, tz) | None -> VNA NADatetime)
+      else VNA NADatetime
   | Arrow_table.NAColumn _ -> (VNA NAGeneric)
   | Arrow_table.DictionaryColumn (a, levels, ordered) ->
       if in_bounds (Array.length a) then
@@ -116,12 +116,31 @@ let values_to_column (values : value array) : Arrow_table.column_data =
          | _ ->
              has_factor := true;
              if not !factor_ordered then factor_ordered := ordered)
-    | VNA _ -> ()
+    | VNA NABool -> has_bool := true
+    | VNA NAInt -> has_int := true
+    | VNA NAFloat -> has_float := true
+    | VNA NAString -> has_string := true
+    | VNA NADate -> has_date := true
+    | VNA NADatetime -> has_datetime := true
+    | VNA NAGeneric -> ()
     | _ -> has_string := true; all_na := false  (* fallback to string *)
   ) values;
-  if !all_na then
-    Arrow_table.NAColumn (Array.length values)
-  else if !has_dataframe then
+  if !all_na then begin
+    if !has_datetime then
+      Arrow_table.DatetimeColumn (Array.map (fun _ -> None) values, None)
+    else if !has_date then
+      Arrow_table.DateColumn (Array.map (fun _ -> None) values)
+    else if !has_int then
+      Arrow_table.IntColumn (Array.map (fun _ -> None) values)
+    else if !has_float then
+      Arrow_table.FloatColumn (Array.map (fun _ -> None) values)
+    else if !has_bool then
+      Arrow_table.BoolColumn (Array.map (fun _ -> None) values)
+    else if !has_string then
+      Arrow_table.StringColumn (Array.map (fun _ -> None) values)
+    else
+      Arrow_table.NAColumn (Array.length values)
+  end else if !has_dataframe then
     if !has_int || !has_float || !has_bool || !has_string || !has_date || !has_datetime || !has_factor || !factor_inconsistent then
       raise (Invalid_argument "values_to_column: mixed DataFrame and non-DataFrame values cannot be stored in a single column")
     else
@@ -215,7 +234,7 @@ let row_to_dict (table : Arrow_table.t) (row_idx : int) : (string * value) list 
         | Arrow_table.DateColumn a ->
             (match a.(row_idx) with Some d -> VDate d | None -> VNA NADate)
         | Arrow_table.DatetimeColumn (a, tz) ->
-            (match a.(row_idx) with Some ts -> VDatetime (ts, tz) | None -> VNA NADate)
+            (match a.(row_idx) with Some ts -> VDatetime (ts, tz) | None -> VNA NADatetime)
         | Arrow_table.NAColumn _ -> (VNA NAGeneric)
         | Arrow_table.DictionaryColumn (a, levels, ordered) ->
             (match a.(row_idx) with Some i -> VFactor (i, levels, ordered) | None -> (VNA NAGeneric))

--- a/src/arrow/arrow_bridge.mli
+++ b/src/arrow/arrow_bridge.mli
@@ -18,6 +18,9 @@ val column_to_values : Arrow_table.column_data -> value array
     (e.g., VNA NAInt for IntColumn) if the index is out of bounds. *)
 val value_at : Arrow_table.column_data -> int -> value
 
+(** Map an Arrow column type to the corresponding T NA variant. *)
+val na_for_column_type : Arrow_table.column_data -> na_type
+
 val values_to_column : value array -> Arrow_table.column_data
 
 (** Extract a specific row from an Arrow table as an associative dictionary of field names to values.

--- a/src/arrow/arrow_column.ml
+++ b/src/arrow/arrow_column.ml
@@ -99,7 +99,7 @@ let get_value_at (view : column_view) (idx : int) : Ast.value =
     | Arrow_table.DateColumn a ->
       (match a.(idx) with Some d -> Ast.VDate d | None -> Ast.VNA Ast.NADate)
     | Arrow_table.DatetimeColumn (a, tz) ->
-      (match a.(idx) with Some ts -> Ast.VDatetime (ts, tz) | None -> Ast.VNA Ast.NADate)
+      (match a.(idx) with Some ts -> Ast.VDatetime (ts, tz) | None -> Ast.VNA Ast.NADatetime)
     | Arrow_table.NAColumn _ -> Ast.VNA Ast.NAGeneric
     | Arrow_table.DictionaryColumn (a, levels, ordered) ->
       (match a.(idx) with Some i -> Ast.VFactor (i, levels, ordered) | None -> Ast.VNA Ast.NAGeneric)

--- a/src/arrow/arrow_compute.ml
+++ b/src/arrow/arrow_compute.ml
@@ -533,11 +533,15 @@ and group_aggregate_ocaml (grouped : grouped_table) (agg_name : string) (col_nam
       let key_col_array = Array.of_list key_col_values in
       let key_result_cols = List.mapi (fun ki k ->
         let key_vals = key_col_array.(ki) in
+        let empty_na = match Arrow_table.get_column t k with
+          | Some col -> Ast.VNA (Arrow_bridge.na_for_column_type col)
+          | None -> Ast.(VNA NAGeneric)
+        in
         let col = Array.init n_groups (fun g_idx ->
           let (_, indices) = groups_array.(g_idx) in
           match indices with
           | first :: _ -> key_vals.(first)
-          | [] -> Ast.(VNA NAGeneric)
+          | [] -> empty_na
         ) in
         (k, col)
       ) grouped.group_keys in

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -17,6 +17,7 @@ type na_type =
   | NAFloat
   | NAString
   | NADate
+  | NADatetime
   | NAGeneric
 
 (** Symbolic error codes *)
@@ -744,6 +745,7 @@ module Utils = struct
     | NAFloat -> "Float"
     | NAString -> "String"
     | NADate -> "Date"
+    | NADatetime -> "Datetime"
     | NAGeneric -> ""
 
   let rec typ_to_string = function

--- a/src/packages/colcraft/expand.ml
+++ b/src/packages/colcraft/expand.ml
@@ -32,6 +32,8 @@ let get_col_vals df col_name =
   | Some (FloatColumn a) -> Array.to_list a |> List.map (function Some f -> VFloat f | None -> (VNA NAGeneric)) |> unique_sorted
   | Some (StringColumn a) -> Array.to_list a |> List.map (function Some s -> VString s | None -> (VNA NAGeneric)) |> unique_sorted
   | Some (BoolColumn a) -> Array.to_list a |> List.map (function Some b -> VBool b | None -> (VNA NAGeneric)) |> unique_sorted
+  | Some (DateColumn a) -> Array.to_list a |> List.map (function Some d -> VDate d | None -> VNA NADate) |> unique_sorted
+  | Some (DatetimeColumn (a, tz)) -> Array.to_list a |> List.map (function Some ts -> VDatetime (ts, tz) | None -> VNA NADatetime) |> unique_sorted
   | _ -> [(VNA NAGeneric)]
 
 let get_nested_vals df col_names =
@@ -45,6 +47,8 @@ let get_nested_vals df col_names =
           | Some (FloatColumn a) -> (match a.(i) with Some x -> VFloat x | None -> (VNA NAGeneric))
           | Some (StringColumn a) -> (match a.(i) with Some x -> VString x | None -> (VNA NAGeneric))
           | Some (BoolColumn a) -> (match a.(i) with Some x -> VBool x | None -> (VNA NAGeneric))
+          | Some (DateColumn a) -> (match a.(i) with Some x -> VDate x | None -> VNA NADate)
+          | Some (DatetimeColumn (a, tz)) -> (match a.(i) with Some x -> VDatetime (x, tz) | None -> VNA NADatetime)
           | _ -> (VNA NAGeneric)
         in v :: get_row i ns
   in

--- a/src/packages/colcraft/joins.ml
+++ b/src/packages/colcraft/joins.ml
@@ -125,11 +125,11 @@ let right_projection left_names right_names by =
   ) [] right_names
   |> List.rev
 
-let merge_left_right ~left_names ~right_projection ~by left_row right_row_opt =
+let merge_left_right ~left_names ~right_projection ~by ~right_na_of left_row right_row_opt =
   let right_lookup name =
     match right_row_opt with
     | Some row -> assoc_value row name
-    | None -> (VNA NAGeneric)
+    | None -> VNA (right_na_of name)
   in
   let left_pairs =
     List.map (fun name -> (name, assoc_value left_row name)) left_names
@@ -151,7 +151,7 @@ let merge_left_right ~left_names ~right_projection ~by left_row right_row_opt =
            (name, value))
   |> fun pairs -> pairs @ right_pairs
 
-let rows_to_dataframe ?(group_keys=[]) column_order rows =
+let rows_to_dataframe ?(group_keys=[]) ?(column_types=(fun _ -> NAGeneric)) column_order rows =
   let nrows = List.length rows in
   let columns =
     List.map (fun name ->
@@ -160,7 +160,7 @@ let rows_to_dataframe ?(group_keys=[]) column_order rows =
           (List.map (fun row ->
                match List.assoc_opt name row with
                | Some value -> value
-               | None -> (VNA NAGeneric)) rows)
+               | None -> VNA (column_types name)) rows)
       in
        (name, values)
      ) column_order
@@ -181,6 +181,24 @@ let join_impl kind named_args _env =
             let left_names = Arrow_table.column_names left.arrow_table in
             let right_names = Arrow_table.column_names right.arrow_table in
             let right_projection = right_projection left_names right_names by in
+            let right_na_of name =
+              match Arrow_table.get_column right.arrow_table name with
+              | Some col -> Arrow_bridge.na_for_column_type col
+              | None -> NAGeneric
+            in
+            let left_na_of name =
+              match Arrow_table.get_column left.arrow_table name with
+              | Some col -> Arrow_bridge.na_for_column_type col
+              | None -> NAGeneric
+            in
+            let column_types name =
+              match Arrow_table.get_column left.arrow_table name with
+              | Some col -> Arrow_bridge.na_for_column_type col
+              | None ->
+                match Arrow_table.get_column right.arrow_table name with
+                | Some col -> Arrow_bridge.na_for_column_type col
+                | None -> NAGeneric
+            in
             let output_columns =
               match kind with
               | Semi | Anti -> left_names
@@ -217,13 +235,13 @@ let join_impl kind named_args _env =
                   joined_rows := List.map (fun name -> (name, assoc_value left_row name)) left_names :: !joined_rows
               | (Left | Full), [] ->
                   joined_rows :=
-                    merge_left_right ~left_names ~right_projection ~by left_row None :: !joined_rows
+                    merge_left_right ~left_names ~right_projection ~by ~right_na_of left_row None :: !joined_rows
               | Inner, [] -> ()
               | _, indices ->
                   List.iter (fun idx ->
                     right_matches.(idx) <- true;
                     joined_rows :=
-                      merge_left_right ~left_names ~right_projection ~by left_row (Some right_rows.(idx))
+                      merge_left_right ~left_names ~right_projection ~by ~right_na_of left_row (Some right_rows.(idx))
                       :: !joined_rows
                   ) indices
             ) left_rows;
@@ -242,9 +260,9 @@ let join_impl kind named_args _env =
                               if List.mem name by then
                                 (name, assoc_value row name)
                               else
-                                (name, (VNA NAGeneric))) left_names
+                                (name, VNA (left_na_of name))) left_names
                           in
-                           Some (merge_left_right ~left_names ~right_projection ~by left_stub (Some row)))
+                           Some (merge_left_right ~left_names ~right_projection ~by ~right_na_of left_stub (Some row)))
                   in
                   List.rev !joined_rows @ unmatched_right_rows
               | _ -> List.rev !joined_rows
@@ -254,7 +272,7 @@ let join_impl kind named_args _env =
               | Left | Inner | Semi | Anti -> left.group_keys
               | Full -> []
             in
-            rows_to_dataframe ~group_keys:preserved_group_keys output_columns joined_rows)
+            rows_to_dataframe ~group_keys:preserved_group_keys ~column_types output_columns joined_rows)
   | _ :: _ :: _ :: _ ->
       Error.make_error ArityError
         "Join functions accept exactly two positional DataFrame arguments and at most one join-key argument (or named `by`)."

--- a/src/packages/colcraft/pivot_wider.ml
+++ b/src/packages/colcraft/pivot_wider.ml
@@ -71,8 +71,8 @@ let register env =
                | Some (FloatColumn a) -> (match a.(i) with Some f -> VFloat f | None -> (VNA NAGeneric))
                | Some (IntColumn a) -> (match a.(i) with Some v -> VInt v | None -> (VNA NAGeneric))
                | Some (BoolColumn a) -> (match a.(i) with Some b -> VBool b | None -> (VNA NAGeneric))
-               | Some (DateColumn a) -> (match a.(i) with Some d -> VDate d | None -> (VNA NAGeneric))
-               | Some (DatetimeColumn (a, tz)) -> (match a.(i) with Some ts -> VDatetime (ts, tz) | None -> (VNA NAGeneric))
+               | Some (DateColumn a) -> (match a.(i) with Some d -> VDate d | None -> VNA NADate)
+               | Some (DatetimeColumn (a, tz)) -> (match a.(i) with Some ts -> VDatetime (ts, tz) | None -> VNA NADatetime)
                | _ -> (VNA NAGeneric)
              ) id_cols
            in

--- a/src/packages/colcraft/summarize.ml
+++ b/src/packages/colcraft/summarize.ml
@@ -225,14 +225,18 @@ let register ~eval_call ~eval_expr:(_eval_expr : Ast.value Ast.Env.t -> Ast.expr
                     | None -> (k, [||])
                   ) df.group_keys in
                   let key_result_cols = List.map (fun k ->
+                    let empty_na = match Arrow_table.get_column df.arrow_table k with
+                      | Some col -> VNA (Arrow_bridge.na_for_column_type col)
+                      | None -> VNA NAGeneric
+                    in
                     let col = Array.init n_groups (fun g_idx ->
                       let (_, indices) = groups_array.(g_idx) in
                       match indices with
                       | first :: _ ->
                         let key_vals = match List.find_opt (fun (kn, _) -> kn = k) key_col_values with
                           | Some (_, v) -> v | None -> [||] in
-                        if first < Array.length key_vals then key_vals.(first) else (VNA NAGeneric)
-                      | [] -> (VNA NAGeneric)
+                        if first < Array.length key_vals then key_vals.(first) else empty_na
+                      | [] -> empty_na
                     ) in
                     (k, col)
                   ) df.group_keys in

--- a/src/packages/colcraft/t_complete.ml
+++ b/src/packages/colcraft/t_complete.ml
@@ -64,7 +64,7 @@ let register env =
               | Some (FloatColumn a) -> (match a.(i) with Some x -> VFloat x | None -> (VNA NAGeneric))
               | Some (BoolColumn a) -> (match a.(i) with Some x -> VBool x | None -> (VNA NAGeneric))
               | Some (DateColumn a) -> (match a.(i) with Some x -> VDate x | None -> VNA NADate)
-              | Some (DatetimeColumn (a, tz)) -> (match a.(i) with Some x -> VDatetime (x, tz) | None -> VNA NADate)
+              | Some (DatetimeColumn (a, tz)) -> (match a.(i) with Some x -> VDatetime (x, tz) | None -> VNA NADatetime)
               | _ -> (VNA NAGeneric)
            in
 

--- a/src/packages/colcraft/window_offset.ml
+++ b/src/packages/colcraft/window_offset.ml
@@ -7,6 +7,20 @@ let to_value_array label = function
   | VNA _ -> Error (Error.na_value_error label)
   | _ -> Error (Error.type_error (Printf.sprintf "Function `%s` expects a Vector or List." label))
 
+(** Determine the appropriate NA fill value for lag/lead padding
+    by inspecting the first element of the input array. *)
+let na_fill_for_array (arr : value array) : value =
+  if Array.length arr = 0 then VNA NAGeneric
+  else match arr.(0) with
+    | VInt _ -> VNA NAInt
+    | VFloat _ -> VNA NAFloat
+    | VBool _ -> VNA NABool
+    | VString _ -> VNA NAString
+    | VDate _ -> VNA NADate
+    | VDatetime _ -> VNA NADatetime
+    | VNA na_t -> VNA na_t
+    | _ -> VNA NAGeneric
+
 let register env =
   (*
   --# Lag values
@@ -32,14 +46,15 @@ let register env =
         (match to_value_array "lag" arg with
          | Error e -> e
          | Ok arr ->
-           let n = Array.length arr in
-           if n = 0 then VVector [||]
-           else
-             let result = Array.make n ((VNA NAGeneric)) in
-             for i = 1 to n - 1 do
-               result.(i) <- arr.(i - 1)
-             done;
-             VVector result)
+            let n = Array.length arr in
+            if n = 0 then VVector [||]
+            else
+              let fill = na_fill_for_array arr in
+              let result = Array.make n fill in
+              for i = 1 to n - 1 do
+                result.(i) <- arr.(i - 1)
+              done;
+              VVector result)
       | [arg; VInt offset] when offset >= 0 ->
         (match to_value_array "lag" arg with
          | Error e -> e
@@ -47,7 +62,8 @@ let register env =
            let n = Array.length arr in
            if n = 0 then VVector [||]
            else
-             let result = Array.make n ((VNA NAGeneric)) in
+             let fill = na_fill_for_array arr in
+             let result = Array.make n fill in
              for i = offset to n - 1 do
                result.(i) <- arr.(i - offset)
              done;
@@ -82,14 +98,15 @@ let register env =
         (match to_value_array "lead" arg with
          | Error e -> e
          | Ok arr ->
-           let n = Array.length arr in
-           if n = 0 then VVector [||]
-           else
-             let result = Array.make n ((VNA NAGeneric)) in
-             for i = 0 to n - 2 do
-               result.(i) <- arr.(i + 1)
-             done;
-             VVector result)
+            let n = Array.length arr in
+            if n = 0 then VVector [||]
+            else
+              let fill = na_fill_for_array arr in
+              let result = Array.make n fill in
+              for i = 0 to n - 2 do
+                result.(i) <- arr.(i + 1)
+              done;
+              VVector result)
       | [arg; VInt offset] when offset >= 0 ->
         (match to_value_array "lead" arg with
          | Error e -> e
@@ -97,7 +114,8 @@ let register env =
            let n = Array.length arr in
            if n = 0 then VVector [||]
            else
-             let result = Array.make n ((VNA NAGeneric)) in
+             let fill = na_fill_for_array arr in
+             let result = Array.make n fill in
              for i = 0 to n - 1 - offset do
                result.(i) <- arr.(i + offset)
              done;

--- a/src/packages/dataframe/t_dataframe.ml
+++ b/src/packages/dataframe/t_dataframe.ml
@@ -152,7 +152,7 @@ let register env =
                       | Arrow_table.DateColumn data ->
                           VVector (Array.map (function Some d -> VDate d | None -> VNA NADate) data)
                       | Arrow_table.DatetimeColumn (data, tz) ->
-                          VVector (Array.map (function Some ts -> VDatetime (ts, tz) | None -> VNA NADate) data)
+                          VVector (Array.map (function Some ts -> VDatetime (ts, tz) | None -> VNA NADatetime) data)
                       | Arrow_table.NAColumn n ->
                           VVector (Array.make n ((VNA NAGeneric)))
                      | Arrow_table.DictionaryColumn (data, levels, ordered) ->

--- a/tests/arrow/test_arrow_integration.ml
+++ b/tests/arrow/test_arrow_integration.ml
@@ -2293,11 +2293,11 @@ let run_tests pass_count fail_count _failures _eval_string eval_string_env test 
 
   test "lag in mutate (vector input)"
     {|lag([10, 20, 30, 40])|}
-    "Vector[NA, 10, 20, 30]";
-
-  test "lead in mutate (vector input)"
-    {|lead([10, 20, 30, 40])|}
-    "Vector[20, 30, 40, NA]";
+    "Vector[NA(Int), 10, 20, 30]";
+ 
+   test "lead in mutate (vector input)"
+     {|lead([10, 20, 30, 40])|}
+     "Vector[20, 30, 40, NA(Int)]";
 
   print_newline ();
 

--- a/tests/colcraft/test_window.ml
+++ b/tests/colcraft/test_window.ml
@@ -122,24 +122,24 @@ let run_tests pass_count fail_count _failures _eval_string _eval_string_env test
   (* lag: shift forward, fill with NA *)
   test "lag simple"
     {|lag([1, 2, 3, 4, 5])|}
-    "Vector[NA, 1, 2, 3, 4]";
+    "Vector[NA(Int), 1, 2, 3, 4]";
   test "lag with offset 2"
     {|lag([1, 2, 3, 4, 5], 2)|}
-    "Vector[NA, NA, 1, 2, 3]";
+    "Vector[NA(Int), NA(Int), 1, 2, 3]";
   test "lag empty"
     {|lag([])|}
     "Vector[]";
   test "lag strings"
     {|lag(["a", "b", "c"])|}
-    {|Vector[NA, "a", "b"]|};
+    {|Vector[NA(String), "a", "b"]|};
 
   (* lead: shift backward, fill with NA *)
   test "lead simple"
     {|lead([1, 2, 3, 4, 5])|}
-    "Vector[2, 3, 4, 5, NA]";
+    "Vector[2, 3, 4, 5, NA(Int)]";
   test "lead with offset 2"
     {|lead([1, 2, 3, 4, 5], 2)|}
-    "Vector[3, 4, 5, NA, NA]";
+    "Vector[3, 4, 5, NA(Int), NA(Int)]";
   test "lead empty"
     {|lead([])|}
     "Vector[]";
@@ -259,10 +259,10 @@ let run_tests pass_count fail_count _failures _eval_string _eval_string_env test
   (* lag/lead with NA in input — NA passes through *)
   test "lag with NA in input"
     {|lag([1, NA, 3, 4])|}
-    "Vector[NA, 1, NA, 3]";
+    "Vector[NA(Int), 1, NA, 3]";
   test "lead with NA in input"
     {|lead([1, NA, 3, 4])|}
-    "Vector[NA, 3, 4, NA]";
+    "Vector[NA, 3, 4, NA(Int)]";
 
   (* Error cases for cumulative *)
   test "cummin with string"

--- a/tests/colcraft/test_window_edge_cases.ml
+++ b/tests/colcraft/test_window_edge_cases.ml
@@ -6,10 +6,10 @@ let run_tests _pass_count _fail_count _failures _eval_string _eval_string_env te
   (* lag with offset larger than array length — all NA *)
   test "lag offset > length"
     {|lag([1, 2, 3], 10)|}
-    "Vector[NA, NA, NA]";
+    "Vector[NA(Int), NA(Int), NA(Int)]";
   test "lag offset = length"
     {|lag([1, 2, 3], 3)|}
-    "Vector[NA, NA, NA]";
+    "Vector[NA(Int), NA(Int), NA(Int)]";
   test "lag offset = 0"
     {|lag([1, 2, 3], 0)|}
     "Vector[1, 2, 3]";
@@ -17,10 +17,10 @@ let run_tests _pass_count _fail_count _failures _eval_string _eval_string_env te
   (* lead with offset larger than array length — all NA *)
   test "lead offset > length"
     {|lead([1, 2, 3], 10)|}
-    "Vector[NA, NA, NA]";
+    "Vector[NA(Int), NA(Int), NA(Int)]";
   test "lead offset = length"
     {|lead([1, 2, 3], 3)|}
-    "Vector[NA, NA, NA]";
+    "Vector[NA(Int), NA(Int), NA(Int)]";
   test "lead offset = 0"
     {|lead([1, 2, 3], 0)|}
     "Vector[1, 2, 3]";
@@ -28,10 +28,10 @@ let run_tests _pass_count _fail_count _failures _eval_string _eval_string_env te
   (* lag/lead on single element *)
   test "lag single element"
     {|lag([42])|}
-    "Vector[NA]";
+    "Vector[NA(Int)]";
   test "lead single element"
     {|lead([42])|}
-    "Vector[NA]";
+    "Vector[NA(Int)]";
 
   print_newline ();
 

--- a/tests/golden/test_golden.ml
+++ b/tests/golden/test_golden.ml
@@ -394,25 +394,25 @@ Valid arguments: pipeline_script (positional/named), name, file.")|};
      => NA, 85.5, 92.3, 78.9, 88.1 *)
   test "golden window: lag matches dplyr"
     {|lag([85.5, 92.3, 78.9, 88.1, 95.0])|}
-    "Vector[NA, 85.5, 92.3, 78.9, 88.1]";
+    "Vector[NA(Float), 85.5, 92.3, 78.9, 88.1]";
 
   (* R: dplyr::lead(c(85.5, 92.3, 78.9, 88.1, 95.0))
      => 92.3, 78.9, 88.1, 95.0, NA *)
   test "golden window: lead matches dplyr"
     {|lead([85.5, 92.3, 78.9, 88.1, 95.0])|}
-    "Vector[92.3, 78.9, 88.1, 95., NA]";
+    "Vector[92.3, 78.9, 88.1, 95., NA(Float)]";
 
   (* R: dplyr::lag(c(1, 2, 3, 4, 5), 2)
      => NA, NA, 1, 2, 3 *)
   test "golden window: lag with offset 2 matches dplyr"
     {|lag([1, 2, 3, 4, 5], 2)|}
-    "Vector[NA, NA, 1, 2, 3]";
+    "Vector[NA(Int), NA(Int), 1, 2, 3]";
 
   (* R: dplyr::lead(c(1, 2, 3, 4, 5), 2)
      => 3, 4, 5, NA, NA *)
   test "golden window: lead with offset 2 matches dplyr"
     {|lead([1, 2, 3, 4, 5], 2)|}
-    "Vector[3, 4, 5, NA, NA]";
+    "Vector[3, 4, 5, NA(Int), NA(Int)]";
 
   (* --- Cumulative functions --- *)
 
@@ -490,12 +490,12 @@ Valid arguments: pipeline_script (positional/named), name, file.")|};
   (* R: dplyr::lag(c(1, NA, 3)) => NA, 1, NA *)
   test "golden window NA: lag propagates NA"
     {|lag([1, NA, 3])|}
-    "Vector[NA, 1, NA]";
+    "Vector[NA(Int), 1, NA]";
 
   (* R: dplyr::lead(c(1, NA, 3)) => NA, 3, NA *)
   test "golden window NA: lead propagates NA"
     {|lead([1, NA, 3])|}
-    "Vector[NA, 3, NA]";
+    "Vector[NA, 3, NA(Int)]";
 
   (* R: cumsum(c(1, NA, 3)) => 1, NA, NA *)
   test "golden window NA: cumsum propagates NA"


### PR DESCRIPTION
…e write path

Adds NADatetime to the na_type variant in ast.ml, disambiguating datetime NAs from date NAs. All DatetimeColumn read-back paths now emit VNA NADatetime instead of VNA NADate.

Implements Approach C in Arrow_bridge.values_to_column: type-specific VNA tags (NAInt, NAFloat, etc.) now set the corresponding type flag, so all-NA columns are routed to the correct typed Arrow column instead of always falling back to NAColumn. This preserves column types through the native Arrow write/read cycle.