### PR TITLE
feat(r): auto-detect R git pkg deps from DESCRIPTION/NAMESPACE

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -76,7 +76,7 @@
     ; packages/explain
     intent_fields intent_get t_explain explain_json
    ; package_manager
-   version nixpkgs_date package_types toml_parser template_engine scaffold nix_generator renv_resolver test_discovery package_doctor release_manager documentation_manager update_manager package_loader
+   version nixpkgs_date package_types toml_parser template_engine scaffold nix_generator renv_resolver r_description_resolver test_discovery package_doctor release_manager documentation_manager update_manager package_loader
    ; tdoc
    tdoc_types tdoc_parser tdoc_registry tdoc_markdown tdoc_json
  )

--- a/src/package_manager/nix_generator.ml
+++ b/src/package_manager/nix_generator.ml
@@ -621,6 +621,10 @@ let install_flake
         r_deps, r_git_deps
     else r_deps, r_git_deps
   in
+  let r_git_deps =
+    if r_git_deps = [] then []
+    else R_description_resolver.auto_detect_all ~cache_root:(Filename.concat dir ".t_r_pkg_cache") ~deps:r_git_deps
+  in
   let content = match kind with
     | Project ->
       generate_project_flake ~project_name:name ~nixpkgs_date ~t_version ~deps ~r_deps ~r_git_deps ~py_deps ~py_version ~py_resolver ~py_workspace ~jl_deps ~jl_version ~additional_tools ~latex_pkgs ~use_atelier ()

--- a/src/package_manager/r_description_resolver.ml
+++ b/src/package_manager/r_description_resolver.ml
@@ -229,8 +229,9 @@ let rec fetch_commit ~cache_root ~url ~rev ~name =
     | Error _ ->
       remove_path_recursively cache_dir;
       fetch_commit ~cache_root ~url ~rev ~name
-  end else begin
+  end   else begin
     (try Unix.mkdir cache_root 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+    (try Unix.mkdir cache_dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
     match run_git ~dir:cache_dir ["init"] with
     | Error msg -> Error msg
     | Ok () ->

--- a/src/package_manager/r_description_resolver.ml
+++ b/src/package_manager/r_description_resolver.ml
@@ -44,7 +44,7 @@ let parse_dep_list value =
       | Some pos -> String.trim (String.sub s 0 pos)
       | None -> s
     )
-    |> List.filter (fun s -> s <> "" && s <> "R")
+    |> List.filter (fun s -> s <> "")
 
 let parse_description_deps content =
   let fields = parse_dcf_content content in
@@ -65,24 +65,35 @@ let parse_remotes_field value =
     String.split_on_char ',' value
     |> List.map String.trim
     |> List.filter (fun s -> s <> "")
-    |> List.map (fun s ->
-      let s = if String.starts_with ~prefix:"github::" s then
-        String.sub s 8 (String.length s - 8)
-      else if String.starts_with ~prefix:"gitlab::" s then
-        String.sub s 8 (String.length s - 8)
-      else s in
-      let s = match String.index_opt s '#' with
-        | Some pos -> String.trim (String.sub s 0 pos)
-        | None -> s in
-      let repo_part =
-        let parts = String.split_on_char '/' s in
-        List.fold_left (fun _ p -> p) "" parts
+    |> List.filter_map (fun s ->
+      let has_unsupported_prefix =
+        match String.index_opt s ':' with
+        | Some pos ->
+          let prefix = String.sub s 0 pos in
+          prefix <> "github" && prefix <> "gitlab"
+        | None -> false
       in
-      match String.index_opt repo_part '@' with
-      | Some pos -> String.trim (String.sub repo_part 0 pos)
-      | None -> String.trim repo_part
+      if has_unsupported_prefix then None
+      else
+        let s = if String.starts_with ~prefix:"github::" s then
+          String.sub s 8 (String.length s - 8)
+        else if String.starts_with ~prefix:"gitlab::" s then
+          String.sub s 8 (String.length s - 8)
+        else s in
+        let s = match String.index_opt s '#' with
+          | Some pos -> String.trim (String.sub s 0 pos)
+          | None -> s in
+        let repo_part =
+          let parts = String.split_on_char '/' s in
+          List.fold_left (fun _ p -> p) "" parts
+        in
+        let final_name =
+          match String.index_opt repo_part '@' with
+          | Some pos -> String.trim (String.sub repo_part 0 pos)
+          | None -> String.trim repo_part
+        in
+        if final_name <> "" then Some final_name else None
     )
-    |> List.filter (fun s -> s <> "")
 
 let parse_namespace_deps content =
   let lines = String.split_on_char '\n' content in
@@ -90,21 +101,25 @@ let parse_namespace_deps content =
     let trimmed = String.trim line in
     if String.starts_with ~prefix:"import(" trimmed then
       let inner = String.sub trimmed 7 (String.length trimmed - 8) in
-      let pkg = String.trim inner in
-      let pkg = if String.length pkg >= 2 && (pkg.[0] = '"' || pkg.[0] = '\'') then
-        String.sub pkg 1 (String.length pkg - 2)
-      else pkg in
-      Some pkg
+      let first_part =
+        match String.split_on_char ',' inner with
+        | first :: _ -> String.trim first
+        | [] -> String.trim inner
+      in
+      let pkg = if String.length first_part >= 2 && (first_part.[0] = '"' || first_part.[0] = '\'') then
+        String.sub first_part 1 (String.length first_part - 2)
+      else first_part in
+      if pkg <> "" then Some pkg else None
     else if String.starts_with ~prefix:"importFrom(" trimmed then
       let inner = String.sub trimmed 11 (String.length trimmed - 12) in
-      match String.index_opt inner ',' with
-      | Some pos ->
-        let pkg = String.trim (String.sub inner 0 pos) in
+      match String.split_on_char ',' inner with
+      | pkg_part :: _ ->
+        let pkg = String.trim pkg_part in
         let pkg = if String.length pkg >= 2 && (pkg.[0] = '"' || pkg.[0] = '\'') then
           String.sub pkg 1 (String.length pkg - 2)
         else pkg in
-        Some pkg
-      | None -> Some (String.trim inner)
+        if pkg <> "" then Some pkg else None
+      | [] -> None
     else
       None
   in
@@ -122,22 +137,36 @@ let run_git ~dir args =
     let out_buf = Buffer.create 1024 in
     let err_buf = Buffer.create 1024 in
     let buf = Bytes.create 4096 in
-    let rec drain () =
-      let fd_out = Unix.descr_of_in_channel ch_in in
-      let fd_err = Unix.descr_of_in_channel ch_err in
-      let ready, _, _ = Unix.select [fd_out; fd_err] [] [] 60.0 in
-      let got_data = ref false in
-      if List.mem fd_out ready then (
-        let n = try input ch_in buf 0 (Bytes.length buf) with End_of_file -> 0 in
-        if n > 0 then (Buffer.add_subbytes out_buf buf 0 n; got_data := true)
-      );
-      if List.mem fd_err ready then (
-        let n = try input ch_err buf 0 (Bytes.length buf) with End_of_file -> 0 in
-        if n > 0 then (Buffer.add_subbytes err_buf buf 0 n; got_data := true)
-      );
-      if !got_data then drain ()
+    let rec drain eof_out eof_err =
+      if eof_out && eof_err then ()
+      else
+        let fd_out = Unix.descr_of_in_channel ch_in in
+        let fd_err = Unix.descr_of_in_channel ch_err in
+        let read_fds =
+          let l = [] in
+          let l = if not eof_out then fd_out :: l else l in
+          let l = if not eof_err then fd_err :: l else l in
+          l
+        in
+        match Unix.select read_fds [] [] 60.0 with
+        | ready, _, _ ->
+          let next_eof_out = ref eof_out in
+          let next_eof_err = ref eof_err in
+          if List.mem fd_out ready then (
+            let n = try input ch_in buf 0 (Bytes.length buf) with End_of_file -> 0 in
+            if n > 0 then Buffer.add_subbytes out_buf buf 0 n
+            else next_eof_out := true
+          );
+          if List.mem fd_err ready then (
+            let n = try input ch_err buf 0 (Bytes.length buf) with End_of_file -> 0 in
+            if n > 0 then Buffer.add_subbytes err_buf buf 0 n
+            else next_eof_err := true
+          );
+          drain !next_eof_out !next_eof_err
+        | exception Unix.Unix_error (Unix.EINTR, _, _) ->
+          drain eof_out eof_err
     in
-    drain ();
+    drain false false;
     let status = Unix.close_process_full (ch_in, ch_out, ch_err) in
     match status with
     | Unix.WEXITED 0 -> Ok ()
@@ -151,13 +180,16 @@ let run_git ~dir args =
     Error (Printf.sprintf "git %s raised: %s" (String.concat " " args) (Printexc.to_string exn))
 
 let rec remove_path_recursively path =
-  if Sys.file_exists path then
-    if Sys.is_directory path then begin
+  try
+    let stats = Unix.lstat path in
+    match stats.st_kind with
+    | Unix.S_DIR ->
       Sys.readdir path
       |> Array.iter (fun name -> remove_path_recursively (Filename.concat path name));
       Unix.rmdir path
-    end else
+    | _ ->
       Sys.remove path
+  with Unix.Unix_error (Unix.ENOENT, _, _) -> ()
 
 let rec fetch_commit ~cache_root ~url ~rev ~name =
   let cache_dir = Filename.concat cache_root (Printf.sprintf "%s-%s" name rev) in
@@ -189,12 +221,12 @@ let rec fetch_commit ~cache_root ~url ~rev ~name =
            | Ok () -> Ok cache_dir)
   end
 
-let find_description_path ~checkout_dir ~subdir =
+let find_file_recursively ~filename ~checkout_dir ~subdir =
   let search_dir = match subdir with
     | Some s -> Filename.concat checkout_dir s
     | None -> checkout_dir
   in
-  let direct = Filename.concat search_dir "DESCRIPTION" in
+  let direct = Filename.concat search_dir filename in
   if Sys.file_exists direct then Some direct
   else
     let rec search path =
@@ -205,7 +237,7 @@ let find_description_path ~checkout_dir ~subdir =
         let found = ref None in
         Array.iter (fun e ->
           let full = Filename.concat path e in
-          if e = "DESCRIPTION" then found := Some full
+          if e = filename then found := Some full
           else if Sys.is_directory full && e <> ".git" && e <> "_pipeline" then
             match search full with
             | Some p -> found := Some p
@@ -215,31 +247,11 @@ let find_description_path ~checkout_dir ~subdir =
     in
     search search_dir
 
+let find_description_path ~checkout_dir ~subdir =
+  find_file_recursively ~filename:"DESCRIPTION" ~checkout_dir ~subdir
+
 let find_namespace_path ~checkout_dir ~subdir =
-  let search_dir = match subdir with
-    | Some s -> Filename.concat checkout_dir s
-    | None -> checkout_dir
-  in
-  let direct = Filename.concat search_dir "NAMESPACE" in
-  if Sys.file_exists direct then Some direct
-  else
-    let rec search path =
-      let entries = try Some (Sys.readdir path) with _ -> None in
-      match entries with
-      | None -> None
-      | Some entries ->
-        let found = ref None in
-        Array.iter (fun e ->
-          let full = Filename.concat path e in
-          if e = "NAMESPACE" then found := Some full
-          else if Sys.is_directory full && e <> ".git" && e <> "_pipeline" then
-            match search full with
-            | Some p -> found := Some p
-            | None -> ()
-        ) entries;
-        !found
-    in
-    search search_dir
+  find_file_recursively ~filename:"NAMESPACE" ~checkout_dir ~subdir
 
 let read_file path =
   try
@@ -294,6 +306,10 @@ let auto_detect_one ~cache_root ~(dep : r_git_dependency) ~(all_git_deps : r_git
             let git_deps, cran_deps =
               List.partition (fun pkg -> List.mem pkg all_git_names) all_deps
             in
+            List.iter (fun pkg ->
+              if not (List.mem pkg all_git_names) && (String.contains pkg '/' || String.contains pkg ':') then
+                Printf.eprintf "Warning: Transitive dependency %S looks like a Git remote but is not declared in tproject.toml or renv.lock. It will be treated as a CRAN package.\n%!" pkg
+            ) all_deps;
             { dep with
               rgd_cran_inputs = cran_deps;
               rgd_git_inputs = git_deps;

--- a/src/package_manager/r_description_resolver.ml
+++ b/src/package_manager/r_description_resolver.ml
@@ -1,0 +1,307 @@
+open Package_types
+
+let base_r_packages =
+  [ "R"; "methods"; "utils"; "stats"; "graphics"; "grDevices"
+  ; "datasets"; "grid"; "tools"; "parallel"; "compiler"; "splines"
+  ; "stats4"; "tcltk"; "Matrix" ]
+
+let is_base_r_package name =
+  List.mem name base_r_packages
+
+let parse_dcf_content content =
+  let lines = String.split_on_char '\n' content in
+  let rec gather keys lines =
+    match lines with
+    | [] -> List.rev keys
+    | "" :: rest -> gather keys rest
+    | line :: rest ->
+      if String.length line > 0 && (line.[0] = ' ' || line.[0] = '\t') then
+        match keys with
+        | (k, v) :: rest_keys ->
+          gather ((k, v ^ " " ^ String.trim line) :: rest_keys) rest
+        | [] -> gather keys rest
+      else
+        match String.index_opt line ':' with
+        | Some pos ->
+          let key = String.trim (String.sub line 0 pos) in
+          let value = String.trim (String.sub line (pos + 1) (String.length line - pos - 1)) in
+          gather ((key, value) :: keys) rest
+        | None -> gather keys rest
+  in
+  gather [] lines
+
+let get_dcf_field fields key =
+  List.assoc_opt key fields
+
+let parse_dep_list value =
+  if value = "" || value = "NA" then []
+  else
+    String.split_on_char ',' value
+    |> List.map String.trim
+    |> List.filter (fun s -> s <> "")
+    |> List.map (fun s ->
+      match String.index_opt s '(' with
+      | Some pos -> String.trim (String.sub s 0 pos)
+      | None -> s
+    )
+    |> List.filter (fun s -> s <> "" && s <> "R")
+
+let parse_description_deps content =
+  let fields = parse_dcf_content content in
+  let deps_from_field key =
+    match get_dcf_field fields key with
+    | Some value -> parse_dep_list value
+    | None -> []
+  in
+  let imports = deps_from_field "Imports" in
+  let depends = deps_from_field "Depends" in
+  let linking_to = deps_from_field "LinkingTo" in
+  let all = List.sort_uniq String.compare (imports @ depends @ linking_to) in
+  List.filter (fun p -> not (is_base_r_package p)) all
+
+let parse_remotes_field value =
+  if value = "" || value = "NA" then []
+  else
+    String.split_on_char ',' value
+    |> List.map String.trim
+    |> List.filter (fun s -> s <> "")
+    |> List.map (fun s ->
+      let s = if String.starts_with ~prefix:"github::" s then
+        String.sub s 8 (String.length s - 8)
+      else if String.starts_with ~prefix:"gitlab::" s then
+        String.sub s 8 (String.length s - 8)
+      else s in
+      let s = match String.index_opt s '#' with
+        | Some pos -> String.trim (String.sub s 0 pos)
+        | None -> s in
+      let repo_part =
+        let parts = String.split_on_char '/' s in
+        List.fold_left (fun _ p -> p) "" parts
+      in
+      match String.index_opt repo_part '@' with
+      | Some pos -> String.trim (String.sub repo_part 0 pos)
+      | None -> String.trim repo_part
+    )
+    |> List.filter (fun s -> s <> "")
+
+let parse_namespace_deps content =
+  let lines = String.split_on_char '\n' content in
+  let extract_import line =
+    let trimmed = String.trim line in
+    if String.starts_with ~prefix:"import(" trimmed then
+      let inner = String.sub trimmed 7 (String.length trimmed - 8) in
+      let pkg = String.trim inner in
+      let pkg = if String.length pkg >= 2 && (pkg.[0] = '"' || pkg.[0] = '\'') then
+        String.sub pkg 1 (String.length pkg - 2)
+      else pkg in
+      Some pkg
+    else if String.starts_with ~prefix:"importFrom(" trimmed then
+      let inner = String.sub trimmed 11 (String.length trimmed - 12) in
+      match String.index_opt inner ',' with
+      | Some pos ->
+        let pkg = String.trim (String.sub inner 0 pos) in
+        let pkg = if String.length pkg >= 2 && (pkg.[0] = '"' || pkg.[0] = '\'') then
+          String.sub pkg 1 (String.length pkg - 2)
+        else pkg in
+        Some pkg
+      | None -> Some (String.trim inner)
+    else
+      None
+  in
+  List.filter_map extract_import lines
+  |> List.filter (fun p -> not (is_base_r_package p))
+  |> List.sort_uniq String.compare
+
+let run_git ~dir args =
+  let argv = Array.append [| "git"; "-C"; dir |] (Array.of_list args) in
+  try
+    let ch_in, ch_out, ch_err =
+      Unix.open_process_args_full "git" argv (Unix.environment ())
+    in
+    close_out ch_out;
+    let out_buf = Buffer.create 1024 in
+    let err_buf = Buffer.create 1024 in
+    let buf = Bytes.create 4096 in
+    let rec drain () =
+      let fd_out = Unix.descr_of_in_channel ch_in in
+      let fd_err = Unix.descr_of_in_channel ch_err in
+      let ready, _, _ = Unix.select [fd_out; fd_err] [] [] 60.0 in
+      let got_data = ref false in
+      if List.mem fd_out ready then (
+        let n = try input ch_in buf 0 (Bytes.length buf) with End_of_file -> 0 in
+        if n > 0 then (Buffer.add_subbytes out_buf buf 0 n; got_data := true)
+      );
+      if List.mem fd_err ready then (
+        let n = try input ch_err buf 0 (Bytes.length buf) with End_of_file -> 0 in
+        if n > 0 then (Buffer.add_subbytes err_buf buf 0 n; got_data := true)
+      );
+      if !got_data then drain ()
+    in
+    drain ();
+    let status = Unix.close_process_full (ch_in, ch_out, ch_err) in
+    match status with
+    | Unix.WEXITED 0 -> Ok ()
+    | Unix.WEXITED code ->
+      let err = String.trim (Buffer.contents err_buf) in
+      Error (Printf.sprintf "git %s failed with exit code %d: %s"
+        (String.concat " " args) code
+        (if err <> "" then err else "(no stderr output)"))
+    | _ -> Error (Printf.sprintf "git %s terminated abnormally" (String.concat " " args))
+  with exn ->
+    Error (Printf.sprintf "git %s raised: %s" (String.concat " " args) (Printexc.to_string exn))
+
+let rec remove_path_recursively path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_path_recursively (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let rec fetch_commit ~cache_root ~url ~rev ~name =
+  let cache_dir = Filename.concat cache_root (Printf.sprintf "%s-%s" name rev) in
+  if Sys.file_exists cache_dir then begin
+    match run_git ~dir:cache_dir ["rev-parse"; "HEAD"] with
+    | Ok _ -> Ok cache_dir
+    | Error _ ->
+      remove_path_recursively cache_dir;
+      fetch_commit ~cache_root ~url ~rev ~name
+  end else begin
+    (try Unix.mkdir cache_root 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+    match run_git ~dir:cache_dir ["init"] with
+    | Error msg -> Error msg
+    | Ok () ->
+      match run_git ~dir:cache_dir ["remote"; "add"; "origin"; url] with
+      | Error msg -> Error msg
+      | Ok () ->
+        let fetch_result =
+          match run_git ~dir:cache_dir ["fetch"; "--depth"; "1"; "origin"; rev] with
+          | Ok () -> Ok ()
+          | Error _ ->
+            run_git ~dir:cache_dir ["fetch"; "--depth"; "1"; "origin"]
+        in
+        (match fetch_result with
+         | Error msg -> Error msg
+         | Ok () ->
+           match run_git ~dir:cache_dir ["checkout"; "FETCH_HEAD"] with
+           | Error msg -> Error msg
+           | Ok () -> Ok cache_dir)
+  end
+
+let find_description_path ~checkout_dir ~subdir =
+  let search_dir = match subdir with
+    | Some s -> Filename.concat checkout_dir s
+    | None -> checkout_dir
+  in
+  let direct = Filename.concat search_dir "DESCRIPTION" in
+  if Sys.file_exists direct then Some direct
+  else
+    let rec search path =
+      let entries = try Some (Sys.readdir path) with _ -> None in
+      match entries with
+      | None -> None
+      | Some entries ->
+        let found = ref None in
+        Array.iter (fun e ->
+          let full = Filename.concat path e in
+          if e = "DESCRIPTION" then found := Some full
+          else if Sys.is_directory full && e <> ".git" && e <> "_pipeline" then
+            match search full with
+            | Some p -> found := Some p
+            | None -> ()
+        ) entries;
+        !found
+    in
+    search search_dir
+
+let find_namespace_path ~checkout_dir ~subdir =
+  let search_dir = match subdir with
+    | Some s -> Filename.concat checkout_dir s
+    | None -> checkout_dir
+  in
+  let direct = Filename.concat search_dir "NAMESPACE" in
+  if Sys.file_exists direct then Some direct
+  else
+    let rec search path =
+      let entries = try Some (Sys.readdir path) with _ -> None in
+      match entries with
+      | None -> None
+      | Some entries ->
+        let found = ref None in
+        Array.iter (fun e ->
+          let full = Filename.concat path e in
+          if e = "NAMESPACE" then found := Some full
+          else if Sys.is_directory full && e <> ".git" && e <> "_pipeline" then
+            match search full with
+            | Some p -> found := Some p
+            | None -> ()
+        ) entries;
+        !found
+    in
+    search search_dir
+
+let read_file path =
+  try
+    let ch = open_in path in
+    let content =
+      Fun.protect
+        ~finally:(fun () -> close_in_noerr ch)
+        (fun () -> really_input_string ch (in_channel_length ch))
+    in
+    Ok content
+  with exn ->
+    Error (Printf.sprintf "Failed to read %s: %s" path (Printexc.to_string exn))
+
+let auto_detect_one ~cache_root ~(dep : r_git_dependency) ~(all_git_deps : r_git_dependency list) : r_git_dependency =
+  if dep.rgd_cran_inputs <> [] || dep.rgd_git_inputs <> [] then
+    dep
+  else begin
+    let all_git_names = List.map (fun d -> d.rgd_name) all_git_deps in
+    match fetch_commit ~cache_root ~url:dep.rgd_git_url ~rev:dep.rgd_rev ~name:dep.rgd_name with
+    | Error msg ->
+      Printf.eprintf "Warning: Failed to fetch %s (%s) for auto-detection: %s\n%!"
+        dep.rgd_name dep.rgd_git_url msg;
+      dep
+    | Ok checkout_dir ->
+      begin
+        match find_description_path ~checkout_dir ~subdir:dep.rgd_subdir with
+        | None ->
+          Printf.eprintf "Warning: No DESCRIPTION file found for %s — skipping auto-detection\n%!" dep.rgd_name;
+          dep
+        | Some desc_path ->
+          match read_file desc_path with
+          | Error msg ->
+            Printf.eprintf "Warning: %s\n%!" msg;
+            dep
+          | Ok desc_content ->
+            let desc_deps = parse_description_deps desc_content in
+            let fields = parse_dcf_content desc_content in
+            let remote_pkgs =
+              match get_dcf_field fields "Remotes" with
+              | Some r -> parse_remotes_field r
+              | None -> []
+            in
+            let namespace_deps =
+              match find_namespace_path ~checkout_dir ~subdir:dep.rgd_subdir with
+              | Some ns_path ->
+                (match read_file ns_path with
+                 | Ok ns_content -> parse_namespace_deps ns_content
+                 | Error _ -> [])
+              | None -> []
+            in
+            let all_deps = List.sort_uniq String.compare (desc_deps @ namespace_deps @ remote_pkgs) in
+            let git_deps, cran_deps =
+              List.partition (fun pkg -> List.mem pkg all_git_names) all_deps
+            in
+            { dep with
+              rgd_cran_inputs = cran_deps;
+              rgd_git_inputs = git_deps;
+            }
+      end
+  end
+
+let auto_detect_all ~cache_root ~(deps : r_git_dependency list) : r_git_dependency list =
+  List.map (fun dep ->
+    auto_detect_one ~cache_root ~dep ~all_git_deps:deps
+  ) deps

--- a/src/package_manager/r_description_resolver.ml
+++ b/src/package_manager/r_description_resolver.ml
@@ -101,15 +101,27 @@ let parse_namespace_deps content =
     let trimmed = String.trim line in
     if String.starts_with ~prefix:"import(" trimmed then
       let inner = String.sub trimmed 7 (String.length trimmed - 8) in
-      let first_part =
-        match String.split_on_char ',' inner with
-        | first :: _ -> String.trim first
-        | [] -> String.trim inner
+      let inner_clean =
+        match String.index_opt inner '=' with
+        | Some pos ->
+          let before = String.sub inner 0 pos in
+          let before_trimmed = String.trim before in
+          if String.ends_with ~suffix:"except" before_trimmed then
+            String.sub before_trimmed 0 (String.length before_trimmed - 6)
+          else
+            before
+        | None -> inner
       in
-      let pkg = if String.length first_part >= 2 && (first_part.[0] = '"' || first_part.[0] = '\'') then
-        String.sub first_part 1 (String.length first_part - 2)
-      else first_part in
-      if pkg <> "" then Some pkg else None
+      String.split_on_char ',' inner_clean
+      |> List.map String.trim
+      |> List.filter_map (fun s ->
+        if s = "" then None
+        else
+          let pkg = if String.length s >= 2 && (s.[0] = '"' || s.[0] = '\'') then
+            String.sub s 1 (String.length s - 2)
+          else s in
+          if pkg <> "" then Some pkg else None
+      )
     else if String.starts_with ~prefix:"importFrom(" trimmed then
       let inner = String.sub trimmed 11 (String.length trimmed - 12) in
       match String.split_on_char ',' inner with
@@ -118,65 +130,83 @@ let parse_namespace_deps content =
         let pkg = if String.length pkg >= 2 && (pkg.[0] = '"' || pkg.[0] = '\'') then
           String.sub pkg 1 (String.length pkg - 2)
         else pkg in
-        if pkg <> "" then Some pkg else None
-      | [] -> None
+        if pkg <> "" then [pkg] else []
+      | [] -> []
     else
-      None
+      []
   in
-  List.filter_map extract_import lines
+  List.map extract_import lines
+  |> List.flatten
   |> List.filter (fun p -> not (is_base_r_package p))
   |> List.sort_uniq String.compare
 
 let run_git ~dir args =
   let argv = Array.append [| "git"; "-C"; dir |] (Array.of_list args) in
+  let pipe_out_read, pipe_out_write = Unix.pipe () in
+  let pipe_err_read, pipe_err_write = Unix.pipe () in
+  let devnull = Unix.openfile "/dev/null" [Unix.O_RDONLY] 0 in
   try
-    let ch_in, ch_out, ch_err =
-      Unix.open_process_args_full "git" argv (Unix.environment ())
-    in
-    close_out ch_out;
+    let pid = Unix.create_process "git" argv devnull pipe_out_write pipe_err_write in
+    Unix.close pipe_out_write;
+    Unix.close pipe_err_write;
+    Unix.close devnull;
     let out_buf = Buffer.create 1024 in
     let err_buf = Buffer.create 1024 in
     let buf = Bytes.create 4096 in
+    let start_time = Unix.gettimeofday () in
     let rec drain eof_out eof_err =
-      if eof_out && eof_err then ()
+      if eof_out && eof_err then Ok ()
       else
-        let fd_out = Unix.descr_of_in_channel ch_in in
-        let fd_err = Unix.descr_of_in_channel ch_err in
-        let read_fds =
-          let l = [] in
-          let l = if not eof_out then fd_out :: l else l in
-          let l = if not eof_err then fd_err :: l else l in
-          l
-        in
-        match Unix.select read_fds [] [] 60.0 with
-        | ready, _, _ ->
-          let next_eof_out = ref eof_out in
-          let next_eof_err = ref eof_err in
-          if List.mem fd_out ready then (
-            let n = try input ch_in buf 0 (Bytes.length buf) with End_of_file -> 0 in
-            if n > 0 then Buffer.add_subbytes out_buf buf 0 n
-            else next_eof_out := true
-          );
-          if List.mem fd_err ready then (
-            let n = try input ch_err buf 0 (Bytes.length buf) with End_of_file -> 0 in
-            if n > 0 then Buffer.add_subbytes err_buf buf 0 n
-            else next_eof_err := true
-          );
-          drain !next_eof_out !next_eof_err
-        | exception Unix.Unix_error (Unix.EINTR, _, _) ->
-          drain eof_out eof_err
+        let elapsed = Unix.gettimeofday () -. start_time in
+        if elapsed > 300.0 then (
+          (try Unix.kill pid Sys.sigkill with _ -> ());
+          Error "process timed out after 300 seconds"
+        ) else
+          let read_fds =
+            let l = [] in
+            let l = if not eof_out then pipe_out_read :: l else l in
+            let l = if not eof_err then pipe_err_read :: l else l in
+            l
+          in
+          match Unix.select read_fds [] [] 5.0 with
+          | ready, _, _ ->
+            let next_eof_out = ref eof_out in
+            let next_eof_err = ref eof_err in
+            if List.mem pipe_out_read ready then (
+              let n = try Unix.read pipe_out_read buf 0 (Bytes.length buf) with _ -> 0 in
+              if n > 0 then Buffer.add_subbytes out_buf buf 0 n
+              else next_eof_out := true
+            );
+            if List.mem pipe_err_read ready then (
+              let n = try Unix.read pipe_err_read buf 0 (Bytes.length buf) with _ -> 0 in
+              if n > 0 then Buffer.add_subbytes err_buf buf 0 n
+              else next_eof_err := true
+            );
+            drain !next_eof_out !next_eof_err
+          | exception Unix.Unix_error (Unix.EINTR, _, _) ->
+            drain eof_out eof_err
     in
-    drain false false;
-    let status = Unix.close_process_full (ch_in, ch_out, ch_err) in
-    match status with
-    | Unix.WEXITED 0 -> Ok ()
-    | Unix.WEXITED code ->
-      let err = String.trim (Buffer.contents err_buf) in
-      Error (Printf.sprintf "git %s failed with exit code %d: %s"
-        (String.concat " " args) code
-        (if err <> "" then err else "(no stderr output)"))
-    | _ -> Error (Printf.sprintf "git %s terminated abnormally" (String.concat " " args))
+    let drain_res = drain false false in
+    Unix.close pipe_out_read;
+    Unix.close pipe_err_read;
+    let _, status = Unix.waitpid [] pid in
+    match drain_res with
+    | Error msg -> Error msg
+    | Ok () ->
+      match status with
+      | Unix.WEXITED 0 -> Ok ()
+      | Unix.WEXITED code ->
+        let err = String.trim (Buffer.contents err_buf) in
+        Error (Printf.sprintf "git %s failed with exit code %d: %s"
+          (String.concat " " args) code
+          (if err <> "" then err else "(no stderr output)"))
+      | _ -> Error (Printf.sprintf "git %s terminated abnormally" (String.concat " " args))
   with exn ->
+    (try Unix.close pipe_out_write with _ -> ());
+    (try Unix.close pipe_err_write with _ -> ());
+    (try Unix.close pipe_out_read with _ -> ());
+    (try Unix.close pipe_err_read with _ -> ());
+    (try Unix.close devnull with _ -> ());
     Error (Printf.sprintf "git %s raised: %s" (String.concat " " args) (Printexc.to_string exn))
 
 let rec remove_path_recursively path =

--- a/src/pipeline/builder_populate.ml
+++ b/src/pipeline/builder_populate.ml
@@ -167,18 +167,18 @@ let populate_pipeline ?(build=false) ?verbose ?pipeline_name ?(nix_options : nix
                  (fun () -> really_input_string ch (in_channel_length ch))
              in
              match Toml_parser.parse_tproject_toml ~root_dir:project_root content with
-              | Ok cfg ->
-                let toml_git_pkgs =
-                  R_description_resolver.auto_detect_all
-                    ~cache_root:(Filename.concat project_root ".t_r_pkg_cache")
-                    ~deps:cfg.proj_r_git_dependencies
-                in
-                if cfg.proj_r_resolver = "renv" then
-                  match Renv_resolver.split_packages ~project_root with
-                  | Ok (renv_cran, renv_git) -> renv_cran, toml_git_pkgs @ renv_git
-                  | Error _ -> [], toml_git_pkgs
-                else
-                  [], toml_git_pkgs
+             | Ok cfg ->
+               let toml_git_pkgs =
+                 R_description_resolver.auto_detect_all
+                   ~cache_root:(Filename.concat project_root ".t_r_pkg_cache")
+                   ~deps:cfg.proj_r_git_dependencies
+               in
+               if cfg.proj_r_resolver = "renv" then
+                 match Renv_resolver.split_packages ~project_root with
+                 | Ok (renv_cran, renv_git) -> renv_cran, toml_git_pkgs @ renv_git
+                 | Error _ -> [], toml_git_pkgs
+               else
+                 [], toml_git_pkgs
              | Error _ -> [], []
            with _ -> [], [])
         else [], []

--- a/src/pipeline/builder_populate.ml
+++ b/src/pipeline/builder_populate.ml
@@ -167,14 +167,18 @@ let populate_pipeline ?(build=false) ?verbose ?pipeline_name ?(nix_options : nix
                  (fun () -> really_input_string ch (in_channel_length ch))
              in
              match Toml_parser.parse_tproject_toml ~root_dir:project_root content with
-             | Ok cfg ->
-               let toml_git_pkgs = cfg.proj_r_git_dependencies in
-               if cfg.proj_r_resolver = "renv" then
-                 match Renv_resolver.split_packages ~project_root with
-                 | Ok (renv_cran, renv_git) -> renv_cran, toml_git_pkgs @ renv_git
-                 | Error _ -> [], toml_git_pkgs
-               else
-                 [], toml_git_pkgs
+              | Ok cfg ->
+                let toml_git_pkgs =
+                  R_description_resolver.auto_detect_all
+                    ~cache_root:(Filename.concat project_root ".t_r_pkg_cache")
+                    ~deps:cfg.proj_r_git_dependencies
+                in
+                if cfg.proj_r_resolver = "renv" then
+                  match Renv_resolver.split_packages ~project_root with
+                  | Ok (renv_cran, renv_git) -> renv_cran, toml_git_pkgs @ renv_git
+                  | Error _ -> [], toml_git_pkgs
+                else
+                  [], toml_git_pkgs
              | Error _ -> [], []
            with _ -> [], [])
         else [], []

--- a/tests/package_manager/test_package_manager.ml
+++ b/tests/package_manager/test_package_manager.ml
@@ -2073,4 +2073,16 @@ export(my_function)
     | _ -> false
   );
 
+  test_pm "parse_namespace_deps handles import(pkg, except = ...) and multi-parameter forms" (fun () ->
+    let ns = "import(pkg1, except = c(a, b))\nimport(pkg2, except = a)\nimportFrom(pkg3, fun1, fun2)" in
+    let deps = R_description_resolver.parse_namespace_deps ns in
+    List.mem "pkg1" deps && List.mem "pkg2" deps && List.mem "pkg3" deps && List.length deps = 3
+  );
+
+  test_pm "parse_remotes_field skips unsupported remote types" (fun () ->
+    let remotes = "github::user/repo, gitlab::user/repo2, url::https://example.com/repo, local::/path/to/repo, bioconductor::Biobase" in
+    let pkgs = R_description_resolver.parse_remotes_field remotes in
+    List.mem "repo" pkgs && List.mem "repo2" pkgs && List.length pkgs = 2
+  );
+
   print_newline ()

--- a/tests/package_manager/test_package_manager.ml
+++ b/tests/package_manager/test_package_manager.ml
@@ -2074,9 +2074,9 @@ export(my_function)
   );
 
   test_pm "parse_namespace_deps handles import(pkg, except = ...) and multi-parameter forms" (fun () ->
-    let ns = "import(pkg1, except = c(a, b))\nimport(pkg2, except = a)\nimportFrom(pkg3, fun1, fun2)" in
+    let ns = "import(pkg1, except = c(a, b))\nimport(pkg2, pkg3, except = a)\nimportFrom(pkg4, fun1, fun2)" in
     let deps = R_description_resolver.parse_namespace_deps ns in
-    List.mem "pkg1" deps && List.mem "pkg2" deps && List.mem "pkg3" deps && List.length deps = 3
+    List.mem "pkg1" deps && List.mem "pkg2" deps && List.mem "pkg3" deps && List.mem "pkg4" deps && List.length deps = 4
   );
 
   test_pm "parse_remotes_field skips unsupported remote types" (fun () ->

--- a/tests/package_manager/test_package_manager.ml
+++ b/tests/package_manager/test_package_manager.ml
@@ -1975,4 +1975,102 @@ packages = ["dplyr"]
     | Ok cfg -> cfg.proj_r_git_dependencies = []
     | Error _ -> false);
 
+  print_newline ();
+  Printf.printf "Package Manager — DESCRIPTION/NAMESPACE parser:\n";
+
+  let sample_description = {|
+Package: testpkg
+Title: A Test Package
+Version: 1.0.0
+Depends:
+    R (>= 3.5),
+    methods
+Imports:
+    dplyr (>= 1.0.0),
+    tidyr,
+    ggplot2
+LinkingTo:
+    Rcpp,
+    RcppArmadillo
+Remotes:
+    user/brotools,
+    gitlab::user/anotherpkg
+Description: A package used for testing.
+|} in
+
+  let sample_namespace = {|
+import(dplyr)
+importFrom(tidyr, pivot_longer, pivot_wider)
+import(ggplot2)
+importFrom(Rcpp, evalCpp)
+export(my_function)
+|} in
+
+  test_pm "parse_dcf_content extracts fields correctly" (fun () ->
+    let fields = R_description_resolver.parse_dcf_content sample_description in
+    let pkg = List.assoc_opt "Package" fields in
+    let vers = List.assoc_opt "Version" fields in
+    let imports = List.assoc_opt "Imports" fields in
+    pkg = Some "testpkg"
+    && vers = Some "1.0.0"
+    && (match imports with Some v -> String.contains v ',' | None -> false)
+  );
+
+  test_pm "parse_description_deps extracts Imports/Depends/LinkingTo" (fun () ->
+    let deps = R_description_resolver.parse_description_deps sample_description in
+    List.mem "dplyr" deps
+    && List.mem "tidyr" deps
+    && List.mem "ggplot2" deps
+    && List.mem "Rcpp" deps
+    && List.mem "RcppArmadillo" deps
+    && not (List.mem "R" deps)
+    && not (List.mem "methods" deps)
+  );
+
+  test_pm "parse_description_deps strips version specs" (fun () ->
+    let deps = R_description_resolver.parse_description_deps sample_description in
+    List.mem "dplyr" deps
+    && not (List.exists (fun d -> String.contains d '(') deps)
+  );
+
+  test_pm "parse_remotes_field extracts remote package names" (fun () ->
+    let fields = R_description_resolver.parse_dcf_content sample_description in
+    match R_description_resolver.get_dcf_field fields "Remotes" with
+    | Some remotes ->
+      let pkgs = R_description_resolver.parse_remotes_field remotes in
+      List.mem "brotools" pkgs && List.mem "anotherpkg" pkgs
+      && List.length pkgs = 2
+    | None -> false
+  );
+
+  test_pm "parse_namespace_deps extracts imports" (fun () ->
+    let deps = R_description_resolver.parse_namespace_deps sample_namespace in
+    List.mem "dplyr" deps
+    && List.mem "tidyr" deps
+    && List.mem "ggplot2" deps
+    && List.mem "Rcpp" deps
+    && List.length deps = 4
+  );
+
+  test_pm "parse empty DESCRIPTION returns no deps" (fun () ->
+    let deps = R_description_resolver.parse_description_deps "" in
+    deps = []
+  );
+
+  test_pm "parse empty NAMESPACE returns no deps" (fun () ->
+    let deps = R_description_resolver.parse_namespace_deps "" in
+    deps = []
+  );
+
+  test_pm "auto_detect_all returns deps unchanged when inputs already populated" (fun () ->
+    let dep : Package_types.r_git_dependency =
+      { rgd_name = "testpkg"; rgd_git_url = "https://example.com/testpkg"; rgd_rev = "abc123";
+        rgd_cran_inputs = ["dplyr"]; rgd_git_inputs = []; rgd_subdir = None }
+    in
+    let result = R_description_resolver.auto_detect_all ~cache_root:"/nonexistent" ~deps:[dep] in
+    match result with
+    | [d] -> d.rgd_cran_inputs = ["dplyr"] && d.rgd_git_inputs = []
+    | _ -> false
+  );
+
   print_newline ()


### PR DESCRIPTION
Adds r_description_resolver.ml which parses DESCRIPTION (DCF format) for Imports/Depends/LinkingTo/Remotes and NAMESPACE for import/importFrom declarations. Fetches each git repo via shallow clone (--depth 1) into .t_r_pkg_cache/, filters base R packages, and separates CRAN vs sibling git dependencies. Explicit deps field in tproject.toml still overrides.

Integration points:
- nix_generator.ml: auto-detect before flake generation in install_flake
- builder_populate.ml: auto-detect before pipeline.nix emission

Closes: auto-detection of R git package dependencies from DESCRIPTION/NAMESPACE