### PR TITLE
feat(check): add --watch mode for continuous file monitoring

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3275,6 +3275,10 @@ When `--env` is passed, `t check` additionally runs environment resolution check
 
 Environment errors are reported as `phase: "env"` diagnostics and trigger exit code 3.
 
+**Watch mode (`--watch`):**
+
+When `--watch` is passed, `t check` runs once and then polls the input file for changes (every 0.5s). On each modification, it re-runs the check and prints updated results. Press Ctrl+C to stop. Watch mode can be combined with `--schema` and/or `--env`.
+
 ---
 
 ### `read_node(node)`

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3277,7 +3277,40 @@ Environment errors are reported as `phase: "env"` diagnostics and trigger exit c
 
 **Watch mode (`--watch`):**
 
-When `--watch` is passed, `t check` runs once and then polls the input file for changes (every 0.5s). On each modification, it re-runs the check and prints updated results. Press Ctrl+C to stop. Watch mode can be combined with `--schema` and/or `--env`.
+When `--watch` is passed, `t check` runs immediately, then polls the input file for changes (every 0.5s). On each modification, it re-runs the check and prints updated results. Press Ctrl+C to stop. Watch mode can be combined with `--schema` and/or `--env`.
+
+### `expect()` — Pipeline shape contracts
+
+Attach a shape contract to a pipeline node to declare expected output column names.
+Contracts are checked statically via `t check --schema`.
+
+**Syntax:**
+
+```t
+clean_data = raw_data
+  |> read_csv("data.csv")
+  |> filter($status == "complete")
+  |> expect(columns = ["id", "name", "score"])
+```
+
+`expect()` must appear at the **end** of a pipe chain.
+
+**Accepted arguments:**
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `columns` | `List[String]` | Expected column names in the output |
+
+**Behavior:**
+
+- Checked only when `t check --schema` is used (tier 2)
+- If the inferred output schema is missing any declared columns, a `contract_violation` diagnostic is emitted
+- `expect()` is stripped from the pipe chain during evaluation — it has no runtime effect
+
+**Limitations:**
+
+- Only column names are checked; types, row counts, and null rates are not yet enforced
+- Column validation depends on accurate schema inference (CSV headers for root nodes, colcraft verb propagation for downstream nodes)
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 
 - **Nix Evaluability Check**: `t check --env` now also generates `pipeline.nix` and `dag.json` and validates them via `nix-instantiate --eval`. This catches Nix expression errors (bad references, type mismatches) before a full build.
 - **Git-Sourced Lockfile Packages**: `check_lockfile_consistency` now includes packages resolved via GitHub/GitLab entries in `renv.lock`, preventing false-positive `missing_from_lockfile` diagnostics.
+- **Watch Mode (`--watch`)**: `t check --watch` polls the input file for changes and re-runs the check on every modification. Can be combined with `--schema` and `--env`.
 
 ## [0.54.0] - 2026-07-08
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,8 @@
 
 - **Nix Evaluability Check**: `t check --env` now also generates `pipeline.nix` and `dag.json` and validates them via `nix-instantiate --eval`. This catches Nix expression errors (bad references, type mismatches) before a full build.
 - **Git-Sourced Lockfile Packages**: `check_lockfile_consistency` now includes packages resolved via GitHub/GitLab entries in `renv.lock`, preventing false-positive `missing_from_lockfile` diagnostics.
-- **Watch Mode (`--watch`)**: `t check --watch` polls the input file for changes and re-runs the check on every modification. Can be combined with `--schema` and `--env`.
+- **Watch Mode (`--watch`)**: `t check --watch` runs immediately, then polls the input file for changes and re-runs the check on every modification. Can be combined with `--schema` and `--env`.
+- **Shape Contracts (`expect()`)**: New `expect(columns = [...])` syntax for pipeline nodes declares expected output columns. Contracts are checked statically via `t check --schema` and produce `contract_violation` diagnostics when the inferred schema is missing declared columns.
 
 ## [0.54.0] - 2026-07-08
 

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -151,13 +151,9 @@ and meta_pipeline = {
 }
 
 
-(** Shape contract for expect() — checked against node output at exec time *)
+(** Shape contract for expect() — checked statically via t check --schema *)
 and contract = {
-  contract_columns : string list option;     (* expected column names *)
-  contract_types : (string * string) list;   (* column -> expected Arrow type *)
-  contract_min_rows : int option;
-  contract_max_rows : int option;
-  contract_null_rates : (string * float) list; (* column -> max null rate *)
+  contract_columns : string list option;
 }
 
 (** Formula specification — captures LHS/RHS of ~ expressions *)
@@ -405,10 +401,6 @@ and typ =
 
 let empty_contract = {
   contract_columns = None;
-  contract_types = [];
-  contract_min_rows = None;
-  contract_max_rows = None;
-  contract_null_rates = [];
 }
 
 type program = stmt list

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -143,12 +143,22 @@ and pipeline_result = {
   p_patterns     : (string * pattern_expr) list; (* Map node name -> pattern *)
   p_iterations   : (string * string) list;       (* Map node name -> iteration type *)
   p_flakes       : (string * string option) list; (* Map node name -> optional flake path *)
+  p_contracts    : (string * contract) list;      (* Map node name -> expect() contract *)
 }
 
 and meta_pipeline = {
   mp_pipelines : (string * value) list;      (* Map sub-pipeline name -> pipeline value (VPipeline) *)
 }
 
+
+(** Shape contract for expect() — checked against node output at exec time *)
+and contract = {
+  contract_columns : string list option;     (* expected column names *)
+  contract_types : (string * string) list;   (* column -> expected Arrow type *)
+  contract_min_rows : int option;
+  contract_max_rows : int option;
+  contract_null_rates : (string * float) list; (* column -> max null rate *)
+}
 
 (** Formula specification — captures LHS/RHS of ~ expressions *)
 and formula_spec = {
@@ -188,6 +198,7 @@ and unbuilt_node = {
   un_pattern : pattern_expr option;     (* None = no dynamic branching *)
   un_iteration : string;                (* "vector" | "list" *)
   un_flake : string option;             (* Optional path to a dedicated Nix flake *)
+  un_contract : contract option;        (* expect() shape contract *)
 }
 
 (** Result of a ?<{...}> shell escape — carries stdout, stderr, and exit code.
@@ -391,6 +402,14 @@ and typ =
   | TComputedNode
   | TSerializer
   | TExpr
+
+let empty_contract = {
+  contract_columns = None;
+  contract_types = [];
+  contract_min_rows = None;
+  contract_max_rows = None;
+  contract_null_rates = [];
+}
 
 type program = stmt list
 

--- a/src/diagnostics.ml
+++ b/src/diagnostics.ml
@@ -227,27 +227,34 @@ let of_pipeline_result ?file (p : Ast.pipeline_result) : diagnostic list =
           }]
       | None -> []
     in
-    (* NOTE: NA counts are currently the only warning source in nd_warnings.
-       If additional warning kinds are added to the pipeline, this filter
-       should be extended to emit them as diagnostics. *)
+    (* NA-exclusion warnings with na_count=0 mean no rows were affected —
+       nothing to report.  All other warning kinds (e.g. invalid_expect_placement)
+       are surfaced unconditionally. *)
     let warnings = List.filter_map (fun nw ->
-      if nw.Ast.nw_na_count = 0 then None
-      else Some ({
-        diag_id = gen_id ();
-        diag_error_class = "na_warning";
-        diag_severity = Warning;
-        diag_phase = Exec;
-        diag_node_id = Some name;
-        diag_node_lang = None;
-        diag_file = file;
-        diag_line = None;
-        diag_column = None;
-        diag_message = nw.Ast.nw_message;
-        diag_caused_by = (match nw.Ast.nw_source with
-          | Ast.WarningUpstream upstream -> [upstream]
-          | Ast.WarningOwn -> []);
-        diag_suggested_fix = NoFix;
-      } : diagnostic)
+      if nw.Ast.nw_kind = "NAExcluded" && nw.Ast.nw_na_count = 0 then None
+      else
+        let diag_error_class, diag_phase =
+          match nw.Ast.nw_kind with
+          | "invalid_expect_placement" -> nw.Ast.nw_kind, Wire
+          | "NAExcluded" -> "na_warning", Exec
+          | other -> other, Exec
+        in
+        Some ({
+          diag_id = gen_id ();
+          diag_error_class;
+          diag_severity = Warning;
+          diag_phase;
+          diag_node_id = Some name;
+          diag_node_lang = None;
+          diag_file = file;
+          diag_line = None;
+          diag_column = None;
+          diag_message = nw.Ast.nw_message;
+          diag_caused_by = (match nw.Ast.nw_source with
+            | Ast.WarningUpstream upstream -> [upstream]
+            | Ast.WarningOwn -> []);
+          diag_suggested_fix = NoFix;
+        } : diagnostic)
     ) nd.Ast.nd_warnings in
     errors @ warnings
   ) p.Ast.p_node_diagnostics)

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -1850,9 +1850,33 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
      that errors in their condition expressions (including NameError from
      typos in condition references) propagate immediately rather than being
      misinterpreted as forward-references to sibling nodes. *)
+  let desugar_warnings : Diagnostics.diagnostic list ref = ref [] in
   let desugar_node (name, node_expr) : (string * Ast.unbuilt_node option, value) result =
     let node_names = List.map fst nodes in
     let node_expr = substitute_env_vars !env_ref node_names node_expr in
+    (* Check if an expression contains any expect(...) call anywhere *)
+    let rec contains_expect expr =
+      match expr.Ast.node with
+      | Call { fn = { node = Var "expect"; _ }; _ } -> true
+      | BinOp { left; right; _ } -> contains_expect left || contains_expect right
+      | BroadcastOp { left; right; _ } -> contains_expect left || contains_expect right
+      | UnOp { operand; _ } -> contains_expect operand
+      | Call { fn; args } ->
+          contains_expect fn || List.exists (fun (_, e) -> contains_expect e) args
+      | Lambda { body; _ } -> contains_expect body
+      | IfElse { cond; then_; else_ } ->
+          contains_expect cond || contains_expect then_ || contains_expect else_
+      | ListLit items -> List.exists (fun (_, e) -> contains_expect e) items
+      | DictLit pairs -> List.exists (fun (_, e) -> contains_expect e) pairs
+      | Block stmts ->
+          List.exists (fun s -> match s.Ast.node with
+            | Expression e -> contains_expect e
+            | Assignment { expr; _ } | Reassignment { expr; _ } -> contains_expect expr
+            | _ -> false) stmts
+      | Match { scrutinee; cases } ->
+          contains_expect scrutinee || List.exists (fun (_, body) -> contains_expect body) cases
+      | _ -> false
+    in
     (* Strip trailing expect(...) from pipe chains: e.g.
        r_script("clean.R") |> expect(columns = [...])
        becomes r_script("clean.R") with a contract attached. *)
@@ -1876,12 +1900,41 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
         Some { Ast.contract_columns = Some !columns }
       else None
     in
-    let node_expr, contract_opt =
+    let make_mid_chain_warn () =
+      [{ Diagnostics.
+         diag_id = Diagnostics.gen_id ();
+         diag_error_class = "invalid_expect_placement";
+         diag_severity = Warning;
+         diag_phase = Wire;
+         diag_node_id = Some name;
+         diag_node_lang = None;
+         diag_file = None;
+         diag_line = (match node_expr.loc with Some l -> Some l.line | None -> None);
+         diag_column = (match node_expr.loc with Some l -> Some l.column | None -> None);
+         diag_message = Printf.sprintf
+           "expect() in node '%s' appears mid-chain and will be ignored. \
+            Move it to the end of the pipe chain." name;
+         diag_caused_by = [];
+         diag_suggested_fix = NoFix;
+       }]
+    in
+    let node_expr, contract_opt, expect_warnings =
       match node_expr.node with
       | BinOp { op = Pipe; left; right = { node = Call { fn = { node = Var "expect"; _ }; args }; _ } } ->
-          (left, extract_contract_from_args args)
-      | _ -> (node_expr, None)
+          (* Terminal expect() at end of chain — extract contract *)
+          let mid_chain_warns =
+            if contains_expect left then make_mid_chain_warn () else []
+          in
+          (left, extract_contract_from_args args, mid_chain_warns)
+      | other ->
+          (* No terminal expect() — check if expect() appears anywhere mid-chain *)
+          if contains_expect { node_expr with node = other } then
+            (node_expr, None, make_mid_chain_warn ())
+          else
+            (node_expr, None, [])
     in
+    if expect_warnings <> [] then
+      desugar_warnings := expect_warnings @ !desugar_warnings;
     let attach_contract un = match contract_opt with
       | None -> un
       | Some c -> { un with un_contract = Some c }
@@ -2084,6 +2137,30 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
 
     let p_nodes = List.rev results in
     let p_node_diagnostics = List.rev diagnostics in
+    (* Merge desugar-phase warnings (e.g. mid-chain expect()) into node diagnostics *)
+    let p_node_diagnostics = if !desugar_warnings <> [] then
+      let warn_by_node = Hashtbl.create 4 in
+      List.iter (fun d ->
+        match d.Diagnostics.diag_node_id with
+        | Some node_name ->
+            let nw = { Ast.nw_kind = d.Diagnostics.diag_error_class;
+                        nw_fn = "expect";
+                        nw_na_count = 0;
+                        nw_na_indices = [];
+                        nw_message = d.Diagnostics.diag_message;
+                        nw_source = Ast.WarningOwn } in
+            let existing = try Hashtbl.find warn_by_node node_name with Not_found -> [] in
+            Hashtbl.replace warn_by_node node_name (nw :: existing)
+        | None -> ()
+      ) !desugar_warnings;
+      List.map (fun (name, diag) ->
+        match Hashtbl.find_opt warn_by_node name with
+        | Some extra_warns ->
+            (name, { diag with Ast.nd_warnings = extra_warns @ diag.Ast.nd_warnings })
+        | None -> (name, diag)
+      ) p_node_diagnostics
+    else p_node_diagnostics
+    in
     if verbose then print_pipeline_diagnostics_summary p_node_diagnostics;
 
     (* Populate in-memory cache with VNodeResult entries so that

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -1857,7 +1857,7 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
        r_script("clean.R") |> expect(columns = [...])
        becomes r_script("clean.R") with a contract attached. *)
     let extract_contract_from_args args =
-      let contract = ref Ast.empty_contract in
+      let columns = ref [] in
       List.iter (fun (param_name, arg_expr) ->
         match param_name with
         | Some "columns" ->
@@ -1868,24 +1868,18 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
                    | Value (VString s) -> Some s
                    | _ -> None
                  ) items in
-                 contract := { !contract with contract_columns = Some cols }
-             | _ -> ())
-        | Some "min_rows" ->
-            (match eval_expr env_ref arg_expr with
-             | VInt n -> contract := { !contract with contract_min_rows = Some n }
-             | _ -> ())
-        | Some "max_rows" ->
-            (match eval_expr env_ref arg_expr with
-             | VInt n -> contract := { !contract with contract_max_rows = Some n }
+                 columns := cols
              | _ -> ())
         | _ -> ()
       ) args;
-      !contract
+      if !columns <> [] then
+        Some { Ast.contract_columns = Some !columns }
+      else None
     in
     let node_expr, contract_opt =
       match node_expr.node with
       | BinOp { op = Pipe; left; right = { node = Call { fn = { node = Var "expect"; _ }; args }; _ } } ->
-          (left, Some (extract_contract_from_args args))
+          (left, extract_contract_from_args args)
       | _ -> (node_expr, None)
     in
     let attach_contract un = match contract_opt with

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -1501,6 +1501,7 @@ and eval_expr (env_ref : environment ref) (expr : Ast.expr) : value =
                       un_pattern;
                       un_iteration;
                       un_flake;
+                      un_contract = None;
                     }
                 | Value (VString _) | Value (VSymbol _) | Value ((VNA NAGeneric)) when runtime = "sh" ->
                     VNode {
@@ -1517,6 +1518,7 @@ and eval_expr (env_ref : environment ref) (expr : Ast.expr) : value =
                       un_pattern;
                       un_iteration;
                       un_flake;
+                      un_contract = None;
                     }
                 | _ when Option.is_some un_script ->
                     VNode {
@@ -1533,6 +1535,7 @@ and eval_expr (env_ref : environment ref) (expr : Ast.expr) : value =
                       un_pattern;
                       un_iteration;
                       un_flake;
+                      un_contract = None;
                     }
                 | _ ->
                     let msg = Printf.sprintf "Node with runtime `%s` requires command to be wrapped in <{ ... }> blocks (RawCode), or use the 'script' argument to point to a .R, .py, .sh, or .qmd file." runtime in
@@ -1552,6 +1555,7 @@ and eval_expr (env_ref : environment ref) (expr : Ast.expr) : value =
                   un_pattern;
                   un_iteration;
                   un_flake;
+                  un_contract = None;
                 }
 )
     | Call { fn; args } ->
@@ -1812,6 +1816,7 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
     un_pattern = None;
     un_iteration = "vector";
     un_flake = None;
+    un_contract = None;
   } in
 
   let wrap_computed_node cn = {
@@ -1831,6 +1836,7 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
     un_pattern = None;
     un_iteration = "vector";
     un_flake = cn.cn_flake;
+    un_contract = None;
   } in
 
   (* Desugar nodes into enriched structures with defaults.
@@ -1847,6 +1853,45 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
   let desugar_node (name, node_expr) : (string * Ast.unbuilt_node option, value) result =
     let node_names = List.map fst nodes in
     let node_expr = substitute_env_vars !env_ref node_names node_expr in
+    (* Strip trailing expect(...) from pipe chains: e.g.
+       r_script("clean.R") |> expect(columns = [...])
+       becomes r_script("clean.R") with a contract attached. *)
+    let extract_contract_from_args args =
+      let contract = ref Ast.empty_contract in
+      List.iter (fun (param_name, arg_expr) ->
+        match param_name with
+        | Some "columns" ->
+            (match arg_expr.node with
+             | ListLit items ->
+                 let cols = List.filter_map (fun (_, e) ->
+                   match e.node with
+                   | Value (VString s) -> Some s
+                   | _ -> None
+                 ) items in
+                 contract := { !contract with contract_columns = Some cols }
+             | _ -> ())
+        | Some "min_rows" ->
+            (match eval_expr env_ref arg_expr with
+             | VInt n -> contract := { !contract with contract_min_rows = Some n }
+             | _ -> ())
+        | Some "max_rows" ->
+            (match eval_expr env_ref arg_expr with
+             | VInt n -> contract := { !contract with contract_max_rows = Some n }
+             | _ -> ())
+        | _ -> ()
+      ) args;
+      !contract
+    in
+    let node_expr, contract_opt =
+      match node_expr.node with
+      | BinOp { op = Pipe; left; right = { node = Call { fn = { node = Var "expect"; _ }; args }; _ } } ->
+          (left, Some (extract_contract_from_args args))
+      | _ -> (node_expr, None)
+    in
+    let attach_contract un = match contract_opt with
+      | None -> un
+      | Some c -> { un with un_contract = Some c }
+    in
     (* node_when/node_fork — resolve conditions at construction time;
        any VError (including NameError) propagates immediately. *)
     let when_fork_fn_name = match node_expr.node with
@@ -1856,9 +1901,9 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
     match when_fork_fn_name with
     | Some fn_name ->
         (match eval_expr env_ref node_expr with
-         | VNode un -> Ok (name, Some un)
+         | VNode un -> Ok (name, Some (attach_contract un))
          | VNullNode -> Ok (name, None)
-         | VComputedNode cn -> Ok (name, Some (wrap_computed_node cn))
+         | VComputedNode cn -> Ok (name, Some (attach_contract (wrap_computed_node cn)))
          | VError _ as e ->
              let annotated = match e with
                | VError err when not (List.mem_assoc "node_name" err.context) ->
@@ -1878,14 +1923,14 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
         in
         if is_node_call then
           match eval_expr env_ref node_expr with
-          | VNode un -> Ok (name, Some un)
+          | VNode un -> Ok (name, Some (attach_contract un))
           | VNullNode -> Ok (name, None)
-          | VComputedNode cn -> Ok (name, Some (wrap_computed_node cn))
-          | VError { code = NameError; _ } -> Ok (name, Some (default_un node_expr))
+          | VComputedNode cn -> Ok (name, Some (attach_contract (wrap_computed_node cn)))
+          | VError { code = NameError; _ } -> Ok (name, Some (attach_contract (default_un node_expr)))
           | VError _ as e -> Error e
-          | _ -> Ok (name, Some (default_un node_expr))
+          | _ -> Ok (name, Some (attach_contract (default_un node_expr)))
         else
-          Ok (name, Some (default_un node_expr))
+          Ok (name, Some (attach_contract (default_un node_expr)))
   in
 
   let rec desugar_all acc = function
@@ -2033,7 +2078,7 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
           un_serializer = Ast.mk_expr (Ast.Var "default"); un_deserializer = Ast.mk_expr (Ast.Var "default");
           un_env_vars = []; un_args = []; un_shell = None; un_shell_args = [];
           un_functions = []; un_includes = []; un_noop = false; un_dependencies = None;
-          un_pattern = None; un_iteration = "vector"; un_flake = None } in
+          un_pattern = None; un_iteration = "vector"; un_flake = None; un_contract = None } in
       let node_deps = match List.assoc_opt name deps with Some d -> d | None -> [] in
       let (v, own_warnings) = capture_node_warnings (fun () -> eval_or_defer name un current_env_ref) in
       let node_diagnostics =
@@ -2080,6 +2125,7 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
       p_patterns = List.filter_map (fun (name, un) -> match un.un_pattern with Some p -> Some (name, p) | None -> None) desugared_nodes;
       p_iterations = List.map (fun (name, un) -> (name, un.un_iteration)) desugared_nodes;
       p_flakes = List.map (fun (name, un) -> (name, un.un_flake)) desugared_nodes;
+      p_contracts = List.filter_map (fun (name, un) -> match un.un_contract with Some c -> Some (name, c) | None -> None) desugared_nodes;
     } in
     result
   end
@@ -2149,6 +2195,7 @@ and rerun_pipeline ?(strict=false) ?(verbose=true) env_ref (prev : Ast.pipeline_
       un_pattern = (match List.assoc_opt name prev.p_patterns with Some p -> Some p | None -> None);
       un_iteration = (match List.assoc_opt name prev.p_iterations with Some it -> it | None -> "vector");
       un_flake = (match List.assoc_opt name prev.p_flakes with Some f -> f | None -> None);
+      un_contract = (match List.assoc_opt name prev.p_contracts with Some c -> Some c | None -> None);
     })
   ) prev.p_exprs in
 
@@ -2185,7 +2232,7 @@ and rerun_pipeline ?(strict=false) ?(verbose=true) env_ref (prev : Ast.pipeline_
           un_serializer = Ast.mk_expr (Ast.Var "default"); un_deserializer = Ast.mk_expr (Ast.Var "default");
           un_env_vars = []; un_args = []; un_shell = None; un_shell_args = [];
           un_functions = []; un_includes = []; un_noop = false; un_dependencies = None;
-          un_pattern = None; un_iteration = "vector"; un_flake = None } in
+          un_pattern = None; un_iteration = "vector"; un_flake = None; un_contract = None } in
       let node_deps = match List.assoc_opt name prev.p_deps with Some d -> d | None -> [] in
       let deps_changed = List.exists (fun d -> List.mem d changed) node_deps in
       let fv = free_vars un.un_command in

--- a/src/package_manager/package_doctor.ml
+++ b/src/package_manager/package_doctor.ml
@@ -454,6 +454,7 @@ let static_pipeline_for_doctor ~project_root nodes =
     p_patterns = [];
     p_iterations = [];
     p_flakes = [];
+    p_contracts = [];
   }
 
 let read_file path =

--- a/src/packages/base/fetchurl.ml
+++ b/src/packages/base/fetchurl.ml
@@ -76,6 +76,7 @@ let register env =
                un_pattern = None;
                un_iteration = "vector";
                un_flake = None;
+               un_contract = None;
              }
          end else
            let output_name = match

--- a/src/packages/core/show_plot.ml
+++ b/src/packages/core/show_plot.ml
@@ -526,6 +526,7 @@ let build_ephemeral_plot_node node_name (un : unbuilt_node) =
       p_patterns = (match un.un_pattern with Some p -> [ (node_name, p) ] | None -> []);
       p_iterations = [ (node_name, un.un_iteration) ];
       p_flakes = [ (node_name, un.un_flake) ];
+      p_contracts = [];
     }
   in
   match Builder.populate_pipeline ~build:true pipeline with

--- a/src/packages/pipeline/arrange_node.ml
+++ b/src/packages/pipeline/arrange_node.ml
@@ -74,6 +74,7 @@ let register env =
           p_patterns     = reorder p.p_patterns;
           p_iterations   = reorder p.p_iterations;
           p_flakes       = reorder p.p_flakes;
+          p_contracts    = reorder p.p_contracts;
           p_has_patterns = p.p_has_patterns;
         }
       in

--- a/src/packages/pipeline/filter_node.ml
+++ b/src/packages/pipeline/filter_node.ml
@@ -85,6 +85,7 @@ let register ~eval_call env =
                       p_patterns     = List.filter (fun (n, _) -> keep_set n) p.p_patterns;
                       p_iterations   = List.filter (fun (n, _) -> keep_set n) p.p_iterations;
                       p_flakes       = List.filter (fun (n, _) -> keep_set n) p.p_flakes;
+                      p_contracts    = List.filter (fun (n, _) -> keep_set n) p.p_contracts;
                       p_has_patterns = (List.filter (fun (n, _) -> keep_set n) p.p_patterns <> []);
                     })
            | _ -> Error.type_error "Function `filter_node` expects a Pipeline as first argument.")

--- a/src/packages/pipeline/pipeline_composition.ml
+++ b/src/packages/pipeline/pipeline_composition.ml
@@ -288,8 +288,9 @@ let rec flatten_meta (v : value) : value =
              List.map (fun (n, pat) -> (ns n, namespace_pattern_expr sub_name local pat)) flat.p_patterns
            ) (@) in
             let p_iterations = merge_fields (fun flat _ ns -> List.map (fun (n, it) -> (ns n, it)) flat.p_iterations) (@) in
-            let p_flakes = merge_fields (fun flat _ ns -> List.map (fun (n, f) -> (ns n, f)) flat.p_flakes) (@) in
-            let p_has_patterns = List.exists (fun (_, flat_sub, _, _) -> flat_sub.p_has_patterns) namespaced_subs in
+             let p_flakes = merge_fields (fun flat _ ns -> List.map (fun (n, f) -> (ns n, f)) flat.p_flakes) (@) in
+             let p_contracts = merge_fields (fun flat _ ns -> List.map (fun (n, c) -> (ns n, c)) flat.p_contracts) (@) in
+             let p_has_patterns = List.exists (fun (_, flat_sub, _, _) -> flat_sub.p_has_patterns) namespaced_subs in
             VPipeline {
              p_nodes;
              p_exprs;
@@ -312,6 +313,7 @@ let rec flatten_meta (v : value) : value =
               p_patterns;
               p_iterations;
               p_flakes;
+              p_contracts;
             })
   | other ->
       Error.type_error (Printf.sprintf "flatten_meta: expected a MetaPipeline or Pipeline value, got %s." (Utils.type_name other))
@@ -388,8 +390,9 @@ let register ~(rerun_pipeline : ?strict:bool -> ?verbose:bool -> value Env.t -> 
                  p_node_diagnostics = merge_new p1'.p_node_diagnostics p2'.p_node_diagnostics;
                  p_has_patterns = p1'.p_has_patterns || p2'.p_has_patterns;
                  p_patterns     = merge_new p1'.p_patterns p2'.p_patterns;
-                 p_iterations   = merge_new p1'.p_iterations p2'.p_iterations;
-                 p_flakes       = merge_new p1'.p_flakes p2'.p_flakes;
+                  p_iterations   = merge_new p1'.p_iterations p2'.p_iterations;
+                  p_flakes       = merge_new p1'.p_flakes p2'.p_flakes;
+                  p_contracts    = merge_new p1'.p_contracts p2'.p_contracts;
                 }
            end)
        | [_; _] -> Error.type_error "Function `chain` expects two Pipeline arguments."
@@ -454,9 +457,10 @@ let register ~(rerun_pipeline : ?strict:bool -> ?verbose:bool -> value Env.t -> 
                 p_node_diagnostics = merge_new p1'.p_node_diagnostics p2'.p_node_diagnostics;
                 p_has_patterns = p1'.p_has_patterns || p2'.p_has_patterns;
                 p_patterns     = merge_new p1'.p_patterns p2'.p_patterns;
-                p_iterations   = merge_new p1'.p_iterations p2'.p_iterations;
-                p_flakes       = merge_new p1'.p_flakes p2'.p_flakes;
-              }
+                 p_iterations   = merge_new p1'.p_iterations p2'.p_iterations;
+                 p_flakes       = merge_new p1'.p_flakes p2'.p_flakes;
+                 p_contracts    = merge_new p1'.p_contracts p2'.p_contracts;
+               }
            )
       | [_; _] -> Error.type_error "Function `parallel` expects two Pipeline arguments."
       | _ -> Error.arity_error_named "parallel" 2 (List.length args)

--- a/src/packages/pipeline/pipeline_dag_ops.ml
+++ b/src/packages/pipeline/pipeline_dag_ops.ml
@@ -62,6 +62,7 @@ let filter_pipeline (names : string list) (p : pipeline_result) : pipeline_resul
     p_patterns     = List.filter (fun (n, _) -> keep n) p.p_patterns;
     p_iterations   = List.filter (fun (n, _) -> keep n) p.p_iterations;
     p_flakes       = List.filter (fun (n, _) -> keep n) p.p_flakes;
+    p_contracts    = List.filter (fun (n, _) -> keep n) p.p_contracts;
     p_has_patterns = (List.filter (fun (n, _) -> keep n) p.p_patterns <> []);
   }
 

--- a/src/packages/pipeline/pipeline_expand.ml
+++ b/src/packages/pipeline/pipeline_expand.ml
@@ -200,6 +200,7 @@ let make_branch (name : string) (orig_name : string) (i : int) (value_idx : int)
     un_pattern = None;
     un_iteration = "vector";
     un_flake = None;
+    un_contract = None;
   }}
 
 
@@ -561,7 +562,8 @@ let expand_pipeline_internal (p : pipeline_result) (env : value Env.t) (to_scrip
                  p_iterations     = List.filter (fun (n, _) -> not (is_removed n)) p.p_iterations @
                    List.map (fun b -> (b.branch_name, "vector")) branches;
                  p_flakes         = List.filter (fun (n, _) -> not (is_removed n)) p.p_flakes @
-                   List.map (fun b -> (b.branch_name, None)) branches;
+                    List.map (fun b -> (b.branch_name, None)) branches;
+                 p_contracts      = List.filter (fun (n, _) -> not (is_removed n)) p.p_contracts;
                } in
 
                match to_script with

--- a/src/packages/pipeline/pipeline_set_ops.ml
+++ b/src/packages/pipeline/pipeline_set_ops.ml
@@ -38,6 +38,7 @@ let filter_node_set keep_set p =
     p_patterns     = List.filter (fun (n, _) -> keep_set n) p.p_patterns;
     p_iterations   = List.filter (fun (n, _) -> keep_set n) p.p_iterations;
     p_flakes       = List.filter (fun (n, _) -> keep_set n) p.p_flakes;
+    p_contracts    = List.filter (fun (n, _) -> keep_set n) p.p_contracts;
     p_has_patterns = (List.filter (fun (n, _) -> keep_set n) p.p_patterns <> []);
   }
 
@@ -70,6 +71,7 @@ let union p1 p2 =
       p_patterns     = p1.p_patterns @ p2.p_patterns;
       p_iterations   = p1.p_iterations @ p2.p_iterations;
       p_flakes       = p1.p_flakes @ p2.p_flakes;
+      p_contracts    = p1.p_contracts @ p2.p_contracts;
       p_has_patterns = p1.p_has_patterns || p2.p_has_patterns;
     })
 
@@ -111,6 +113,7 @@ let patch p1 p2 =
     p_patterns     = p1_filtered.p_patterns @ p2_filtered.p_patterns;
     p_iterations   = p1_filtered.p_iterations @ p2_filtered.p_iterations;
     p_flakes       = p1_filtered.p_flakes @ p2_filtered.p_flakes;
+    p_contracts    = p1_filtered.p_contracts @ p2_filtered.p_contracts;
     p_has_patterns = p1_filtered.p_has_patterns || p2_filtered.p_has_patterns;
   }
 

--- a/src/packages/pipeline/rename_node.ml
+++ b/src/packages/pipeline/rename_node.ml
@@ -109,6 +109,7 @@ let register env =
               p_patterns     = rewire_patterns p.p_patterns;
               p_iterations   = rename_key p.p_iterations;
               p_flakes       = rename_key p.p_flakes;
+              p_contracts    = rename_key p.p_contracts;
             } in
             begin match Ast.get_in_memory_node_value ~p_exprs:p.p_exprs ~node_name:old_name with
             | Some v ->

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -784,8 +784,12 @@ let cmd_check_watch ?(json=false) ?(schema=false) ?(env_check=false) mode filena
   in
   let poll_interval = 0.5 in
   let last_mtime = ref (get_mtime filename) in
-  let first_run = ref true in
+  let last_exit_code = ref 0 in
   Printf.eprintf "Watching %s for changes (Ctrl+C to stop)...\n%!" filename;
+  (* Initial run *)
+  let check_result = run_check ~schema ~env_check mode filename env in
+  print_check_result ~json check_result;
+  last_exit_code := Diagnostics.exit_code_of_diagnostics (Diagnostics.check_result_entries check_result);
   let forever = ref true in
   Sys.set_signal Sys.sigint (Sys.Signal_handle (fun _ -> forever := false));
   while !forever do
@@ -793,14 +797,14 @@ let cmd_check_watch ?(json=false) ?(schema=false) ?(env_check=false) mode filena
     let current_mtime = get_mtime filename in
     if current_mtime > !last_mtime then begin
       last_mtime := current_mtime;
-      if not !first_run then
-        Printf.eprintf "\n--- file changed, re-checking ---\n%!";
-      first_run := false;
+      Printf.eprintf "\n--- file changed, re-checking ---\n%!";
       let check_result = run_check ~schema ~env_check mode filename env in
-      print_check_result ~json check_result
+      print_check_result ~json check_result;
+      last_exit_code := Diagnostics.exit_code_of_diagnostics (Diagnostics.check_result_entries check_result)
     end
   done;
-  Printf.eprintf "\nStopped watching.\n%!"
+  Printf.eprintf "\nStopped watching.\n%!";
+  exit !last_exit_code
 
 let cmd_debug ?(unsafe=false) ?failfast mode filename node_name env =
   let _ = unsafe in

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -708,7 +708,7 @@ let cmd_run_expr ?failfast mode expr env =
   | Ast.(VNA NAGeneric) -> ()
   | v -> print_string (Pretty_print.pretty_print_value v)
 
-let cmd_check ?(json=false) ?(schema=false) ?(env_check=false) mode filename env =
+let run_check ?(schema=false) ?(env_check=false) mode filename env =
   Packages.ensure_docs_loaded ();
   ensure_file_path filename;
   let run () =
@@ -756,6 +756,9 @@ let cmd_check ?(json=false) ?(schema=false) ?(env_check=false) mode filename env
     let tier = Diagnostics.worst_tier diag_list in
     Diagnostics.make_result ~tier ~phase:check_phase diag_list
   in
+  check_result
+
+let print_check_result ?(json=false) check_result =
   if json then
     print_string (Yojson.Safe.pretty_to_string (Diagnostics.check_result_to_yojson check_result))
   else begin
@@ -768,8 +771,36 @@ let cmd_check ?(json=false) ?(schema=false) ?(env_check=false) mode filename env
     ) cr_diags;
     if cr_diags <> [] then
       Printf.eprintf "\n"
-  end;
+  end
+
+let cmd_check ?(json=false) ?(schema=false) ?(env_check=false) mode filename env =
+  let check_result = run_check ~schema ~env_check mode filename env in
+  print_check_result ~json check_result;
   exit (Diagnostics.exit_code_of_diagnostics (Diagnostics.check_result_entries check_result))
+
+let cmd_check_watch ?(json=false) ?(schema=false) ?(env_check=false) mode filename env =
+  let get_mtime path =
+    try (Unix.stat path).Unix.st_mtime with Unix.Unix_error _ -> 0.0
+  in
+  let poll_interval = 0.5 in
+  let last_mtime = ref (get_mtime filename) in
+  let first_run = ref true in
+  Printf.eprintf "Watching %s for changes (Ctrl+C to stop)...\n%!" filename;
+  let forever = ref true in
+  Sys.set_signal Sys.sigint (Sys.Signal_handle (fun _ -> forever := false));
+  while !forever do
+    Unix.sleepf poll_interval;
+    let current_mtime = get_mtime filename in
+    if current_mtime > !last_mtime then begin
+      last_mtime := current_mtime;
+      if not !first_run then
+        Printf.eprintf "\n--- file changed, re-checking ---\n%!";
+      first_run := false;
+      let check_result = run_check ~schema ~env_check mode filename env in
+      print_check_result ~json check_result
+    end
+  done;
+  Printf.eprintf "\nStopped watching.\n%!"
 
 let cmd_debug ?(unsafe=false) ?failfast mode filename node_name env =
   let _ = unsafe in
@@ -1470,20 +1501,24 @@ let () =
       Printf.eprintf "Unexpected arguments after `t run <file.t>`.\n";
       exit 1
   | _ :: "check" :: [] ->
-      Printf.eprintf "Usage: t check [--json] [--schema] [--env] <file.t>\n";
+      Printf.eprintf "Usage: t check [--json] [--schema] [--env] [--watch] <file.t>\n";
       exit 1
   | _ :: "check" :: rest ->
       let json = List.mem "--json" rest in
       let schema = List.mem "--schema" rest in
       let check_env = List.mem "--env" rest in
+      let watch = List.mem "--watch" rest in
       let filename = List.find_opt (fun s -> not (String.length s > 0 && s.[0] = '-')) rest in
       let script_mode = if mode_parse.mode = Typecheck.Repl && not mode_parse.mode_flag then Typecheck.Strict else mode_parse.mode in
       (match filename with
        | None ->
-           Printf.eprintf "Usage: t check [--json] [--schema] [--env] <file.t>\n";
+           Printf.eprintf "Usage: t check [--json] [--schema] [--env] [--watch] <file.t>\n";
            exit 1
        | Some f ->
-           cmd_check ~json ~schema ~env_check:check_env script_mode f env)
+           if watch then
+             cmd_check_watch ~json ~schema ~env_check:check_env script_mode f env
+           else
+             cmd_check ~json ~schema ~env_check:check_env script_mode f env)
   | _ :: "repl" :: _ -> cmd_repl ~failfast mode_parse.mode env
   | _ :: "explain" :: rest -> cmd_explain ~failfast mode_parse.mode rest env
   | _ :: "init" :: "--package" :: rest -> cmd_init_package rest

--- a/src/schema_check.ml
+++ b/src/schema_check.ml
@@ -221,6 +221,41 @@ let validate_col_refs ~node_name ~(file : string option) ~schema expr =
     end
   ) refs
 
+(* ---------- Contract validation ---------- *)
+
+(* Validate contracts attached via expect() against inferred schemas.
+   Checks that all declared contract columns exist in the output schema. *)
+let validate_contracts ~file (p : pipeline_result) schemas =
+  List.filter_map (fun (node_name, contract) ->
+    let output_schema =
+      try Hashtbl.find schemas node_name with Not_found -> []
+    in
+    match contract.contract_columns with
+    | None -> None
+    | Some required_cols ->
+        let missing = List.filter (fun col -> not (List.mem col output_schema)) required_cols in
+        if missing <> [] then
+          Some (Diagnostics.{
+            diag_id = Diagnostics.gen_id ();
+            diag_error_class = "contract_violation";
+            diag_severity = Error;
+            diag_phase = Schema;
+            diag_node_id = Some node_name;
+            diag_node_lang = None;
+            diag_file = Some file;
+            diag_line = None;
+            diag_column = None;
+            diag_message = Printf.sprintf "Node '%s' contract expects columns [%s] but output schema is [%s]. Missing: [%s]"
+              node_name
+              (String.concat ", " required_cols)
+              (String.concat ", " output_schema)
+              (String.concat ", " missing);
+            diag_caused_by = [];
+            diag_suggested_fix = NoFix;
+          })
+        else None
+  ) p.p_contracts
+
 (* ---------- Main entry point ---------- *)
 
 (* Check schemas for a pipeline. Returns Schema-phase diagnostics. *)
@@ -372,4 +407,6 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
       | _ -> ()
   ) topo_order;
 
-  !diagnostics
+  (* Validate contracts (expect() annotations) against computed schemas *)
+  let contract_diags = validate_contracts ~file p schemas in
+  contract_diags @ !diagnostics

--- a/summary.md
+++ b/summary.md
@@ -78,7 +78,7 @@ t check path/to/script.t                  # structural validation (default: no N
 t check --schema path/to/script.t          # + column-level schema validation
 t check --env path/to/script.t             # + environment/lockfile checks + Nix eval
 t check --json path/to/script.t            # machine-readable diagnostics
-t check --watch path/to/script.t           # re-run on file save (Ctrl+C to stop)
+t check --watch path/to/script.t           # run immediately, then re-run on file save
 
 t test
 
@@ -206,6 +206,12 @@ build_pipeline(p)
 ```
 
 Pipelines are DAGs. Nodes can be declared in any order; dependencies are resolved automatically.
+
+**Shape Contracts**: Use `expect(columns = [...])` at the end of a pipe chain to declare expected output columns. Contracts are checked statically via `t check --schema`.
+
+```t
+clean = raw |> filter($age > 18) |> expect(columns = ["id", "name", "age"])
+```
 
 **Block Evaluation**: Blocks (`{ ... }`) abort immediately on encountering a `VError`, returning the error rather than continuing evaluation of remaining statements. Nodes that soft-fail and return `VError` conditionally fall back to binary serialization rather than triggering custom serializers like Arrow, preventing crashes.
 

--- a/summary.md
+++ b/summary.md
@@ -78,6 +78,7 @@ t check path/to/script.t                  # structural validation (default: no N
 t check --schema path/to/script.t          # + column-level schema validation
 t check --env path/to/script.t             # + environment/lockfile checks + Nix eval
 t check --json path/to/script.t            # machine-readable diagnostics
+t check --watch path/to/script.t           # re-run on file save (Ctrl+C to stop)
 
 t test
 

--- a/tests/test_check.ml
+++ b/tests/test_check.ml
@@ -266,4 +266,30 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
   check "terminal expect: contract attached with columns" has_contract;
   Ast.check_mode := false;
 
+  (* End-to-end: verify warning survives of_pipeline_result (the t check path) *)
+  Printf.printf "\nMid-chain expect() end-to-end (of_pipeline_result):\n";
+  Ast.check_mode := true;
+  let e2e_result = eval_string "pipeline { a = 1 |> expect(columns = [\"x\"]) |> as.integer() }" in
+  let e2e_diags = match e2e_result with
+    | VPipeline p -> Diagnostics.of_pipeline_result p
+    | _ -> []
+  in
+  let e2e_has_warn = List.exists (fun d ->
+    d.Diagnostics.diag_error_class = "invalid_expect_placement"
+    && d.Diagnostics.diag_phase = Diagnostics.Wire
+  ) e2e_diags in
+  check "of_pipeline_result surfaces invalid_expect_placement diagnostic" e2e_has_warn;
+
+  (* Verify terminal expect() does NOT produce a spurious diagnostic *)
+  let e2e_terminal = eval_string "pipeline { a = 1 |> expect(columns = [\"x\"]) }" in
+  let e2e_terminal_diags = match e2e_terminal with
+    | VPipeline p -> Diagnostics.of_pipeline_result p
+    | _ -> []
+  in
+  let e2e_no_spurious = not (List.exists (fun d ->
+    d.Diagnostics.diag_error_class = "invalid_expect_placement"
+  ) e2e_terminal_diags) in
+  check "of_pipeline_result: no spurious diagnostic for terminal expect" e2e_no_spurious;
+  Ast.check_mode := false;
+
   Printf.printf "\n";

--- a/tests/test_check.ml
+++ b/tests/test_check.ml
@@ -230,4 +230,40 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
   check_eq "validate_contracts: passes when all columns present"
     (string_of_int (List.length pass_diags)) "0";
 
+  Printf.printf "\nMid-chain expect() placement:\n";
+
+  (* Test that mid-chain expect() produces a warning *)
+  Ast.check_mode := true;
+  let result = eval_string "pipeline { a = 1 |> expect(columns = [\"x\"]) |> as.integer() }" in
+  let has_warn = match result with
+    | VPipeline p ->
+        List.exists (fun (_, diag) ->
+          List.exists (fun w -> w.Ast.nw_kind = "invalid_expect_placement") diag.Ast.nd_warnings
+        ) p.p_node_diagnostics
+    | _ -> false
+  in
+  check "mid-chain expect: produces invalid_expect_placement warning" has_warn;
+  Ast.check_mode := false;
+
+  (* Test that terminal expect() does NOT produce a mid-chain warning *)
+  Ast.check_mode := true;
+  let result2 = eval_string "pipeline { a = 1 |> expect(columns = [\"x\"]) }" in
+  let has_mid_warn = match result2 with
+    | VPipeline p ->
+        List.exists (fun (_, diag) ->
+          List.exists (fun w -> w.Ast.nw_kind = "invalid_expect_placement") diag.Ast.nd_warnings
+        ) p.p_node_diagnostics
+    | _ -> false
+  in
+  check "terminal expect: no mid-chain warning" (not has_mid_warn);
+
+  (* Test that terminal expect() attaches the contract *)
+  let has_contract = match result2 with
+    | VPipeline p ->
+        List.exists (fun (_, c) -> c.Ast.contract_columns = Some ["x"]) p.p_contracts
+    | _ -> false
+  in
+  check "terminal expect: contract attached with columns" has_contract;
+  Ast.check_mode := false;
+
   Printf.printf "\n";

--- a/tests/test_check.ml
+++ b/tests/test_check.ml
@@ -199,7 +199,6 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
     p_has_patterns = false; p_patterns = []; p_iterations = [];
     p_flakes = [];
     p_contracts = ["clean", {
-      empty_contract with
       contract_columns = Some ["mpg"; "cyl"; "hp"];
     }];
   } in
@@ -223,7 +222,6 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
     p_has_patterns = false; p_patterns = []; p_iterations = [];
     p_flakes = [];
     p_contracts = ["clean", {
-      empty_contract with
       contract_columns = Some ["mpg"; "cyl"];
     }];
   } in

--- a/tests/test_check.ml
+++ b/tests/test_check.ml
@@ -185,4 +185,51 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
   (* Cleanup temp fixture *)
   ignore (Sys.command "rm -rf /tmp/schema_test");
 
+  Printf.printf "\nContract validation:\n";
+
+  (* Test validate_contracts detects missing columns *)
+  let schemas_tbl = Hashtbl.create 4 in
+  Hashtbl.add schemas_tbl "clean" ["mpg"; "cyl"];
+  let p_with_contract = {
+    p_nodes = []; p_exprs = []; p_deps = []; p_imports = [];
+    p_runtimes = []; p_serializers = []; p_deserializers = [];
+    p_env_vars = []; p_args = []; p_shells = []; p_shell_args = [];
+    p_functions = []; p_includes = []; p_noops = []; p_scripts = [];
+    p_explicit_deps = []; p_node_diagnostics = [];
+    p_has_patterns = false; p_patterns = []; p_iterations = [];
+    p_flakes = [];
+    p_contracts = ["clean", {
+      empty_contract with
+      contract_columns = Some ["mpg"; "cyl"; "hp"];
+    }];
+  } in
+  let contract_diags = Schema_check.validate_contracts
+    ~file:"test.t" p_with_contract schemas_tbl in
+  check_eq "validate_contracts: detects missing column"
+    (string_of_int (List.length contract_diags)) "1";
+  let missing_msg = Diagnostics.diagnostic_message (List.hd contract_diags) in
+  check "validate_contracts: message mentions missing column"
+    (Str.string_match (Str.regexp ".*Missing.*hp.*") missing_msg 0);
+
+  (* Test validate_contracts passes when all columns present *)
+  let schemas_tbl2 = Hashtbl.create 4 in
+  Hashtbl.add schemas_tbl2 "clean" ["mpg"; "cyl"; "hp"];
+  let p_pass = {
+    p_nodes = []; p_exprs = []; p_deps = []; p_imports = [];
+    p_runtimes = []; p_serializers = []; p_deserializers = [];
+    p_env_vars = []; p_args = []; p_shells = []; p_shell_args = [];
+    p_functions = []; p_includes = []; p_noops = []; p_scripts = [];
+    p_explicit_deps = []; p_node_diagnostics = [];
+    p_has_patterns = false; p_patterns = []; p_iterations = [];
+    p_flakes = [];
+    p_contracts = ["clean", {
+      empty_contract with
+      contract_columns = Some ["mpg"; "cyl"];
+    }];
+  } in
+  let pass_diags = Schema_check.validate_contracts
+    ~file:"test.t" p_pass schemas_tbl2 in
+  check_eq "validate_contracts: passes when all columns present"
+    (string_of_int (List.length pass_diags)) "0";
+
   Printf.printf "\n";


### PR DESCRIPTION
Implements t check --watch: polls the input file for mtime changes every 0.5s and re-runs the check on modification. Can be combined with --schema and/or --env. Ctrl+C to stop.

Refactored cmd_check to separate run_check (core logic) from print_check_result (output formatting), enabling the watch loop to reuse the check pipeline without duplicating logic.

Updates api-reference.md, summary.md, and changelog.md.