### PR TITLE
feat(diff): add content-addressed output diffing (t diff / diff_summary)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,9 @@ t check --schema myfile.t
 # Watch mode: re-run on file save
 t check --watch myfile.t
 
+# Compare two builds (output diff)
+t diff myfile.t
+
 # Build with coverage instrumentation (Nix)
 nix build .#t-coverage
 ./result/bin/t run myfile.t

--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ T requires [Nix](docs/nix-installation.md) with flakes enabled. T is distributed
 
 We recommend using the [Determinate Systems Nix Installer](https://install.determinate.systems/nix) for the best experience. See the [Nix Installation Guide](docs/nix-installation.md) for detailed platform-specific steps.
 
+> [!NOTE]
+> After installing Nix, you may need to add yourself as a trusted user so that Nix
+> can use the T binary cache. See
+> [Configuring Trusted Users](docs/nix-installation.md#configuring-trusted-users) for
+> platform-specific steps.
+
 Start by launching a temporary shell that provides the `t` executable:
 
 ```bash

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3200,6 +3200,78 @@ build_pipeline(p, nix_options = [targets: ["c"], max_jobs: 4, cache: "rstats-on-
 
 ---
 
+### `t_check(file, json = false, schema = false, env = false)`
+
+REPL-callable version of `t check`. Runs structural, wire-phase, schema, and environment checks on a T script and returns the diagnostics as a string.
+
+**Arguments:**
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `file` | String | *(required)* | Path to the `.t` file to check |
+| `json` | Bool | `false` | Output diagnostics as JSON |
+| `schema` | Bool | `false` | Enable column-level schema validation |
+| `env` | Bool | `false` | Enable `tproject.toml` environment checks |
+
+**Returns:** `String` — formatted diagnostics (text or JSON, same as CLI `t check`).
+
+**Examples:**
+
+```t
+result = t_check("src/pipeline.t")
+result = t_check("src/pipeline.t", schema = true)
+result = t_check("src/pipeline.t", json = true, schema = true, env = true)
+```
+
+---
+
+### `t_diff(file, json = false, log_a = 2, log_b = 1)`
+
+REPL-callable version of `t diff`. Compares two builds of a pipeline using per-node Nix content hashes and returns the diff summary as a string.
+
+**Arguments:**
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `file` | String | *(required)* | Path to the `.t` file to diff |
+| `json` | Bool | `false` | Output diff as JSON |
+| `log_a` | Int | `2` | Rank of the first (older) build log |
+| `log_b` | Int | `1` | Rank of the second (newer) build log |
+
+**Returns:** `String` — formatted diff (text or JSON, same as CLI `t diff`).
+
+**Examples:**
+
+```t
+result = t_diff("src/pipeline.t")
+result = t_diff("src/pipeline.t", log_a = 1, log_b = 2)
+result = t_diff("src/pipeline.t", json = true)
+```
+
+---
+
+### `t_fix(file, dry_run = false)`
+
+REPL-callable version of `t fix`. Runs `t check --schema` on a file, extracts diagnostics with `suggested_fix`, and applies them mechanically (e.g., inserting `|> mutate($col = as.type($col))` for type contract violations).
+
+**Arguments:**
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `file` | String | *(required)* | Path to the `.t` file to fix |
+| `dry_run` | Bool | `false` | Show what would be fixed without modifying the file |
+
+**Returns:** `String` — summary of fixes applied (or would be applied), same as CLI `t fix`.
+
+**Examples:**
+
+```t
+result = t_fix("src/pipeline.t")
+result = t_fix("src/pipeline.t", dry_run = true)
+```
+
+---
+
 ### `t check` (CLI)
 
 Structural pipeline validation without triggering Nix builds. Runs the full evaluator with `--failfast` but short-circuits Nix builds, so it can surface errors across all phases — syntax (parse), graph structure (wire), types (schema), and environment (missing files). The reported `tier` and `phase` reflect the deepest phase reached during evaluation, not a fixed depth limit.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3572,27 +3572,48 @@ t diff <file.t> --json             # structured JSON output
 t diff <file.t> --log-a 2 --log-b 4  # compare specific build ranks
 ```
 
-### `collect_exceptions(p)`
+---
 
-Collects all terminal error exceptions and non-terminal warning diagnostics from the computed nodes of a built pipeline.
+### CLI: `t fix`
 
-**Parameters:**
+Mechanically applies `suggested_fix` values from `t check --json` diagnostics. Runs `t check --json` internally, collects diagnostics with non-null `suggested_fix`, and applies them to the source file.
 
-- `p` — The Pipeline object to collect diagnostics from.
+```bash
+t fix <file.t>                     # apply all suggested fixes
+t fix --dry-run <file.t>           # preview fixes without applying
+```
 
-**Returns:**
+**Supported fix types:**
 
-`DataFrame` — A DataFrame with columns `node`, `status`, `code`, and `message` detailing the exceptions and warnings across all nodes.
+| Fix Kind | Action |
+|----------|--------|
+| `cast` | Inserts `\|> mutate($col = as.type($col, "target"))` before the `expect()` node |
+| `rename_column` | Replaces all occurrences of the old column name with the new name |
+| `add_node_arg` | (planned) Adds an argument to a pipeline node |
+| `pin_package_version` | (planned) Adds or updates a package version in `tproject.toml` |
 
-**Examples:**
-```t
-p = pipeline { a = 1 / 0; b = a + 5 }
-build_pipeline(p)
-exceptions = collect_exceptions(p)
--- Returns a DataFrame with:
---   node | status  | code             | message
---   "a"  | "Error" | "DivisionByZero" | "Division by zero"
---   "b"  | "Error" | "UpstreamError"  | "Upstream dependency 'a' failed"
+**Exit codes:**
+
+| Code | Meaning |
+|------|---------|
+| 0 | Fixes applied (or `--dry-run` preview completed) |
+| 1 | No fixes available or `t check` failed |
+
+**Example:**
+
+```bash
+$ t check --json pipeline.t | jq '.diagnostics[].suggested_fix'
+{
+  "kind": "cast",
+  "column": "amount",
+  "cast_to": "double",
+  "file": "pipeline.t",
+  "line": 5
+}
+
+$ t fix pipeline.t
+Applied 1 fix(es), skipped 0.
+Run 't check pipeline.t' to verify.
 ```
 
 ---

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3281,7 +3281,7 @@ When `--watch` is passed, `t check` runs immediately, then polls the input file 
 
 ### `expect()` — Pipeline shape contracts
 
-Attach a shape contract to a pipeline node to declare expected output column names.
+Attach a shape contract to a pipeline node to declare expected output properties.
 Contracts are checked statically via `t check --schema`.
 
 **Syntax:**
@@ -3293,6 +3293,15 @@ clean_data = raw_data
   |> expect(columns = ["id", "name", "score"])
 ```
 
+Type contracts and null-rate contracts can be mixed with column contracts:
+
+```t
+clean_data = raw_data
+  |> expect(columns = ["id", "amount", "region"],
+             amount ~ double(),
+             null_rate("amount") < 0.02)
+```
+
 `expect()` must appear at the **end** of a pipe chain.
 
 **Accepted arguments:**
@@ -3300,16 +3309,22 @@ clean_data = raw_data
 | Argument | Type | Description |
 |----------|------|-------------|
 | `columns` | `List[String]` | Expected column names in the output |
+| `col ~ type()` | Type contract | Asserts a column has a specific type (e.g., `amount ~ double()`, `id ~ int()`) |
+| `null_rate("col") < n` | Null-rate contract | Asserts the fraction of null values in a column is below a threshold |
 
 **Behavior:**
 
-- Checked only when `t check --schema` is used (tier 2)
-- If the inferred output schema is missing any declared columns, a `contract_violation` diagnostic is emitted
-- `expect()` is stripped from the pipe chain during evaluation — it has no runtime effect
+- Column contracts: checked when `t check --schema` is used (tier 2). If the inferred output schema is missing any declared columns, a `contract_violation` diagnostic is emitted.
+- Type contracts: checked statically when the column type is known (e.g., from CSV headers). If the type doesn't match, a `contract_violation` error is emitted. If the type is unknown (e.g., Python/Julia nodes), a `contract_unverifiable` warning is emitted.
+- Null-rate contracts: cannot be verified statically (require actual data). A `contract_unverifiable` warning is emitted during `t check --schema`. Runtime enforcement is planned for a future release.
+- `expect()` is stripped from the pipe chain during evaluation — it has no runtime effect.
+
+**Supported type names:** `double`, `int`, `string`, `bool`, `date`
 
 **Limitations:**
 
-- Only column names are checked; types, row counts, and null rates are not yet enforced
+- Null-rate contracts are checked at `t check --schema` time as warnings only; runtime enforcement is not yet implemented
+- Type inference from CSV headers is based on sampling; complex types may not be detected correctly
 - Column validation depends on accurate schema inference (CSV headers for root nodes, colcraft verb propagation for downstream nodes)
 
 ---

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3517,6 +3517,46 @@ diff_model = node_diff(p.model_node, p.model_node, log_a = ".*train1.*", log_b =
 
 ---
 
+### `diff_summary(p)`
+
+Compares the two most recent builds of a pipeline and returns a DataFrame summarizing which nodes changed, were added, or were removed. Uses per-node Nix content hashes stored in build logs for fast comparison without loading artifacts.
+
+**Parameters:**
+
+- `p` — The pipeline to compare builds for.
+
+**Returns:**
+
+`DataFrame` — A summary with columns:
+- `name` (String) — Node name.
+- `status` (String) — One of `"unchanged"`, `"changed"`, `"added"`, `"removed"`.
+- `hash_a` (String) — Nix content hash from build A.
+- `hash_b` (String) — Nix content hash from build B.
+- `class_a` (String) — Output value class from build A.
+- `class_b` (String) — Output value class from build B.
+
+**Examples:**
+```t
+p = pipeline { a = 1; b = 2 }
+build_pipeline(p)
+-- ... edit pipeline ...
+build_pipeline(p)
+summary = diff_summary(p)
+print(summary)
+```
+
+---
+
+### CLI: `t diff`
+
+The `t diff` command provides the same functionality from the shell, without needing to write a T script:
+
+```bash
+t diff <file.t>                    # compare last two builds
+t diff <file.t> --json             # structured JSON output
+t diff <file.t> --log-a 2 --log-b 4  # compare specific build ranks
+```
+
 ### `collect_exceptions(p)`
 
 Collects all terminal error exceptions and non-terminal warning diagnostics from the computed nodes of a built pipeline.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,6 +14,12 @@ platform-specific steps, please see our:
 
 👉 **[Nix Installation Guide](nix-installation.md)**
 
+> [!NOTE]
+> After installing Nix, you may need to add yourself as a trusted user so that Nix
+> can fetch pre-built binaries from the T cache. If you see warnings like
+> `ignoring untrusted substituter`, follow the steps in
+> [Configuring Trusted Users](nix-installation.md#configuring-trusted-users).
+
 ## Running T
 
 As a user, you don't need to clone the repository or build the compiler from

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,13 +41,28 @@ echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
 Append `--extra-experimental-features "nix-command flakes"` to each Nix command.
 
 ### Trusted Users and Binary Caches
-If you see warnings like `ignoring untrusted substituter`, you need to add yourself as a trusted user so Nix allows you to use the T binary cache. On macOS, run:
+If you see warnings like `ignoring untrusted substituter`, you need to add yourself as a trusted user so Nix allows you to use the T binary cache.
+
+**Linux (Ubuntu, Debian, Fedora, Arch):**
 
 ```bash
-echo "trusted-users = root $USER" | sudo tee -a /etc/nix/nix.custom.conf && sudo launchctl kickstart -k system/org.nixos.nix-daemon
+sudo nano /etc/nix/nix.conf
+# Add: trusted-users = root your_username
+sudo systemctl restart nix-daemon.service
 ```
 
-This works for both standard and Determinate Nix installations.
+**macOS:**
+
+```bash
+echo "trusted-users = root $USER" | sudo tee -a /etc/nix/nix.custom.conf
+sudo launchctl kickstart -k system/org.nixos.nix-daemon
+```
+
+**NixOS:**
+
+Add `nix.trustedUsers = [ "root" "your_username" ];` to your `configuration.nix` and run `sudo nixos-rebuild switch`.
+
+See the [Nix Installation Guide](nix-installation.md#configuring-trusted-users) for detailed per-distro instructions.
 
 ## Step 3: Clone T Repository
 

--- a/docs/llm-collaboration.md
+++ b/docs/llm-collaboration.md
@@ -61,6 +61,15 @@ Before an agent generates or modifies pipeline code, it should validate the resu
 | :--- | :--- | :--- |
 | `t check <file.t>` | Pipeline DAG structure, dependency cycles, node syntax | No |
 | `t check --schema <file.t>` | + column references, schema propagation, `expect()` contracts | No |
+
+**REPL-callable versions** (same options, returns `String`):
+
+```t
+result = t_check("src/pipeline.t")             -- same as: t check
+result = t_check("src/pipeline.t", schema=true) -- same as: t check --schema
+result = t_diff("src/pipeline.t")              -- same as: t diff
+result = t_fix("src/pipeline.t")               -- same as: t fix
+```
 | `t check --env <file.t>` | + `tproject.toml` declarations, lockfile consistency, Nix eval | Yes |
 | `t check --json <file.t>` | Structured JSON diagnostics (works with any tier) | Depends on tier |
 
@@ -599,10 +608,10 @@ These tools give agents structured, parseable output instead of human-readable e
 3. **Include Error Handling**: Use `na_rm`, validation checks
 4. **Preserve Intents**: Keep intent blocks in generated code
 5. **Explain Assumptions**: Document why specific approaches were chosen
-6. **Always `t check` First**: Run `t check --schema` before `build_pipeline` — it catches structural and schema errors in seconds
+6. **Always `t check` First**: Run `t check --schema` before `build_pipeline` — it catches structural and schema errors in seconds. In the REPL, use `t_check(file, schema=true)` (same behavior, returns a string).
 7. **Declare Shapes**: Add `expect(columns = [...])` to pipeline nodes so downstream agents (and humans) know the output contract
-8. **Use `t fix` for Mechanical Changes**: When `t check --json` reports a `suggested_fix`, apply it with `t fix` rather than manually editing — it handles line-number drift and word-boundary safety
-9. **Verify with `t diff`**: After modifying a pipeline, run `t diff` to confirm only the intended nodes changed
+8. **Use `t fix` for Mechanical Changes**: When `t check --json` reports a `suggested_fix`, apply it with `t fix` rather than manually editing — it handles line-number drift and word-boundary safety. In the REPL, use `t_fix(file)`.
+9. **Verify with `t diff`**: After modifying a pipeline, run `t diff` to confirm only the intended nodes changed. In the REPL, use `t_diff(file)`.
 
 ---
 
@@ -746,4 +755,4 @@ git show abc123:src/pipeline.t
 - [Examples](examples.md) — Intent-driven analysis examples
 - [Pipeline Tutorial](pipeline_tutorial.md) — Pipeline structure
 - [Debugging](debugging.md) — `t debug` for interactive node debugging
-- [API Reference](api-reference.md) — `t check`, `t fix`, `t diff` CLI documentation
+- [API Reference](api-reference.md) — `t_check()`, `t_diff()`, `t_fix()` REPL functions and `t check`, `t fix`, `t diff` CLI documentation

--- a/docs/llm-collaboration.md
+++ b/docs/llm-collaboration.md
@@ -47,6 +47,152 @@ T treats LLMs as **first-class collaborators** with structured boundaries:
 2. **Local over Global**: LLMs generate pipeline nodes, not entire scripts
 3. **Inspectable over Opaque**: Intent blocks make assumptions explicit
 4. **Regenerable over Brittle**: Stable boundaries enable safe code updates
+5. **Validatable over Trusting**: Instant static checks catch errors before Nix builds
+
+---
+
+## Instant Feedback: `t check`
+
+Before an agent generates or modifies pipeline code, it should validate the result. T provides a tiered checking system that runs in seconds — no Nix builds required.
+
+### Three Tiers of Checking
+
+| Command | What it checks | Nix required? |
+| :--- | :--- | :--- |
+| `t check <file.t>` | Pipeline DAG structure, dependency cycles, node syntax | No |
+| `t check --schema <file.t>` | + column references, schema propagation, `expect()` contracts | No |
+| `t check --env <file.t>` | + `tproject.toml` declarations, lockfile consistency, Nix eval | Yes |
+| `t check --json <file.t>` | Structured JSON diagnostics (works with any tier) | Depends on tier |
+
+The first two tiers are the workhorses for agent iteration. They catch structural errors and schema mismatches in seconds, letting agents fix problems before triggering expensive Nix builds.
+
+### Watch Mode
+
+Use `--watch` during active development for continuous feedback:
+
+```bash
+t check --watch --schema src/pipeline.t
+```
+
+This runs immediately, then re-runs on every file save. Press Ctrl+C to stop. The exit code reflects the last check's result, making it usable in CI and editor integrations.
+
+### Shape Contracts with `expect()`
+
+Agents declare expected output columns on pipeline nodes using `expect()`:
+
+```t
+clean = raw
+  |> filter($status == "complete")
+  |> mutate($score = as.numeric($score))
+  |> expect(columns = ["id", "name", "score"])
+```
+
+- `expect()` must appear at the **end** of a pipe chain
+- Checked statically via `t check --schema` — emits `contract_violation` if columns are missing
+- Mid-chain `expect()` (e.g., `raw |> expect(...) |> filter(...)`) produces a warning
+- `expect()` has no runtime effect — it is stripped during evaluation
+
+#### Type Contracts
+
+Declare expected column types to catch type mismatches statically:
+
+```t
+clean = raw
+  |> expect(
+       columns = ["id", "amount", "date"],
+       amount ~ double()
+     )
+```
+
+Type contracts like `amount ~ double()` are checked during `t check --schema`. If the column exists in the schema but has a different type, a `contract_violation` error is emitted with a mechanical fix suggestion.
+
+#### Null-Rate Contracts
+
+Declare acceptable null-rate thresholds (deferred to runtime):
+
+```t
+clean = raw
+  |> expect(
+       columns = ["id", "amount"],
+       null_rate("amount") < 0.05
+     )
+```
+
+Null-rate contracts emit a `contract_unverifiable` warning during `t check --schema` because they require runtime data to evaluate. The check still validates that the referenced column exists.
+
+### Structured Diagnostics
+
+`t check --json` emits machine-readable diagnostics:
+
+```json
+{
+  "diagnostics": [
+    {
+      "error_class": "contract_violation",
+      "message": "Node 'clean' contract expects columns [id, name, score] but output schema is [id, name]. Missing: [score]",
+      "node": "clean",
+      "span": { "start": [12, 5], "end": [12, 50] },
+      "suggested_fix": null
+    }
+  ],
+  "exit_code": 1
+}
+```
+
+Each diagnostic includes:
+- `error_class`: categorizes the issue (`contract_violation`, `type_mismatch`, `cycle_detected`, etc.)
+- `node`: the pipeline node where the issue was found
+- `span`: source location `[line, column]`
+- `suggested_fix`: a mechanical fix the agent can apply (see `t fix` below)
+
+Agents consume this output to make targeted decisions — no parsing of human-readable error strings required.
+
+### Mechanical Fixes with `t fix`
+
+When `t check --schema` emits a `suggested_fix`, the agent can apply it mechanically:
+
+```bash
+t fix src/pipeline.t          -- apply fixes and rewrite the file
+t fix --dry-run src/pipeline.t -- preview changes without modifying
+```
+
+Currently supported fix types:
+
+| Fix type | What it does |
+| :--- | :--- |
+| **Cast** | Inserts a type coercion (e.g., `mutate($amount = as.numeric($amount))`) when a type contract expects a different type |
+| **Rename_column** | Renames `$old_name` column references to `$new_name` throughout the file |
+| **Add_node_arg** | Adds a missing argument to a node function call |
+| **Pin_package_version** | Pins a dependency to a specific version in `tproject.toml` |
+
+The agent workflow is: run `t check --schema`, parse the JSON output for `suggested_fix` entries, then run `t fix` to apply them. Always review the diff before committing.
+
+### Build Diffing with `t diff`
+
+After iterative development, `t diff` compares the last two Nix builds of a pipeline:
+
+```bash
+t diff src/pipeline.t
+```
+
+It reports per-node status:
+
+| Status | Meaning |
+| :--- | :--- |
+| **Unchanged** | Same content hash in both builds |
+| **Changed** | Different content hash |
+| **Added** | Present in second build, absent in first |
+| **Removed** | Present in first build, absent in second |
+| **Errored** | Node failed in one or both builds |
+
+For programmatic access, use `diff_summary(p)` in the REPL:
+
+```t
+diff_summary(p)
+-- DataFrame with columns: name, status, hash_a, hash_b, class_a, class_b
+```
+
+This is useful for verifying that a code change only affected the intended nodes.
 
 ---
 
@@ -307,6 +453,55 @@ monthly = sales
 
 **Each iteration**: Intent updated, LLM regenerates, human verifies.
 
+### Pattern 4: Check-Fix-Verify
+
+This pattern uses T's static checking tools to catch and fix errors before running the pipeline.
+
+**Step 1**: Agent generates pipeline with `expect()` contracts
+
+```t
+analysis = pipeline {
+  raw = read_csv("sales.csv")
+  cleaned = raw
+    |> filter($amount > 0)
+    |> expect(columns = ["id", "region", "amount", "date"])
+  by_region = cleaned
+    |> group_by($region)
+    |> summarize($total = sum($amount))
+}
+```
+
+**Step 2**: Run `t check --schema` to validate
+
+```bash
+$ t check --schema src/pipeline.t
+error [contract_violation] Node 'cleaned' contract expects columns [id, region, amount, date]
+  but output schema is [id, region, amount]. Missing: [date]
+```
+
+**Step 3**: Agent fixes the missing column (localized change)
+
+```t
+  cleaned = raw
+    |> filter($amount > 0)
+    |> expect(columns = ["id", "region", "amount"])
+```
+
+**Step 4**: Run `t check --schema` again — clean
+
+```bash
+$ t check --schema src/pipeline.t
+$
+```
+
+**Step 5**: Only now trigger the Nix build
+
+```bash
+$ t run src/pipeline.t
+```
+
+This loop — **generate, check, fix, build** — ensures agents never waste time on Nix builds that would fail for structural or schema reasons. The check step takes seconds; the build step takes minutes.
+
 ---
 
 ## Introspection for LLMs
@@ -355,6 +550,34 @@ pipeline_deps(p, "z")
 -- LLM can understand dependency graph
 ```
 
+### Structured Diagnostics via CLI
+
+For machine consumption, agents use `t check --json` and `t fix --dry-run`:
+
+```bash
+$ t check --json --schema src/pipeline.t
+{
+  "diagnostics": [
+    {
+      "error_class": "contract_violation",
+      "message": "Node 'cleaned' contract expects columns [...] but output schema is [...]. Missing: [date]",
+      "node": "cleaned",
+      "span": { "start": [8, 5], "end": [8, 60] },
+      "suggested_fix": null
+    }
+  ],
+  "exit_code": 1
+}
+```
+
+```bash
+$ t fix --dry-run src/pipeline.t
+dry-run: would apply 1 fix to src/pipeline.t:
+  [Cast] line 12: insert mutate($amount = as.numeric($amount))
+```
+
+These tools give agents structured, parseable output instead of human-readable error strings. The agent can programmatically decide what to fix and verify the fix before applying it.
+
 ---
 
 ## LLM Best Practices
@@ -366,6 +589,8 @@ pipeline_deps(p, "z")
 3. **Review Generated Code**: Verify LLM understood correctly
 4. **Iterate Locally**: Request changes to specific nodes, not entire scripts
 5. **Version Intents**: Track intent changes in Git
+6. **Review `t fix` Diffs**: Use `t fix --dry-run` to preview changes before applying. Always review the diff before committing.
+7. **Use `--watch`**: Run `t check --watch --schema` during active development for continuous feedback
 
 ### For LLMs
 
@@ -374,6 +599,10 @@ pipeline_deps(p, "z")
 3. **Include Error Handling**: Use `na_rm`, validation checks
 4. **Preserve Intents**: Keep intent blocks in generated code
 5. **Explain Assumptions**: Document why specific approaches were chosen
+6. **Always `t check` First**: Run `t check --schema` before `build_pipeline` — it catches structural and schema errors in seconds
+7. **Declare Shapes**: Add `expect(columns = [...])` to pipeline nodes so downstream agents (and humans) know the output contract
+8. **Use `t fix` for Mechanical Changes**: When `t check --json` reports a `suggested_fix`, apply it with `t fix` rather than manually editing — it handles line-number drift and word-boundary safety
+9. **Verify with `t diff`**: After modifying a pipeline, run `t diff` to confirm only the intended nodes changed
 
 ---
 
@@ -381,7 +610,8 @@ pipeline_deps(p, "z")
 
 **Human**: "I need to analyze employee salaries by department and identify outliers"
 
-**LLM Response**:
+**LLM generates** with intent and `expect()` contracts:
+
 ```t
 intent {
   description: "Employee salary analysis with outlier detection",
@@ -402,56 +632,95 @@ intent {
     "outliers.csv: employees with salaries > 2 SD from mean"
   ],
   
-  created: "2024-01-15",
+  created: "2024-07-12",
   llm_assistant: "Claude"
 }
 
 salary_analysis = pipeline {
   -- Load data
   employees = read_csv("employees.csv", clean_colnames = true)
+    |> expect(columns = ["employee_id", "department", "salary"],
+              salary ~ double())
   
   -- Department statistics
   dept_stats = employees
     |> group_by($department)
-    |> summarize($mean_salary = mean($salary), $sd_salary = sd($salary), $count = nrow($department))
+    |> summarize($mean_salary = mean($salary),
+                 $sd_salary = sd($salary),
+                 $count = nrow($department))
+    |> expect(columns = ["department", "mean_salary", "sd_salary", "count"])
   
-  -- Identify outliers
-  -- (Join would be manual or use a join function if available)
-  -- For now, calculate globally
-  overall_mean = mean(employees.salary, na_rm = true)
-  overall_sd = sd(employees.salary, na_rm = true)
-  threshold = overall_mean + 2 * overall_sd
+  -- Per-department outliers (>2 SD from department mean)
+  with_stats = employees
+    |> group_by($department)
+    |> mutate($dept_mean = mean($salary, na_rm = true))
+    |> mutate($dept_sd = sd($salary, na_rm = true))
   
-  outliers = employees
-    |> filter($salary > threshold)
-    |> select($employee_id, $department, $salary)
+  outliers = with_stats
+    |> filter($salary > $dept_mean + 2 * $dept_sd)
+    |> select($employee_id, $department, $salary, $dept_mean, $dept_sd)
+    |> expect(columns = ["employee_id", "department", "salary",
+                         "dept_mean", "dept_sd"])
 }
 
 -- Export results
 write_csv(salary_analysis.dept_stats, "department_stats.csv")
 write_csv(salary_analysis.outliers, "outliers.csv")
-
-print("Analysis complete:")
-print("Department stats: department_stats.csv")
-print("Outliers: outliers.csv")
 ```
 
-**Human Review**: "Good! But I want outliers per department, not overall"
+**LLM validates** before building:
 
-**LLM Update** (regenerates `outliers` node):
+```bash
+$ t check --schema src/pipeline.t
+error [contract_violation] Node 'employees' contract expects columns
+  [employee_id, department, salary] but output schema could not be inferred
+  for read_csv. Missing columns cannot be verified statically.
+warning [contract_unverifiable] Node 'employees' type contract for column
+  'salary' (~ double) cannot be verified statically: column type is unknown
+```
+
+The `read_csv` output schema depends on the actual file contents, so the column contract can't be verified statically. The type contract for `salary` is also unverifiable without runtime data. These are expected warnings — the contracts will be enforced at build time via the pipeline assertions, and the type contract will be checked if a typed schema source (like Arrow) is used.
+
+**LLM confirms** the warnings are expected and runs the build:
+
+```bash
+$ t run src/pipeline.t
+```
+
+**Human Review**: "Good! But the outliers should only flag employees making more than $200k, not just 2 SD from mean"
+
+**LLM updates** the `outliers` node (localized change):
+
 ```t
-  -- Update: Per-department outliers
-  with_dept_stats = employees
-    |> group_by($department)
-    |> mutate($dept_mean, \(g) mean(g.salary, na_rm = true))
-    |> mutate($dept_sd, \(g) sd(g.salary, na_rm = true))
-  
-  outliers = with_dept_stats
-    |> filter($salary > $dept_mean + 2 * $dept_sd)
+  outliers = with_stats
+    |> filter($salary > 200000)
     |> select($employee_id, $department, $salary, $dept_mean, $dept_sd)
 ```
 
-**Note**: Only `outliers` node changed; `dept_stats` and `employees` nodes unchanged.
+**LLM validates** the change:
+
+```bash
+$ t check --schema src/pipeline.t
+$
+```
+
+Clean. The `expect()` contracts on `employees`, `dept_stats`, and `outliers` still hold. Only the filter predicate changed.
+
+**LLM builds and verifies** with `t diff`:
+
+```bash
+$ t run src/pipeline.t
+$ t diff src/pipeline.t
+Name          Status    Class_a  Class_b
+employees     Unchanged T        T
+dept_stats    Unchanged T        T
+with_stats    Unchanged T        T
+outliers      Changed   T        T
+```
+
+The diff confirms only `outliers` changed. `employees`, `dept_stats`, and `with_stats` are unchanged — their cached artifacts are reused.
+
+**Note**: The `expect()` contracts served as guardrails throughout. When the filter predicate changed, the contracts on `dept_stats` and `employees` were re-validated automatically. If the change had broken a downstream contract (e.g., by removing a column that `dept_stats` depends on), `t check --schema` would have caught it before the build.
 
 ---
 
@@ -476,3 +745,5 @@ git show abc123:src/pipeline.t
 - [Reproducibility](reproducibility.md) — Nix for reproducible environments
 - [Examples](examples.md) — Intent-driven analysis examples
 - [Pipeline Tutorial](pipeline_tutorial.md) — Pipeline structure
+- [Debugging](debugging.md) — `t debug` for interactive node debugging
+- [API Reference](api-reference.md) — `t check`, `t fix`, `t diff` CLI documentation

--- a/docs/nix-installation.md
+++ b/docs/nix-installation.md
@@ -75,6 +75,90 @@ echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
 
 ---
 
+## Configuring Trusted Users
+
+Nix restricts certain operations (like using binary caches) to "trusted users." If
+you see warnings like `ignoring untrusted substituter` when running `nix shell` or
+`nix develop`, you need to add yourself as a trusted user.
+
+### Linux (Ubuntu, Debian)
+
+```bash
+sudo nano /etc/nix/nix.conf
+```
+
+Add your username to the `trusted-users` line:
+
+```text
+trusted-users = root your_username
+```
+
+Restart the Nix daemon:
+
+```bash
+sudo systemctl restart nix-daemon.service
+```
+
+> [!NOTE]
+> If you used the Determinate Systems installer, the daemon is managed by systemd. If
+> `nix-daemon.service` is not found, try `sudo determinate-nixd restart` or check
+> available units with `systemctl list-units | grep nix`.
+
+### Linux (Fedora, RHEL, CentOS)
+
+```bash
+sudo nano /etc/nix/nix.conf
+# Add: trusted-users = root your_username
+sudo systemctl restart nix-daemon.service
+```
+
+If `nix-daemon.service` is not found, try `sudo systemctl restart nix`.
+
+### Linux (Arch, Manjaro)
+
+```bash
+sudo nano /etc/nix/nix.conf
+# Add: trusted-users = root your_username
+sudo systemctl restart nix-daemon.service
+```
+
+### macOS
+
+```bash
+echo "trusted-users = root $USER" | sudo tee -a /etc/nix/nix.custom.conf
+sudo launchctl kickstart -k system/org.nixos.nix-daemon
+```
+
+This works for both the standard installer and the Determinate Systems installer.
+
+### NixOS
+
+On NixOS, add the following to your `configuration.nix`:
+
+```nix
+nix.trustedUsers = [ "root" "your_username" ];
+```
+
+Then rebuild:
+
+```bash
+sudo nixos-rebuild switch
+```
+
+### Windows (WSL2)
+
+Inside your WSL2 terminal, follow the Linux instructions above for your WSL2 distribution (usually Ubuntu). After editing `nix.conf`, restart the daemon:
+
+```bash
+sudo systemctl restart nix-daemon.service
+```
+
+> [!NOTE]
+> If systemd is not enabled in your WSL2 setup, you need to enable it first. See the
+> [Windows (WSL2)](#windows-wsl2) section above.
+
+---
+
 ## Binary Caches (Cachix)
 
 To avoid building everything from source, we recommend configuring binary caches.
@@ -136,11 +220,8 @@ The installer usually updates your shell profile. Try restarting your terminal o
 . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
 ```
 
-### Permission Denied
-If you encounter permission issues when using Nix, ensure your user is in the `trusted-users` list in `/etc/nix/nix.conf`:
-```text
-trusted-users = root @wheel your_username
-```
+### Permission Denied or "ignoring untrusted substituter"
+See [Configuring Trusted Users](#configuring-trusted-users) above.
 
 ## Next Steps
 

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -156,6 +156,7 @@ and contract = {
   contract_columns : string list option;
   contract_types : (string * string) list option;    (* [(column, type_name)] *)
   contract_null_rates : (string * float) list option; (* [(column, threshold)] *)
+  contract_loc : source_location option;             (* location of the expect() call *)
 }
 
 (** Formula specification — captures LHS/RHS of ~ expressions *)
@@ -405,6 +406,7 @@ let empty_contract = {
   contract_columns = None;
   contract_types = None;
   contract_null_rates = None;
+  contract_loc = None;
 }
 
 type program = stmt list

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -154,6 +154,8 @@ and meta_pipeline = {
 (** Shape contract for expect() — checked statically via t check --schema *)
 and contract = {
   contract_columns : string list option;
+  contract_types : (string * string) list option;    (* [(column, type_name)] *)
+  contract_null_rates : (string * float) list option; (* [(column, threshold)] *)
 }
 
 (** Formula specification — captures LHS/RHS of ~ expressions *)
@@ -401,6 +403,8 @@ and typ =
 
 let empty_contract = {
   contract_columns = None;
+  contract_types = None;
+  contract_null_rates = None;
 }
 
 type program = stmt list

--- a/src/check_utils.ml
+++ b/src/check_utils.ml
@@ -1,0 +1,162 @@
+(* src/check_utils.ml *)
+(* Shared logic for running T files in check mode.
+   Used by both the CLI (repl.ml) and REPL-callable functions (t_check, t_diff, t_fix). *)
+
+open Ast
+
+(* --- Source location helpers --- *)
+
+let source_location ?file pos : source_location =
+  {
+    file;
+    line = pos.Lexing.pos_lnum;
+    column = max 1 (pos.Lexing.pos_cnum - pos.Lexing.pos_bol + 1);
+  }
+
+let make_located_error ?file code message pos =
+  VError {
+    code;
+    message;
+    context = [];
+    location = Some (source_location ?file pos);
+    na_count = 0;
+  }
+
+let interrupt_error () =
+  VError {
+    code = RuntimeError;
+    message = "Interrupted.";
+    context = [];
+    location = None;
+    na_count = 0;
+  }
+
+(* --- Parsing and evaluation --- *)
+
+let parse_and_eval ?filename ?(failfast=false) mode env input =
+  let lexbuf = Lexing.from_string input in
+  (match filename with
+   | Some file -> lexbuf.lex_curr_p <- { lexbuf.lex_curr_p with pos_fname = file }
+   | None -> ());
+  try
+    let program = Parser.program Lexer.token lexbuf in
+    match Typecheck.validate_program ~mode program with
+    | Error err -> (VError err, env)
+    | Ok () -> Eval.eval_program ~resilient:(not failfast) program env
+  with
+  | Lexer.SyntaxError msg ->
+      let pos = Lexing.lexeme_start_p lexbuf in
+      (make_located_error ?file:filename SyntaxError ("Syntax Error: " ^ msg) pos, env)
+  | Parser.Error ->
+      let pos = Lexing.lexeme_start_p lexbuf in
+      (make_located_error ?file:filename SyntaxError "Parse Error" pos, env)
+  | Mixed_bracket_form ->
+      let pos = Lexing.lexeme_start_p lexbuf in
+      (make_located_error ?file:filename SyntaxError "Mixed bracket literal (found both single elements and key-value pairs)" pos, env)
+  | Invalid_match_pattern msg ->
+      let pos = Lexing.lexeme_start_p lexbuf in
+      (make_located_error ?file:filename SyntaxError msg pos, env)
+  | Sys.Break ->
+      (interrupt_error (), env)
+
+let run_file ?failfast mode filename env =
+  try
+    let ch = open_in filename in
+    let content = really_input_string ch (in_channel_length ch) in
+    close_in ch;
+    parse_and_eval ~filename ?failfast mode env content
+  with
+  | Sys_error msg ->
+      (VError {
+         code = FileError;
+         message = "File Error: " ^ msg;
+         context = [];
+         location = None;
+         na_count = 0;
+       }, env)
+
+(* --- Check mode --- *)
+
+let run_check ?(schema=false) ?(env_check=false) mode filename env =
+  let run () =
+    Ast.check_mode := true;
+    Fun.protect ~finally:(fun () -> Ast.check_mode := false)
+      (fun () -> run_file ~failfast:true mode filename env)
+  in
+  let (result, new_env) = run () in
+  let check_result =
+    let pipelines : (string * pipeline_result) list = match result with
+      | VPipeline p -> [("pipeline", p)]
+      | VError _ -> []
+      | _ ->
+          let bindings = Env.bindings new_env in
+          List.filter_map (fun (name, v) ->
+            match v with
+            | VPipeline p -> Some (name, p)
+            | _ -> None
+          ) bindings
+    in
+    let diag_list : Diagnostics.diagnostic list =
+      let error_diags = match result with
+        | VError err -> [Diagnostics.of_verror ~file:filename err]
+        | _ -> []
+      in
+      let pipeline_diags = List.concat_map (fun (_name, p) ->
+        let wire_diags = Diagnostics.of_pipeline_result ~file:filename p in
+        let schema_diags =
+          if schema then Schema_check.check_pipeline_schemas ~file:filename p
+          else []
+        in
+        let env_diags =
+          if env_check then Env_check.check_env ~file:filename p
+          else []
+        in
+        wire_diags @ schema_diags @ env_diags
+      ) pipelines in
+      error_diags @ pipeline_diags
+    in
+    let check_phase = Diagnostics.worst_phase diag_list in
+    let tier = Diagnostics.worst_tier diag_list in
+    Diagnostics.make_result ~tier ~phase:check_phase diag_list
+  in
+  check_result
+
+(* --- Formatting --- *)
+
+let format_check_result ?(json=false) check_result =
+  if json then
+    Yojson.Safe.pretty_to_string (Diagnostics.check_result_to_yojson check_result)
+  else begin
+    let buf = Buffer.create 256 in
+    let cr_diags = Diagnostics.check_result_entries check_result in
+    List.iter (fun d ->
+      Buffer.add_string buf
+        (Printf.sprintf "%s [%s] %s\n"
+           (Diagnostics.severity_to_string (Diagnostics.diagnostic_severity d))
+           (Diagnostics.diagnostic_error_class d)
+           (Diagnostics.diagnostic_message d))
+    ) cr_diags;
+    if cr_diags <> [] then Buffer.add_char buf '\n';
+    Buffer.contents buf
+  end
+
+(** Extract pipeline(s) from a file run in check mode *)
+let extract_pipelines mode filename env =
+  let (result, new_env) =
+    Ast.check_mode := true;
+    Fun.protect ~finally:(fun () -> Ast.check_mode := false)
+      (fun () -> run_file ~failfast:true mode filename env)
+  in
+  match result with
+  | VPipeline p -> Ok [("pipeline", p)]
+  | VError err -> Error err
+  | _ ->
+      let bindings = Env.bindings new_env in
+      let pipelines = List.filter_map (fun (name, v) ->
+        match v with VPipeline p -> Some (name, p) | _ -> None
+      ) bindings in
+      if pipelines = [] then
+        Error { code = FileError;
+                message = Printf.sprintf "No pipeline found in %s." filename;
+                context = []; location = None; na_count = 0 }
+      else Ok pipelines

--- a/src/diagnostics.ml
+++ b/src/diagnostics.ml
@@ -6,10 +6,10 @@ type diagnostic_phase = Parse | Wire | Schema | Env | Build | Exec
 type severity = Error | Warning
 
 type suggested_fix =
-  | Cast of { column: string; cast_to: string }
-  | Rename_column of { old_name: string; new_name: string }
-  | Add_node_arg of { node: string; arg: string }
-  | Pin_package_version of { pkg: string; version: string }
+  | Cast of { column: string; cast_to: string; file: string option; line: int option }
+  | Rename_column of { old_name: string; new_name: string; file: string option; line: int option }
+  | Add_node_arg of { node: string; arg: string; file: string option; line: int option }
+  | Pin_package_version of { pkg: string; version: string; file: string option }
   | NoFix
 
 type diagnostic = {
@@ -56,32 +56,94 @@ let severity_to_string = function
 let phase_to_yojson p = `String (phase_to_string p)
 let severity_to_yojson s = `String (severity_to_string s)
 
+let opt_string_to_yojson = function
+  | Some s -> `String s
+  | None -> `Null
+
+let opt_int_to_yojson = function
+  | Some i -> `Int i
+  | None -> `Null
+
 let suggested_fix_to_yojson = function
-  | Cast { column; cast_to } ->
+  | Cast { column; cast_to; file; line } ->
       `Assoc [
         ("kind", `String "cast");
         ("column", `String column);
         ("cast_to", `String cast_to);
+        ("file", opt_string_to_yojson file);
+        ("line", opt_int_to_yojson line);
       ]
-  | Rename_column { old_name; new_name } ->
+  | Rename_column { old_name; new_name; file; line } ->
       `Assoc [
         ("kind", `String "rename_column");
         ("old_name", `String old_name);
         ("new_name", `String new_name);
+        ("file", opt_string_to_yojson file);
+        ("line", opt_int_to_yojson line);
       ]
-  | Add_node_arg { node; arg } ->
+  | Add_node_arg { node; arg; file; line } ->
       `Assoc [
         ("kind", `String "add_node_arg");
         ("node", `String node);
         ("arg", `String arg);
+        ("file", opt_string_to_yojson file);
+        ("line", opt_int_to_yojson line);
       ]
-  | Pin_package_version { pkg; version } ->
+  | Pin_package_version { pkg; version; file } ->
       `Assoc [
         ("kind", `String "pin_package_version");
         ("pkg", `String pkg);
         ("version", `String version);
+        ("file", opt_string_to_yojson file);
       ]
   | NoFix -> `Null
+
+let opt_string_of_yojson json =
+  match json with
+  | `String s -> Some s
+  | `Null -> None
+  | _ -> None
+
+let opt_int_of_yojson json =
+  match json with
+  | `Int i -> Some i
+  | `Null -> None
+  | _ -> None
+
+let suggested_fix_of_yojson json =
+  let open Yojson.Safe.Util in
+  match json with
+  | `Null -> NoFix
+  | _ ->
+      let kind = json |> member "kind" |> to_string in
+      let file = json |> member "file" |> opt_string_of_yojson in
+      let line = json |> member "line" |> opt_int_of_yojson in
+      match kind with
+      | "cast" ->
+          Cast {
+            column = json |> member "column" |> to_string;
+            cast_to = json |> member "cast_to" |> to_string;
+            file; line;
+          }
+      | "rename_column" ->
+          Rename_column {
+            old_name = json |> member "old_name" |> to_string;
+            new_name = json |> member "new_name" |> to_string;
+            file; line;
+          }
+      | "add_node_arg" ->
+          Add_node_arg {
+            node = json |> member "node" |> to_string;
+            arg = json |> member "arg" |> to_string;
+            file; line;
+          }
+      | "pin_package_version" ->
+          Pin_package_version {
+            pkg = json |> member "pkg" |> to_string;
+            version = json |> member "version" |> to_string;
+            file;
+          }
+      | _ -> NoFix
 
 let diagnostic_to_yojson d =
   `Assoc [

--- a/src/dune
+++ b/src/dune
@@ -50,7 +50,7 @@
    arrow_table arrow_ffi arrow_bridge arrow_io arrow_compute arrow_column
    arrow_owl_bridge
     ; core language
-        ast lexer parser eval typecheck error serialization serialization_registry pmml_utils semantic_type symbol_table completion analyzer stats import_registry value_hash cli_args diff rng diagnostics schema_check env_check fix
+        ast lexer parser eval typecheck error serialization serialization_registry pmml_utils semantic_type symbol_table completion analyzer stats import_registry value_hash cli_args diff rng diagnostics schema_check env_check fix check_utils
     ; pipeline compiler
     nix_utils nix_unparse nix_emit_node nix_emit_pipeline nix_emitter pipeline_script
     builder_utils pipeline_dependency_requirements builder_write_dag builder_nix_store builder_logs builder_internal builder_populate builder_inspect builder_read_node builder_copy builder_artifacts builder_diff builder
@@ -67,7 +67,7 @@
       ; packages/pipeline
        pipeline_utils pipeline_args pipeline_nodes pipeline_deps pipeline_node pipeline_run build_pipeline populate_pipeline inspect_pipeline trace_nodes read_node read_past_node pipeline_copy
       pipeline_to_frame filter_node which_nodes mutate_node rename_node select_node arrange_node pipeline_to_drv
-       pipeline_set_ops pipeline_dag_ops pipeline_composition pipeline_expand pipeline_inspect2 pipeline_to_ga t_make_mod build_log pipeline_diff diff_summary pipeline_report
+       pipeline_set_ops pipeline_dag_ops pipeline_composition pipeline_expand pipeline_inspect2 pipeline_to_ga t_make_mod build_log pipeline_diff diff_summary pipeline_report t_check t_diff t_fix
       pipeline_to_store set_nix_defaults pipeline_cache_status pipeline_gc export_artifacts import_artifacts inspect_artifacts
     ; packages/colcraft
     t_select t_filter mutate arrange group_by ungroup summarize n n_distinct

--- a/src/dune
+++ b/src/dune
@@ -50,7 +50,7 @@
    arrow_table arrow_ffi arrow_bridge arrow_io arrow_compute arrow_column
    arrow_owl_bridge
     ; core language
-        ast lexer parser eval typecheck error serialization serialization_registry pmml_utils semantic_type symbol_table completion analyzer stats import_registry value_hash cli_args diff rng diagnostics schema_check env_check
+        ast lexer parser eval typecheck error serialization serialization_registry pmml_utils semantic_type symbol_table completion analyzer stats import_registry value_hash cli_args diff rng diagnostics schema_check env_check fix
     ; pipeline compiler
     nix_utils nix_unparse nix_emit_node nix_emit_pipeline nix_emitter pipeline_script
     builder_utils pipeline_dependency_requirements builder_write_dag builder_nix_store builder_logs builder_internal builder_populate builder_inspect builder_read_node builder_copy builder_artifacts builder_diff builder

--- a/src/dune
+++ b/src/dune
@@ -53,7 +53,7 @@
         ast lexer parser eval typecheck error serialization serialization_registry pmml_utils semantic_type symbol_table completion analyzer stats import_registry value_hash cli_args diff rng diagnostics schema_check env_check
     ; pipeline compiler
     nix_utils nix_unparse nix_emit_node nix_emit_pipeline nix_emitter pipeline_script
-    builder_utils pipeline_dependency_requirements builder_write_dag builder_nix_store builder_logs builder_internal builder_populate builder_inspect builder_read_node builder_copy builder_artifacts builder
+    builder_utils pipeline_dependency_requirements builder_write_dag builder_nix_store builder_logs builder_internal builder_populate builder_inspect builder_read_node builder_copy builder_artifacts builder_diff builder
     ; packages/core
     t_print t_type args head tail is_error t_seq t_float_seq t_map sum pretty_print show_plot packages t_get help t_boolean t_pattern t_write_text converters file_ops path_ops
     ; packages/strcraft
@@ -67,7 +67,7 @@
       ; packages/pipeline
        pipeline_utils pipeline_args pipeline_nodes pipeline_deps pipeline_node pipeline_run build_pipeline populate_pipeline inspect_pipeline trace_nodes read_node read_past_node pipeline_copy
       pipeline_to_frame filter_node which_nodes mutate_node rename_node select_node arrange_node pipeline_to_drv
-       pipeline_set_ops pipeline_dag_ops pipeline_composition pipeline_expand pipeline_inspect2 pipeline_to_ga t_make_mod build_log pipeline_diff pipeline_report
+       pipeline_set_ops pipeline_dag_ops pipeline_composition pipeline_expand pipeline_inspect2 pipeline_to_ga t_make_mod build_log pipeline_diff diff_summary pipeline_report
       pipeline_to_store set_nix_defaults pipeline_cache_status pipeline_gc export_artifacts import_artifacts inspect_artifacts
     ; packages/colcraft
     t_select t_filter mutate arrange group_by ungroup summarize n n_distinct

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -1880,7 +1880,7 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
     (* Strip trailing expect(...) from pipe chains: e.g.
        r_script("clean.R") |> expect(columns = [...])
        becomes r_script("clean.R") with a contract attached. *)
-    let extract_contract_from_args args =
+    let extract_contract_from_args ?loc args =
       let columns = ref [] in
       let types = ref [] in
       let null_rates = ref [] in
@@ -1926,6 +1926,7 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
           Ast.contract_columns = (if !columns <> [] then Some !columns else None);
           contract_types = (if !types <> [] then Some !types else None);
           contract_null_rates = (if !null_rates <> [] then Some !null_rates else None);
+          contract_loc = loc;
         }
       else None
     in
@@ -1949,13 +1950,13 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
     in
     let node_expr, contract_opt, expect_warnings =
       match node_expr.node with
-      | BinOp { op = Pipe; left; right = { node = Call { fn = { node = Var "expect"; _ }; args }; _ } } ->
+      | BinOp { op = Pipe; left; right = { node = Call { fn = { node = Var "expect"; _ }; args }; loc = expect_loc; _ } } ->
           (* Terminal expect() at end of chain — extract contract.
              args are the expect() call's own args (piped value is `left`, not in args). *)
           let mid_chain_warns =
             if contains_expect left then make_mid_chain_warn () else []
           in
-          (left, extract_contract_from_args args, mid_chain_warns)
+          (left, extract_contract_from_args ?loc:expect_loc args, mid_chain_warns)
       | other ->
           (* No terminal expect() — check if expect() appears anywhere mid-chain *)
           if contains_expect { node_expr with node = other } then

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -1882,6 +1882,8 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
        becomes r_script("clean.R") with a contract attached. *)
     let extract_contract_from_args args =
       let columns = ref [] in
+      let types = ref [] in
+      let null_rates = ref [] in
       List.iter (fun (param_name, arg_expr) ->
         match param_name with
         | Some "columns" ->
@@ -1894,10 +1896,37 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
                  ) items in
                  columns := cols
              | _ -> ())
+        | None ->
+            (* Positional arg: check for type contract (col ~ type()) *)
+            (match arg_expr.node with
+             | BinOp { op = Formula; left; right } ->
+                 (match left.node, right.node with
+                  | Var col, Call { fn = { node = Var type_name; _ }; args = []; _ } ->
+                      types := (col, type_name) :: !types
+                  | _ -> ())
+             | _ ->
+                 (* Check for null-rate contract: null_rate("col") < threshold *)
+                 (match arg_expr.node with
+                  | BinOp { op = Lt; left; right } ->
+                      (match left.node, right.node with
+                       | Call { fn = { node = Var "null_rate"; _ };
+                                args = [(_, col_expr)]; _ },
+                         Value (VFloat threshold) ->
+                             (match col_expr.node with
+                              | Value (VString col) ->
+                                  null_rates := (col, threshold) :: !null_rates
+                              | _ -> ())
+                       | _ -> ())
+                  | _ -> ()))
         | _ -> ()
       ) args;
-      if !columns <> [] then
-        Some { Ast.contract_columns = Some !columns }
+      let has_contract = !columns <> [] || !types <> [] || !null_rates <> [] in
+      if has_contract then
+        Some {
+          Ast.contract_columns = (if !columns <> [] then Some !columns else None);
+          contract_types = (if !types <> [] then Some !types else None);
+          contract_null_rates = (if !null_rates <> [] then Some !null_rates else None);
+        }
       else None
     in
     let make_mid_chain_warn () =
@@ -1921,7 +1950,8 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
     let node_expr, contract_opt, expect_warnings =
       match node_expr.node with
       | BinOp { op = Pipe; left; right = { node = Call { fn = { node = Var "expect"; _ }; args }; _ } } ->
-          (* Terminal expect() at end of chain — extract contract *)
+          (* Terminal expect() at end of chain — extract contract.
+             args are the expect() call's own args (piped value is `left`, not in args). *)
           let mid_chain_warns =
             if contains_expect left then make_mid_chain_warn () else []
           in

--- a/src/fix.ml
+++ b/src/fix.ml
@@ -5,6 +5,7 @@ type fix_result = {
   file : string;
   applied : int;
   skipped : int;
+  would_apply : int;
   diagnostics : Diagnostics.diagnostic list;
 }
 
@@ -36,6 +37,29 @@ let apply_cast ~file ~line ~column ~cast_to =
     (fun () ->
        List.iter (fun l -> output_string oc (l ^ "\n")) (List.rev !lines))
 
+let is_word_char = function
+  | 'a'..'z' | 'A'..'Z' | '0'..'9' | '_' -> true
+  | _ -> false
+
+let replace_word_bound ~content ~old ~replacement =
+  let buf = Buffer.create (String.length content) in
+  let old_len = String.length old in
+  let i = ref 0 in
+  while !i < String.length content do
+    if !i + old_len <= String.length content
+       && String.sub content !i old_len = old
+       && (!i + old_len >= String.length content
+           || not (is_word_char content.[!i + old_len]))
+    then begin
+      Buffer.add_string buf replacement;
+      i := !i + old_len
+    end else begin
+      Buffer.add_char buf content.[!i];
+      incr i
+    end
+  done;
+  Buffer.contents buf
+
 let apply_rename_column ~file ~old_name ~new_name =
   let content =
     let ch = open_in file in
@@ -43,11 +67,15 @@ let apply_rename_column ~file ~old_name ~new_name =
       (fun () -> really_input_string ch (in_channel_length ch))
   in
   (* Only replace $old_name and $`old_name` — the T column reference forms.
-     Avoids corrupting unrelated identifiers like `valid`, `hidden`, etc. *)
-  let re_dollar = Str.regexp ("\\$" ^ Str.quote old_name) in
-  let re_backtick = Str.regexp ("\\$`" ^ Str.quote old_name ^ "`") in
-  let content = Str.global_replace re_dollar ("$" ^ new_name) content in
-  let content = Str.global_replace re_backtick ("$`" ^ new_name ^ "`") content in
+     Avoids corrupting unrelated identifiers like `valid`, `hidden`, etc.
+     Uses manual word-boundary check: the character after the match must not be
+     [a-zA-Z0-9_], so $id is not matched inside $identity. *)
+  let dollar_old = "$" ^ old_name in
+  let dollar_new = "$" ^ new_name in
+  let backtick_old = "$`" ^ old_name ^ "`" in
+  let backtick_new = "$`" ^ new_name ^ "`" in
+  let content = replace_word_bound ~content ~old:dollar_old ~replacement:dollar_new in
+  let content = replace_word_bound ~content ~old:backtick_old ~replacement:backtick_new in
   let oc = open_out file in
   Fun.protect ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc content)
@@ -78,6 +106,34 @@ let sort_fixes_by_descending_line fixes =
       compare lb la
   ) fixes
 
+let apply_fixes ~dry_run ~default_file (fixes : Diagnostics.diagnostic list) =
+  let applied = ref 0 in
+  let skipped = ref 0 in
+  let would_apply = ref 0 in
+  List.iter (fun (d : Diagnostics.diagnostic) ->
+    if dry_run then begin
+      Printf.printf "Would apply: %s on %s\n" d.diag_message
+        (match d.diag_file with Some f -> f | None -> "<unknown>");
+      let would_work = match d.diag_suggested_fix with
+        | Diagnostics.Cast { line = Some _; _ } -> true
+        | Diagnostics.Rename_column _ -> true
+        | _ -> false
+      in
+      if would_work then incr would_apply else incr skipped
+    end else begin
+      let file_to_fix = match d.diag_file with
+        | Some f -> f
+        | None -> default_file
+      in
+      if apply_fix ~file:file_to_fix d.diag_suggested_fix then
+        incr applied
+      else
+        incr skipped
+    end
+  ) fixes;
+  { file = default_file; applied = !applied; skipped = !skipped;
+    would_apply = !would_apply; diagnostics = fixes }
+
 (* cmd_fix accepts a check function to avoid circular dependency with Repl.
    The caller (repl.ml) passes run_check ~schema:true. *)
 let cmd_fix ?(dry_run = false) ~check_fn file =
@@ -90,21 +146,4 @@ let cmd_fix ?(dry_run = false) ~check_fn file =
     )
     |> sort_fixes_by_descending_line
   in
-  let applied = ref 0 in
-  let skipped = ref 0 in
-  List.iter (fun (d : Diagnostics.diagnostic) ->
-    if dry_run then begin
-      Printf.printf "Would apply: %s on %s\n" d.diag_message
-        (match d.diag_file with Some f -> f | None -> "<unknown>")
-    end else begin
-      let file_to_fix = match d.diag_file with
-        | Some f -> f
-        | None -> file
-      in
-      if apply_fix ~file:file_to_fix d.diag_suggested_fix then
-        incr applied
-      else
-        incr skipped
-    end
-  ) fixes;
-  { file; applied = !applied; skipped = !skipped; diagnostics = fixes }
+  apply_fixes ~dry_run ~default_file:file fixes

--- a/src/fix.ml
+++ b/src/fix.ml
@@ -1,0 +1,126 @@
+(* src/fix.ml *)
+(* Mechanical application of suggested_fix from diagnostics *)
+
+type fix_result = {
+  file : string;
+  applied : int;
+  skipped : int;
+  diagnostics : Diagnostics.diagnostic list;
+}
+
+let run_check_json file =
+  let cmd = Printf.sprintf "t check --json %s" file in
+  let ic = Unix.open_process_in cmd in
+  let buf = Buffer.create 1024 in
+  (try
+     while true do
+       Buffer.add_channel buf ic 1024
+     done
+   with End_of_file -> ());
+  let _ = Unix.close_process_in ic in
+  Buffer.contents buf
+
+let apply_cast ~file ~line ~column ~cast_to =
+  let lines = ref [] in
+  let ch = open_in file in
+  Fun.protect ~finally:(fun () -> close_in_noerr ch)
+    (fun () ->
+       let i = ref 1 in
+       try
+         while true do
+           let l = input_line ch in
+           if !i = line then
+             let indent =
+               let rec count s n =
+                 if n < String.length s && s.[n] = ' ' then count s (n + 1) else n
+               in
+               count l 0
+             in
+             let pad = String.make indent ' ' in
+             lines := !lines @ [
+               Printf.sprintf "%s|> mutate($%s = as.%s($%s))" pad column cast_to column;
+               l;
+             ]
+           else
+             lines := !lines @ [l];
+           incr i
+         done
+       with End_of_file -> ());
+  let oc = open_out file in
+  Fun.protect ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+       List.iter (fun l -> output_string oc (l ^ "\n")) !lines)
+
+let apply_rename_column ~file ~old_name ~new_name =
+  let content =
+    let ch = open_in file in
+    Fun.protect ~finally:(fun () -> close_in_noerr ch)
+      (fun () -> really_input_string ch (in_channel_length ch))
+  in
+  let re = Str.regexp_string old_name in
+  let new_content = Str.global_replace re new_name content in
+  if content <> new_content then begin
+    let oc = open_out file in
+    Fun.protect ~finally:(fun () -> close_out_noerr oc)
+      (fun () -> output_string oc new_content)
+  end
+
+let apply_fix ~file (fix : Diagnostics.suggested_fix) =
+  match fix with
+  | Cast { column; cast_to; file = _; line } ->
+      (match line with
+       | Some l -> apply_cast ~file ~line:l ~column ~cast_to; true
+       | None -> false)
+  | Rename_column { old_name; new_name; file = _; line = _ } ->
+      apply_rename_column ~file ~old_name ~new_name; true
+  | Add_node_arg _ -> false
+  | Pin_package_version _ -> false
+  | NoFix -> false
+
+let opt_string json = match json with `String s -> Some s | `Null -> None | _ -> None
+let opt_int json = match json with `Int i -> Some i | `Null -> None | _ -> None
+
+let cmd_fix ?(dry_run = false) file =
+  let json_str = run_check_json file in
+  let json = Yojson.Safe.from_string json_str in
+  let open Yojson.Safe.Util in
+  let diagnostics = json |> member "diagnostics" |> to_list in
+  let fixes = List.filter_map (fun d ->
+    let fix_json = d |> member "suggested_fix" in
+    if fix_json = `Null then None
+    else
+      let fix = Diagnostics.suggested_fix_of_yojson fix_json in
+      if fix = Diagnostics.NoFix then None
+      else Some (Diagnostics.{
+        diag_id = d |> member "id" |> to_string;
+        diag_error_class = d |> member "error_class" |> to_string;
+        diag_severity = (if d |> member "severity" |> to_string = "error" then Diagnostics.Error else Diagnostics.Warning);
+        diag_phase = Diagnostics.Schema;
+        diag_node_id = d |> member "node_id" |> opt_string;
+        diag_node_lang = None;
+        diag_file = d |> member "file" |> opt_string;
+        diag_line = d |> member "line" |> opt_int;
+        diag_column = d |> member "column" |> opt_int;
+        diag_message = d |> member "message" |> to_string;
+        diag_caused_by = [];
+        diag_suggested_fix = fix;
+      })
+  ) diagnostics in
+  let applied = ref 0 in
+  let skipped = ref 0 in
+  List.iter (fun (d : Diagnostics.diagnostic) ->
+    if dry_run then begin
+      Printf.printf "Would apply: %s on %s\n" d.diag_message
+        (match d.diag_file with Some f -> f | None -> "<unknown>")
+    end else begin
+      let file_to_fix = match d.diag_file with
+        | Some f -> f
+        | None -> file
+      in
+      if apply_fix ~file:file_to_fix d.diag_suggested_fix then
+        incr applied
+      else
+        incr skipped
+    end
+  ) fixes;
+  { file; applied = !applied; skipped = !skipped; diagnostics = fixes }

--- a/src/fix.ml
+++ b/src/fix.ml
@@ -25,19 +25,16 @@ let apply_cast ~file ~line ~column ~cast_to =
                count l 0
              in
              let pad = String.make indent ' ' in
-             lines := !lines @ [
-               Printf.sprintf "%s|> mutate($%s = as.%s($%s))" pad column cast_to column;
-               l;
-             ]
+             lines := l :: Printf.sprintf "%s|> mutate($%s = as.%s($%s))" pad column cast_to column :: !lines
            else
-             lines := !lines @ [l];
+             lines := l :: !lines;
            incr i
          done
        with End_of_file -> ());
   let oc = open_out file in
   Fun.protect ~finally:(fun () -> close_out_noerr oc)
     (fun () ->
-       List.iter (fun l -> output_string oc (l ^ "\n")) !lines)
+       List.iter (fun l -> output_string oc (l ^ "\n")) (List.rev !lines))
 
 let apply_rename_column ~file ~old_name ~new_name =
   let content =

--- a/src/fix.ml
+++ b/src/fix.ml
@@ -8,18 +8,6 @@ type fix_result = {
   diagnostics : Diagnostics.diagnostic list;
 }
 
-let run_check_json file =
-  let cmd = Printf.sprintf "t check --json %s" file in
-  let ic = Unix.open_process_in cmd in
-  let buf = Buffer.create 1024 in
-  (try
-     while true do
-       Buffer.add_channel buf ic 1024
-     done
-   with End_of_file -> ());
-  let _ = Unix.close_process_in ic in
-  Buffer.contents buf
-
 let apply_cast ~file ~line ~column ~cast_to =
   let lines = ref [] in
   let ch = open_in file in
@@ -57,13 +45,15 @@ let apply_rename_column ~file ~old_name ~new_name =
     Fun.protect ~finally:(fun () -> close_in_noerr ch)
       (fun () -> really_input_string ch (in_channel_length ch))
   in
-  let re = Str.regexp_string old_name in
-  let new_content = Str.global_replace re new_name content in
-  if content <> new_content then begin
-    let oc = open_out file in
-    Fun.protect ~finally:(fun () -> close_out_noerr oc)
-      (fun () -> output_string oc new_content)
-  end
+  (* Only replace $old_name and $`old_name` — the T column reference forms.
+     Avoids corrupting unrelated identifiers like `valid`, `hidden`, etc. *)
+  let re_dollar = Str.regexp ("\\$" ^ Str.quote old_name) in
+  let re_backtick = Str.regexp ("\\$`" ^ Str.quote old_name ^ "`") in
+  let content = Str.global_replace re_dollar ("$" ^ new_name) content in
+  let content = Str.global_replace re_backtick ("$`" ^ new_name ^ "`") content in
+  let oc = open_out file in
+  Fun.protect ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
 
 let apply_fix ~file (fix : Diagnostics.suggested_fix) =
   match fix with
@@ -77,35 +67,32 @@ let apply_fix ~file (fix : Diagnostics.suggested_fix) =
   | Pin_package_version _ -> false
   | NoFix -> false
 
-let opt_string json = match json with `String s -> Some s | `Null -> None | _ -> None
-let opt_int json = match json with `Int i -> Some i | `Null -> None | _ -> None
-
-let cmd_fix ?(dry_run = false) file =
-  let json_str = run_check_json file in
-  let json = Yojson.Safe.from_string json_str in
-  let open Yojson.Safe.Util in
-  let diagnostics = json |> member "diagnostics" |> to_list in
-  let fixes = List.filter_map (fun d ->
-    let fix_json = d |> member "suggested_fix" in
-    if fix_json = `Null then None
+(* Sort fixes by descending line within each file, so bottom-up application
+   avoids line-number drift when multiple fixes target the same file. *)
+let sort_fixes_by_descending_line fixes =
+  List.sort (fun a b ->
+    let fa = Option.value ~default:"" a.Diagnostics.diag_file in
+    let fb = Option.value ~default:"" b.Diagnostics.diag_file in
+    let cmp = String.compare fa fb in
+    if cmp <> 0 then cmp
     else
-      let fix = Diagnostics.suggested_fix_of_yojson fix_json in
-      if fix = Diagnostics.NoFix then None
-      else Some (Diagnostics.{
-        diag_id = d |> member "id" |> to_string;
-        diag_error_class = d |> member "error_class" |> to_string;
-        diag_severity = (if d |> member "severity" |> to_string = "error" then Diagnostics.Error else Diagnostics.Warning);
-        diag_phase = Diagnostics.Schema;
-        diag_node_id = d |> member "node_id" |> opt_string;
-        diag_node_lang = None;
-        diag_file = d |> member "file" |> opt_string;
-        diag_line = d |> member "line" |> opt_int;
-        diag_column = d |> member "column" |> opt_int;
-        diag_message = d |> member "message" |> to_string;
-        diag_caused_by = [];
-        diag_suggested_fix = fix;
-      })
-  ) diagnostics in
+      let la = Option.value ~default:0 a.Diagnostics.diag_line in
+      let lb = Option.value ~default:0 b.Diagnostics.diag_line in
+      compare lb la
+  ) fixes
+
+(* cmd_fix accepts a check function to avoid circular dependency with Repl.
+   The caller (repl.ml) passes run_check ~schema:true. *)
+let cmd_fix ?(dry_run = false) ~check_fn file =
+  let check_result = check_fn file in
+  let fixes = Diagnostics.check_result_entries check_result
+    |> List.filter_map (fun d ->
+      match d.Diagnostics.diag_suggested_fix with
+      | Diagnostics.NoFix -> None
+      | _ -> Some d
+    )
+    |> sort_fixes_by_descending_line
+  in
   let applied = ref 0 in
   let skipped = ref 0 in
   List.iter (fun (d : Diagnostics.diagnostic) ->

--- a/src/packages/core/packages.ml
+++ b/src/packages/core/packages.ml
@@ -851,6 +851,7 @@ let init_env () =
   let env = Pipeline_to_ga.register env in
   let env = Build_log.register env in
   let env = Pipeline_diff.register env in
+  let env = Diff_summary.register env in
   let env = Pipeline_report.register env in
   (* Colcraft package *)
   let env = T_select.register env in

--- a/src/packages/core/packages.ml
+++ b/src/packages/core/packages.ml
@@ -202,8 +202,9 @@ let pipeline_package = {
                "chain"; "parallel";
                  "pipeline_edges"; "pipeline_roots"; "pipeline_leaves"; "pipeline_depth";
                  "pipeline_cycles"; "pipeline_validate"; "pipeline_assert";
-                 "pipeline_print"; "pipeline_to_dot"; "pipeline_to_mermaid";
-                 "pipeline_to_ga"];
+                  "pipeline_print"; "pipeline_to_dot"; "pipeline_to_mermaid";
+                  "pipeline_to_ga";
+                  "t_check"; "t_diff"; "t_fix"];
 }
 
 let explain_package = {
@@ -853,6 +854,9 @@ let init_env () =
   let env = Pipeline_diff.register env in
   let env = Diff_summary.register env in
   let env = Pipeline_report.register env in
+  let env = T_check.register env in
+  let env = T_diff.register env in
+  let env = T_fix.register env in
   (* Colcraft package *)
   let env = T_select.register env in
   let env = T_filter.register ~eval_call:Eval.eval_call_immutable ~eval_expr:Eval.eval_expr_immutable ~uses_nse:Eval.uses_nse ~desugar_nse_expr:Eval.desugar_nse_expr env in

--- a/src/packages/pipeline/diff_summary.ml
+++ b/src/packages/pipeline/diff_summary.ml
@@ -1,0 +1,73 @@
+open Ast
+
+(*
+--# Summarize Output Changes Across Builds
+--#
+--# Compares the two most recent builds of a pipeline and returns a DataFrame
+--# summarizing which nodes changed, were added, or were removed.
+--#
+--# Uses per-node Nix content hashes stored in build logs to detect changes
+--# without loading artifacts. Only loads artifacts for nodes that actually changed.
+--#
+--# @name diff_summary
+--# @param p :: Pipeline The pipeline to compare builds for.
+--# @return :: DataFrame A summary with columns: name, status, hash_a, hash_b.
+--# @family pipeline
+--# @export
+*)
+let register env =
+  Env.add "diff_summary"
+    (make_builtin ~name:"diff_summary" 1 (fun args _env ->
+      match args with
+      | [VPipeline p] ->
+          (match Builder.find_two_matching_logs p with
+           | None ->
+               Error.make_error FileError
+                 "diff_summary: fewer than 2 matching build logs found. Run build_pipeline(p) at least twice."
+           | Some (log_a_path, log_b_path) ->
+               (match Builder.compute_diff log_a_path log_b_path with
+                | Error msg ->
+                    Error.make_error RuntimeError
+                      (Printf.sprintf "diff_summary: failed to compute diff: %s" msg)
+                | Ok diff_result ->
+                    let nrows = diff_result.dr_total in
+                    let arr_name = Array.make nrows None in
+                    let arr_status = Array.make nrows None in
+                    let arr_hash_a = Array.make nrows None in
+                    let arr_hash_b = Array.make nrows None in
+                    let arr_class_a = Array.make nrows None in
+                    let arr_class_b = Array.make nrows None in
+                    List.iteri (fun i e ->
+                      arr_name.(i) <- Some e.Builder_diff.nde_name;
+                      arr_status.(i) <- Some (Builder_diff.node_status_to_string e.nde_status);
+                      arr_class_a.(i) <- Some e.nde_class_a;
+                      arr_class_b.(i) <- Some e.nde_class_b;
+                      (match e.nde_status with
+                       | Builder_diff.Unchanged { hash } ->
+                           arr_hash_a.(i) <- Some hash;
+                           arr_hash_b.(i) <- Some hash
+                       | Builder_diff.Changed { hash_a; hash_b } ->
+                           arr_hash_a.(i) <- Some hash_a;
+                           arr_hash_b.(i) <- Some hash_b
+                       | Builder_diff.Added { hash } ->
+                           arr_hash_b.(i) <- Some hash
+                       | Builder_diff.Removed { hash } ->
+                           arr_hash_a.(i) <- Some hash
+                       | Builder_diff.Errored _ -> ())
+                    ) diff_result.dr_nodes;
+                    let columns = [
+                      ("name", Arrow_table.StringColumn arr_name);
+                      ("status", Arrow_table.StringColumn arr_status);
+                      ("hash_a", Arrow_table.StringColumn arr_hash_a);
+                      ("hash_b", Arrow_table.StringColumn arr_hash_b);
+                      ("class_a", Arrow_table.StringColumn arr_class_a);
+                      ("class_b", Arrow_table.StringColumn arr_class_b);
+                    ] in
+                    let arrow_table = Arrow_table.create columns nrows in
+                    VDataFrame { arrow_table; group_keys = [] }))
+      | [other] ->
+          Error.type_error
+            (Printf.sprintf "Function `diff_summary` expects a Pipeline, but got %s."
+               (Utils.type_name other))
+      | _ -> Error.arity_error_named "diff_summary" 1 (List.length args)
+    )) env

--- a/src/packages/pipeline/t_check.ml
+++ b/src/packages/pipeline/t_check.ml
@@ -1,0 +1,68 @@
+(* src/packages/pipeline/t_check.ml *)
+(* REPL-callable version of `t check` — validates pipeline structure,
+   column references, schema contracts, and environment declarations. *)
+
+open Ast
+
+(*
+--# Check a T Script for Errors
+--#
+--# Runs structural, wire-phase, schema, and environment checks on a T script.
+--# Returns the same diagnostics as the CLI `t check` command.
+--#
+--# @name t_check
+--# @param file :: String The path to the .t file to check.
+--# @param json :: Bool = false Output diagnostics as JSON.
+--# @param schema :: Bool = false Enable column-level schema validation.
+--# @param env :: Bool = false Enable tproject.toml environment checks.
+--# @return :: String The formatted diagnostics (text or JSON).
+--# @family pipeline
+--# @export
+*)
+
+let register env =
+  Env.add "t_check"
+    (make_builtin_named ~name:"t_check" ~variadic:true 1 (fun named_args _env ->
+      let named_keys = List.filter_map (fun (k, _) -> k) named_args in
+      let positional_count = List.length (List.filter (fun (k, _) -> k = None) named_args) in
+      match List.find_opt (fun k -> not (List.mem k ["file"; "json"; "schema"; "env"])) named_keys with
+      | Some k ->
+          Error.type_error (Printf.sprintf "t_check: unknown argument '%s'" k)
+      | None when positional_count > 1 ->
+          Error.make_error ArityError
+            (Printf.sprintf "Function `t_check` accepts at most 1 positional argument but received %d." positional_count)
+      | None ->
+        match Pipeline_args.get_arg "file" 1 (VNA NAGeneric) named_args with
+        | (_, VString filename) ->
+            let (_, json_val) = Pipeline_args.get_arg "json" 2 (VBool false) named_args in
+            let (_, schema_val) = Pipeline_args.get_arg "schema" 3 (VBool false) named_args in
+            let (_, env_val) = Pipeline_args.get_arg "env" 4 (VBool false) named_args in
+
+            let json_result =
+              match json_val with
+              | VBool b -> Ok b
+              | _ -> Error (Error.type_error "Function `t_check` expects `json` to be a Bool.")
+            in
+            let schema_result =
+              match schema_val with
+              | VBool b -> Ok b
+              | _ -> Error (Error.type_error "Function `t_check` expects `schema` to be a Bool.")
+            in
+            let env_result =
+              match env_val with
+              | VBool b -> Ok b
+              | _ -> Error (Error.type_error "Function `t_check` expects `env` to be a Bool.")
+            in
+
+            let (let*) x f = match x with Ok v -> f v | Error e -> e in
+            let* do_json = json_result in
+            let* do_schema = schema_result in
+            let* do_env = env_result in
+
+            let check_result = Check_utils.run_check ~schema:do_schema ~env_check:do_env Typecheck.Strict filename Env.empty in
+            VString (Check_utils.format_check_result ~json:do_json check_result)
+        | (_, other) ->
+            Error.type_error
+              (Printf.sprintf "Function `t_check` expects a file path (String) as first argument, but got %s."
+                 (Utils.type_name other))
+    )) env

--- a/src/packages/pipeline/t_diff.ml
+++ b/src/packages/pipeline/t_diff.ml
@@ -1,0 +1,142 @@
+(* src/packages/pipeline/t_diff.ml *)
+(* REPL-callable version of `t diff` — compares two builds of a pipeline
+   using per-node Nix content hashes. *)
+
+open Ast
+
+(*
+--# Compare Two Builds of a Pipeline
+--#
+--# Compares two builds of a pipeline and returns a summary of which nodes
+--# changed, were added, or were removed. Uses per-node Nix content hashes.
+--#
+--# @name t_diff
+--# @param file :: String The path to the .t file to diff.
+--# @param json :: Bool = false Output diff as JSON.
+--# @param log_a :: Int = 2 Rank of the first (older) build log.
+--# @param log_b :: Int = 1 Rank of the second (newer) build log.
+--# @return :: String The formatted diff (text or JSON).
+--# @family pipeline
+--# @export
+*)
+
+let format_diff_result (r : Builder_diff.diff_result) =
+  let buf = Buffer.create 256 in
+  Buffer.add_string buf (Printf.sprintf "\nBuild A: %s (%s)\n" r.dr_build_a.Builder_diff.bi_log_file r.dr_build_a.Builder_diff.bi_timestamp);
+  Buffer.add_string buf (Printf.sprintf "Build B: %s (%s)\n\n" r.dr_build_b.Builder_diff.bi_log_file r.dr_build_b.Builder_diff.bi_timestamp);
+  Buffer.add_string buf (Printf.sprintf "%-20s %-12s %s\n" "Node" "Status" "Detail");
+  Buffer.add_string buf (Printf.sprintf "%-20s %-12s %s\n" (String.make 20 '-') (String.make 12 '-') (String.make 30 '-'));
+  List.iter (fun (e : Builder_diff.node_diff_entry) ->
+    let detail = match e.nde_status with
+      | Builder_diff.Unchanged _ -> ""
+      | Builder_diff.Changed { hash_a; hash_b } ->
+          Printf.sprintf "hash %s -> %s" (String.sub hash_a 0 (min 7 (String.length hash_a)))
+                                         (String.sub hash_b 0 (min 7 (String.length hash_b)))
+      | Builder_diff.Added _ -> "new node"
+      | Builder_diff.Removed _ -> "removed"
+      | Builder_diff.Errored { error_class } -> Printf.sprintf "error: %s" error_class
+    in
+    Buffer.add_string buf (Printf.sprintf "%-20s %-12s %s\n" e.nde_name (Builder_diff.node_status_to_string e.nde_status) detail)
+  ) r.dr_nodes;
+  Buffer.add_string buf (Printf.sprintf "\nSummary: %d nodes, %d unchanged, %d changed, %d errored, %d added, %d removed\n"
+    r.dr_total r.dr_unchanged r.dr_changed r.dr_errored r.dr_added r.dr_removed);
+  Buffer.contents buf
+
+let register env =
+  Env.add "t_diff"
+    (make_builtin_named ~name:"t_diff" ~variadic:true 1 (fun named_args _env ->
+      let named_keys = List.filter_map (fun (k, _) -> k) named_args in
+      let positional_count = List.length (List.filter (fun (k, _) -> k = None) named_args) in
+      match List.find_opt (fun k -> not (List.mem k ["file"; "json"; "log_a"; "log_b"])) named_keys with
+      | Some k ->
+          Error.type_error (Printf.sprintf "t_diff: unknown argument '%s'" k)
+      | None when positional_count > 1 ->
+          Error.make_error ArityError
+            (Printf.sprintf "Function `t_diff` accepts at most 1 positional argument but received %d." positional_count)
+      | None ->
+        match Pipeline_args.get_arg "file" 1 (VNA NAGeneric) named_args with
+        | (_, VString filename) ->
+            let (_, json_val) = Pipeline_args.get_arg "json" 2 (VBool false) named_args in
+            let (_, log_a_val) = Pipeline_args.get_arg "log_a" 3 (VInt 2) named_args in
+            let (_, log_b_val) = Pipeline_args.get_arg "log_b" 4 (VInt 1) named_args in
+
+            let json_result =
+              match json_val with
+              | VBool b -> Ok b
+              | _ -> Error (Error.type_error "Function `t_diff` expects `json` to be a Bool.")
+            in
+            let log_a_result =
+              match log_a_val with
+              | VInt i when i >= 1 -> Ok i
+              | VInt _ -> Error (Error.value_error "Function `t_diff` expects `log_a` to be >= 1.")
+              | _ -> Error (Error.type_error "Function `t_diff` expects `log_a` to be an Int.")
+            in
+            let log_b_result =
+              match log_b_val with
+              | VInt i when i >= 1 -> Ok i
+              | VInt _ -> Error (Error.value_error "Function `t_diff` expects `log_b` to be >= 1.")
+              | _ -> Error (Error.type_error "Function `t_diff` expects `log_b` to be an Int.")
+            in
+
+            let (let*) x f = match x with Ok v -> f v | Error e -> e in
+            let* do_json = json_result in
+            let* do_log_a = log_a_result in
+            let* do_log_b = log_b_result in
+
+            let pipelines = Check_utils.extract_pipelines Typecheck.Strict filename Env.empty in
+            (match pipelines with
+             | Error err -> VError err
+             | Ok [] ->
+                 Error.make_error FileError
+                   (Printf.sprintf "t_diff: no pipeline found in %s." filename)
+             | Ok ((_, p) :: _) ->
+                 let is_default = (do_log_a = 2 && do_log_b = 1) in
+                 if is_default then
+                   match Builder.find_two_matching_logs p with
+                   | None ->
+                       Error.make_error FileError
+                         "t_diff: fewer than 2 matching build logs found. Run build_pipeline(p) at least twice."
+                   | Some (log_a_path, log_b_path) ->
+                       (match Builder_diff.compute_diff log_a_path log_b_path with
+                        | Error msg ->
+                            Error.make_error RuntimeError
+                              (Printf.sprintf "t_diff: %s" msg)
+                        | Ok diff_result ->
+                            if do_json then
+                              VString (Yojson.Safe.pretty_to_string (Builder_diff.diff_result_to_yojson diff_result))
+                            else
+                              VString (format_diff_result diff_result))
+                 else
+                   let logs = Builder.get_logs () in
+                   let try_log log_file =
+                     let full_path = Filename.concat Builder.pipeline_dir log_file in
+                     match Builder.read_log full_path with
+                     | Ok entries when Builder_read_node.pipeline_matches_logged_entries p entries -> Some full_path
+                     | _ -> None
+                   in
+                   let matching = List.filter_map try_log logs in
+                   let n_matching = List.length matching in
+                   if n_matching < 2 then
+                     Error.make_error FileError
+                       (Printf.sprintf "t_diff: need at least 2 matching build logs to diff. Found %d." n_matching)
+                   else if do_log_a > n_matching || do_log_b > n_matching then
+                     Error.make_error FileError
+                       (Printf.sprintf "t_diff: requested rank exceeds available builds: --log-a %d --log-b %d but only %d matching builds found."
+                          do_log_a do_log_b n_matching)
+                   else
+                     let path_a = List.nth matching (do_log_a - 1) in
+                     let path_b = List.nth matching (do_log_b - 1) in
+                     (match Builder_diff.compute_diff path_a path_b with
+                      | Error msg ->
+                          Error.make_error RuntimeError
+                            (Printf.sprintf "t_diff: %s" msg)
+                      | Ok diff_result ->
+                          if do_json then
+                            VString (Yojson.Safe.pretty_to_string (Builder_diff.diff_result_to_yojson diff_result))
+                          else
+                            VString (format_diff_result diff_result)))
+        | (_, other) ->
+            Error.type_error
+              (Printf.sprintf "Function `t_diff` expects a file path (String) as first argument, but got %s."
+                 (Utils.type_name other))
+    )) env

--- a/src/packages/pipeline/t_fix.ml
+++ b/src/packages/pipeline/t_fix.ml
@@ -1,0 +1,96 @@
+(* src/packages/pipeline/t_fix.ml *)
+(* REPL-callable version of `t fix` — mechanically applies suggested fixes
+   from check diagnostics (type casts, column renames). *)
+
+open Ast
+
+(*
+--# Mechanically Apply Suggested Fixes
+--#
+--# Runs `t check --schema` on a file, extracts diagnostics with suggested_fix,
+--# and applies them (e.g., inserting `|> mutate($col = as.type($col))` for type
+--# contract violations). Uses bottom-up line order to avoid line-number drift.
+--#
+--# @name t_fix
+--# @param file :: String The path to the .t file to fix.
+--# @param dry_run :: Bool = false Show what would be fixed without modifying the file.
+--# @return :: String Summary of fixes applied (or would be applied).
+--# @family pipeline
+--# @export
+*)
+
+let format_fix_result (result : Fix.fix_result) =
+  if result.Fix.applied = 0 && result.Fix.skipped = 0 then
+    "No fixes to apply.\n"
+  else
+    let buf = Buffer.create 256 in
+    Buffer.add_string buf (Printf.sprintf "Applied %d fix(es), skipped %d.\n" result.Fix.applied result.Fix.skipped);
+    List.iter (fun (d : Diagnostics.diagnostic) ->
+      let fix_desc = match d.diag_suggested_fix with
+        | Diagnostics.Cast { column; cast_to; _ } ->
+            Printf.sprintf "  Cast column '%s' to %s" column cast_to
+        | Diagnostics.Rename_column { old_name; new_name; _ } ->
+            Printf.sprintf "  Rename column '%s' to '%s'" old_name new_name
+        | Diagnostics.Add_node_arg _ -> "  Add node argument"
+        | Diagnostics.Pin_package_version _ -> "  Pin package version"
+        | Diagnostics.NoFix -> "  No fix"
+      in
+      Buffer.add_string buf (Printf.sprintf "%s:%d: %s\n"
+        (Option.value ~default:"<unknown>" d.diag_file)
+        (Option.value ~default:0 d.diag_line)
+        fix_desc)
+    ) result.Fix.diagnostics;
+    Buffer.contents buf
+
+let register env =
+  Env.add "t_fix"
+    (make_builtin_named ~name:"t_fix" ~variadic:true 1 (fun named_args _env ->
+      let named_keys = List.filter_map (fun (k, _) -> k) named_args in
+      let positional_count = List.length (List.filter (fun (k, _) -> k = None) named_args) in
+      match List.find_opt (fun k -> not (List.mem k ["file"; "dry_run"])) named_keys with
+      | Some k ->
+          Error.type_error (Printf.sprintf "t_fix: unknown argument '%s'" k)
+      | None when positional_count > 1 ->
+          Error.make_error ArityError
+            (Printf.sprintf "Function `t_fix` accepts at most 1 positional argument but received %d." positional_count)
+      | None ->
+        match Pipeline_args.get_arg "file" 1 (VNA NAGeneric) named_args with
+        | (_, VString file) ->
+            let (_, dry_run_val) = Pipeline_args.get_arg "dry_run" 2 (VBool false) named_args in
+
+            let dry_run_result =
+              match dry_run_val with
+              | VBool b -> Ok b
+              | _ -> Error (Error.type_error "Function `t_fix` expects `dry_run` to be a Bool.")
+            in
+
+            let (let*) x f = match x with Ok v -> f v | Error e -> e in
+            let* do_dry_run = dry_run_result in
+
+            let check_result = Check_utils.run_check ~schema:true Typecheck.Strict file Env.empty in
+            let diags = Diagnostics.check_result_entries check_result in
+            let fixes = diags
+              |> List.filter_map (fun (d : Diagnostics.diagnostic) ->
+                match d.diag_suggested_fix with Diagnostics.NoFix -> None | _ -> Some d)
+              |> Fix.sort_fixes_by_descending_line
+            in
+            let applied = ref 0 in
+            let skipped = ref 0 in
+            List.iter (fun (d : Diagnostics.diagnostic) ->
+              if do_dry_run then
+                incr skipped
+              else begin
+                let file_to_fix = match d.diag_file with Some f -> f | None -> file in
+                if Fix.apply_fix ~file:file_to_fix d.diag_suggested_fix then
+                  incr applied
+                else
+                  incr skipped
+              end
+            ) fixes;
+            let result = { Fix.file; applied = !applied; skipped = !skipped; diagnostics = fixes } in
+            VString (format_fix_result result)
+        | (_, other) ->
+            Error.type_error
+              (Printf.sprintf "Function `t_fix` expects a file path (String) as first argument, but got %s."
+                 (Utils.type_name other))
+    )) env

--- a/src/packages/pipeline/t_fix.ml
+++ b/src/packages/pipeline/t_fix.ml
@@ -20,11 +20,14 @@ open Ast
 *)
 
 let format_fix_result (result : Fix.fix_result) =
-  if result.Fix.applied = 0 && result.Fix.skipped = 0 then
+  if result.Fix.applied = 0 && result.Fix.would_apply = 0 && result.Fix.skipped = 0 then
     "No fixes to apply.\n"
   else
     let buf = Buffer.create 256 in
-    Buffer.add_string buf (Printf.sprintf "Applied %d fix(es), skipped %d.\n" result.Fix.applied result.Fix.skipped);
+    if result.Fix.would_apply > 0 then
+      Buffer.add_string buf (Printf.sprintf "Would apply %d fix(es), skipped %d.\n" result.Fix.would_apply result.Fix.skipped)
+    else
+      Buffer.add_string buf (Printf.sprintf "Applied %d fix(es), skipped %d.\n" result.Fix.applied result.Fix.skipped);
     List.iter (fun (d : Diagnostics.diagnostic) ->
       let fix_desc = match d.diag_suggested_fix with
         | Diagnostics.Cast { column; cast_to; _ } ->
@@ -74,20 +77,7 @@ let register env =
                 match d.diag_suggested_fix with Diagnostics.NoFix -> None | _ -> Some d)
               |> Fix.sort_fixes_by_descending_line
             in
-            let applied = ref 0 in
-            let skipped = ref 0 in
-            List.iter (fun (d : Diagnostics.diagnostic) ->
-              if do_dry_run then
-                incr skipped
-              else begin
-                let file_to_fix = match d.diag_file with Some f -> f | None -> file in
-                if Fix.apply_fix ~file:file_to_fix d.diag_suggested_fix then
-                  incr applied
-                else
-                  incr skipped
-              end
-            ) fixes;
-            let result = { Fix.file; applied = !applied; skipped = !skipped; diagnostics = fixes } in
+            let result = Fix.apply_fixes ~dry_run:do_dry_run ~default_file:file fixes in
             VString (format_fix_result result)
         | (_, other) ->
             Error.type_error

--- a/src/pipeline/builder.ml
+++ b/src/pipeline/builder.ml
@@ -7,3 +7,4 @@ include Builder_populate
 include Builder_inspect
 include Builder_read_node
 include Builder_copy
+include Builder_diff

--- a/src/pipeline/builder_diff.ml
+++ b/src/pipeline/builder_diff.ml
@@ -33,6 +33,7 @@ type diff_result = {
   dr_total : int;
   dr_unchanged : int;
   dr_changed : int;
+  dr_errored : int;
   dr_added : int;
   dr_removed : int;
 }
@@ -49,6 +50,10 @@ let find_two_matching_logs (p : pipeline_result) =
   match matching with
   | a :: b :: _ -> Some (b, a)
   | _ -> None
+
+let no_hash_sentinel = "no_hash"
+
+let is_no_hash h = h = no_hash_sentinel
 
 let load_log_with_hashes path =
   match Builder_logs.read_log_with_hashes path with
@@ -79,11 +84,13 @@ let compute_diff log_a_path log_b_path =
         | Some (cn_a, hash_a), Some (cn_b, hash_b) ->
             let class_a = cn_a.Ast.cn_class in
             let class_b = cn_b.Ast.cn_class in
-            if hash_a = hash_b && hash_a <> "" then
-              Some { nde_name = name; nde_status = Unchanged { hash = hash_a };
+            let a_errored = class_a = "Error" || is_no_hash hash_a in
+            let b_errored = class_b = "Error" || is_no_hash hash_b in
+            if a_errored || b_errored then
+              Some { nde_name = name; nde_status = Errored { error_class = class_a ^ " -> " ^ class_b };
                      nde_class_a = class_a; nde_class_b = class_b }
-            else if hash_a = "" || hash_b = "" then
-              Some { nde_name = name; nde_status = Changed { hash_a; hash_b };
+            else if hash_a = hash_b then
+              Some { nde_name = name; nde_status = Unchanged { hash = hash_a };
                      nde_class_a = class_a; nde_class_b = class_b }
             else
               Some { nde_name = name; nde_status = Changed { hash_a; hash_b };
@@ -96,24 +103,25 @@ let compute_diff log_a_path log_b_path =
                    nde_class_a = ""; nde_class_b = cn_b.Ast.cn_class }
         | None, None -> None
       ) all_names in
-      let counts = List.fold_left (fun (u, c, a, r) e ->
-        match e.nde_status with
-        | Unchanged _ -> (u + 1, c, a, r)
-        | Changed _ -> (u, c + 1, a, r)
-        | Added _ -> (u, c, a + 1, r)
-        | Removed _ -> (u, c, a, r + 1)
-        | Errored _ -> (u, c + 1, a, r)
-      ) (0, 0, 0, 0) entries in
+      let counts = List.fold_left (fun (u, c, er, a, r) entry ->
+        match entry.nde_status with
+        | Unchanged _ -> (u + 1, c, er, a, r)
+        | Changed _ -> (u, c + 1, er, a, r)
+        | Errored _ -> (u, c, er + 1, a, r)
+        | Added _ -> (u, c, er, a + 1, r)
+        | Removed _ -> (u, c, er, a, r + 1)
+      ) (0, 0, 0, 0, 0) entries in
       let total = List.length entries in
       Ok {
         dr_build_a = info_a;
         dr_build_b = info_b;
         dr_nodes = entries;
         dr_total = total;
-        dr_unchanged = (fun (u, _, _, _) -> u) counts;
-        dr_changed = (fun (_, c, _, _) -> c) counts;
-        dr_added = (fun (_, _, a, _) -> a) counts;
-        dr_removed = (fun (_, _, _, r) -> r) counts;
+        dr_unchanged = (fun (u, _, _, _, _) -> u) counts;
+        dr_changed = (fun (_, c, _, _, _) -> c) counts;
+        dr_errored = (fun (_, _, er, _, _) -> er) counts;
+        dr_added = (fun (_, _, _, a, _) -> a) counts;
+        dr_removed = (fun (_, _, _, _, r) -> r) counts;
       }
 
 let node_status_to_string = function
@@ -132,17 +140,16 @@ let print_diff_result (r : diff_result) =
     let detail = match e.nde_status with
       | Unchanged _ -> ""
       | Changed { hash_a; hash_b } ->
-          if hash_a = "" || hash_b = "" then "output hash differs"
-          else Printf.sprintf "hash %s -> %s" (String.sub hash_a 0 (min 7 (String.length hash_a)))
+          Printf.sprintf "hash %s -> %s" (String.sub hash_a 0 (min 7 (String.length hash_a)))
                                          (String.sub hash_b 0 (min 7 (String.length hash_b)))
       | Added _ -> "new node"
       | Removed _ -> "removed"
-      | Errored _ -> "errored"
+      | Errored { error_class } -> Printf.sprintf "error: %s" error_class
     in
     Printf.printf "%-20s %-12s %s\n" e.nde_name (node_status_to_string e.nde_status) detail
   ) r.dr_nodes;
-  Printf.printf "\nSummary: %d nodes, %d unchanged, %d changed, %d added, %d removed\n"
-    r.dr_total r.dr_unchanged r.dr_changed r.dr_added r.dr_removed
+  Printf.printf "\nSummary: %d nodes, %d unchanged, %d changed, %d errored, %d added, %d removed\n"
+    r.dr_total r.dr_unchanged r.dr_changed r.dr_errored r.dr_added r.dr_removed
 
 let diff_result_to_yojson (r : diff_result) =
   let node_to_yojson e =
@@ -178,6 +185,7 @@ let diff_result_to_yojson (r : diff_result) =
       ("total", `Int r.dr_total);
       ("unchanged", `Int r.dr_unchanged);
       ("changed", `Int r.dr_changed);
+      ("errored", `Int r.dr_errored);
       ("added", `Int r.dr_added);
       ("removed", `Int r.dr_removed);
     ]);

--- a/src/pipeline/builder_diff.ml
+++ b/src/pipeline/builder_diff.ml
@@ -1,0 +1,185 @@
+(* src/pipeline/builder_diff.ml *)
+(* Content-addressed output diffing: compares two builds and reports per-node changes.
+   Uses per-node Nix content hashes stored in build logs for fast comparison without
+   loading artifacts. Implements §3.3 of the path-to-0.54.1 spec. *)
+
+open Ast
+open Builder_utils
+
+type node_status =
+  | Unchanged of { hash : string }
+  | Changed of { hash_a : string; hash_b : string }
+  | Added of { hash : string }
+  | Removed of { hash : string }
+  | Errored of { error_class : string }
+
+type node_diff_entry = {
+  nde_name : string;
+  nde_status : node_status;
+  nde_class_a : string;
+  nde_class_b : string;
+}
+
+type build_info = {
+  bi_log_file : string;
+  bi_timestamp : string;
+  bi_hash : string;
+}
+
+type diff_result = {
+  dr_build_a : build_info;
+  dr_build_b : build_info;
+  dr_nodes : node_diff_entry list;
+  dr_total : int;
+  dr_unchanged : int;
+  dr_changed : int;
+  dr_added : int;
+  dr_removed : int;
+}
+
+let find_two_matching_logs (p : pipeline_result) =
+  let logs = Builder_logs.get_logs () in
+  let try_log log_file =
+    let full_path = Filename.concat pipeline_dir log_file in
+    match Builder_logs.read_log full_path with
+    | Ok entries when Builder_read_node.pipeline_matches_logged_entries p entries -> Some full_path
+    | _ -> None
+  in
+  let matching = List.filter_map try_log logs in
+  match matching with
+  | a :: b :: _ -> Some (b, a)
+  | _ -> None
+
+let load_log_with_hashes path =
+  match Builder_logs.read_log_with_hashes path with
+  | Ok (entries, timestamp, top_hash) ->
+      let node_map = Hashtbl.create (List.length entries) in
+      List.iter (fun (name, cn, node_hash) ->
+        Hashtbl.replace node_map name (cn, node_hash)
+      ) entries;
+      let info = {
+        bi_log_file = Filename.basename path;
+        bi_timestamp = timestamp;
+        bi_hash = top_hash;
+      } in
+      Ok (info, node_map)
+  | Error msg -> Error msg
+
+let compute_diff log_a_path log_b_path =
+  match load_log_with_hashes log_a_path, load_log_with_hashes log_b_path with
+  | Error e, _ | _, Error e -> Error e
+  | Ok (info_a, nodes_a), Ok (info_b, nodes_b) ->
+      let names_a = Hashtbl.fold (fun k _ acc -> k :: acc) nodes_a [] |> List.sort String.compare in
+      let names_b = Hashtbl.fold (fun k _ acc -> k :: acc) nodes_b [] |> List.sort String.compare in
+      let all_names = List.sort String.compare (List.sort_uniq String.compare (names_a @ names_b)) in
+      let entries = List.filter_map (fun name ->
+        let in_a = Hashtbl.find_opt nodes_a name in
+        let in_b = Hashtbl.find_opt nodes_b name in
+        match in_a, in_b with
+        | Some (cn_a, hash_a), Some (cn_b, hash_b) ->
+            let class_a = cn_a.Ast.cn_class in
+            let class_b = cn_b.Ast.cn_class in
+            if hash_a = hash_b && hash_a <> "" then
+              Some { nde_name = name; nde_status = Unchanged { hash = hash_a };
+                     nde_class_a = class_a; nde_class_b = class_b }
+            else if hash_a = "" || hash_b = "" then
+              Some { nde_name = name; nde_status = Changed { hash_a; hash_b };
+                     nde_class_a = class_a; nde_class_b = class_b }
+            else
+              Some { nde_name = name; nde_status = Changed { hash_a; hash_b };
+                     nde_class_a = class_a; nde_class_b = class_b }
+        | Some (cn_a, hash_a), None ->
+            Some { nde_name = name; nde_status = Removed { hash = hash_a };
+                   nde_class_a = cn_a.Ast.cn_class; nde_class_b = "" }
+        | None, Some (cn_b, hash_b) ->
+            Some { nde_name = name; nde_status = Added { hash = hash_b };
+                   nde_class_a = ""; nde_class_b = cn_b.Ast.cn_class }
+        | None, None -> None
+      ) all_names in
+      let counts = List.fold_left (fun (u, c, a, r) e ->
+        match e.nde_status with
+        | Unchanged _ -> (u + 1, c, a, r)
+        | Changed _ -> (u, c + 1, a, r)
+        | Added _ -> (u, c, a + 1, r)
+        | Removed _ -> (u, c, a, r + 1)
+        | Errored _ -> (u, c + 1, a, r)
+      ) (0, 0, 0, 0) entries in
+      let total = List.length entries in
+      Ok {
+        dr_build_a = info_a;
+        dr_build_b = info_b;
+        dr_nodes = entries;
+        dr_total = total;
+        dr_unchanged = (fun (u, _, _, _) -> u) counts;
+        dr_changed = (fun (_, c, _, _) -> c) counts;
+        dr_added = (fun (_, _, a, _) -> a) counts;
+        dr_removed = (fun (_, _, _, r) -> r) counts;
+      }
+
+let node_status_to_string = function
+  | Unchanged _ -> "unchanged"
+  | Changed _ -> "changed"
+  | Added _ -> "added"
+  | Removed _ -> "removed"
+  | Errored _ -> "errored"
+
+let print_diff_result (r : diff_result) =
+  Printf.printf "\nBuild A: %s (%s)\n" r.dr_build_a.bi_log_file r.dr_build_a.bi_timestamp;
+  Printf.printf "Build B: %s (%s)\n\n" r.dr_build_b.bi_log_file r.dr_build_b.bi_timestamp;
+  Printf.printf "%-20s %-12s %s\n" "Node" "Status" "Detail";
+  Printf.printf "%-20s %-12s %s\n" (String.make 20 '-') (String.make 12 '-') (String.make 30 '-');
+  List.iter (fun e ->
+    let detail = match e.nde_status with
+      | Unchanged _ -> ""
+      | Changed { hash_a; hash_b } ->
+          if hash_a = "" || hash_b = "" then "output hash differs"
+          else Printf.sprintf "hash %s -> %s" (String.sub hash_a 0 (min 7 (String.length hash_a)))
+                                         (String.sub hash_b 0 (min 7 (String.length hash_b)))
+      | Added _ -> "new node"
+      | Removed _ -> "removed"
+      | Errored _ -> "errored"
+    in
+    Printf.printf "%-20s %-12s %s\n" e.nde_name (node_status_to_string e.nde_status) detail
+  ) r.dr_nodes;
+  Printf.printf "\nSummary: %d nodes, %d unchanged, %d changed, %d added, %d removed\n"
+    r.dr_total r.dr_unchanged r.dr_changed r.dr_added r.dr_removed
+
+let diff_result_to_yojson (r : diff_result) =
+  let node_to_yojson e =
+    let status_str = node_status_to_string e.nde_status in
+    let base = [
+      ("name", `String e.nde_name);
+      ("status", `String status_str);
+    ] in
+    let with_detail = match e.nde_status with
+      | Unchanged { hash } -> base @ [("hash", `String hash)]
+      | Changed { hash_a; hash_b } -> base @ [("hash_a", `String hash_a); ("hash_b", `String hash_b)]
+      | Added { hash } -> base @ [("hash", `String hash)]
+      | Removed { hash } -> base @ [("hash", `String hash)]
+      | Errored { error_class } -> base @ [("error_class", `String error_class)]
+    in
+    `Assoc with_detail
+  in
+  `Assoc [
+    ("schema_version", `String "1");
+    ("status", `String "ok");
+    ("phase", `String "diff");
+    ("build_a", `Assoc [
+      ("log", `String r.dr_build_a.bi_log_file);
+      ("timestamp", `String r.dr_build_a.bi_timestamp);
+      ("hash", `String r.dr_build_a.bi_hash);
+    ]);
+    ("build_b", `Assoc [
+      ("log", `String r.dr_build_b.bi_log_file);
+      ("timestamp", `String r.dr_build_b.bi_timestamp);
+      ("hash", `String r.dr_build_b.bi_hash);
+    ]);
+    ("summary", `Assoc [
+      ("total", `Int r.dr_total);
+      ("unchanged", `Int r.dr_unchanged);
+      ("changed", `Int r.dr_changed);
+      ("added", `Int r.dr_added);
+      ("removed", `Int r.dr_removed);
+    ]);
+    ("nodes", `List (List.map node_to_yojson r.dr_nodes));
+  ]

--- a/src/pipeline/builder_internal.ml
+++ b/src/pipeline/builder_internal.ml
@@ -486,6 +486,14 @@ let build_pipeline_internal ?verbose ?pipeline_name ?(nix_options : nix_opts opt
         let log_name = Printf.sprintf "build_log_%s_%s.json" timestamp hash in
         let log_path = Filename.concat pipeline_dir log_name in
         
+        let node_hash name =
+          match Hashtbl.find_opt node_store_paths name with
+          | Some path ->
+              (match String.split_on_char '-' (Filename.basename path) with
+               | hd :: _ -> hd
+               | [] -> "no_hash")
+          | None -> "no_hash"
+        in
         let log_entries =
           List.map (fun (name, _) ->
             let node_path =
@@ -557,6 +565,7 @@ let build_pipeline_internal ?verbose ?pipeline_name ?(nix_options : nix_opts opt
             Serialization.json_dict ([
               ("node", "\"" ^ Serialization.json_escape name ^ "\"");
               ("path", "\"" ^ Serialization.json_escape artifact_path ^ "\"");
+              ("hash", "\"" ^ Serialization.json_escape (node_hash name) ^ "\"");
               ("runtime", "\"" ^ Serialization.json_escape runtime ^ "\"");
               ("serializer", "\"" ^ Serialization.json_escape serializer ^ "\"");
               ("class", "\"" ^ Serialization.json_escape class_val ^ "\"");

--- a/src/pipeline/builder_logs.ml
+++ b/src/pipeline/builder_logs.ml
@@ -98,6 +98,63 @@ let read_log path =
     Ok entries
   with exn -> Error (Printexc.to_string exn)
 
+let read_log_with_hashes path =
+  try
+    let json = Yojson.Safe.from_file path in
+    let open Yojson.Safe.Util in
+    let timestamp =
+      match json |> member "timestamp" with
+      | `String s -> s
+      | _ -> ""
+    in
+    let top_hash =
+      match json |> member "hash" with
+      | `String s -> s
+      | _ -> ""
+    in
+    let nodes = json |> member "nodes" |> to_list in
+    let entries_and_hashes = List.map (fun node_json ->
+      let name = node_json |> member "node" |> to_string in
+      let status =
+        match node_json |> member "status" with
+        | `String s -> s
+        | _ -> ""
+      in
+      let err_code =
+        match node_json |> member "error_code" with
+        | `String s -> s
+        | _ -> ""
+      in
+      let cn_class =
+        if status = "Errored" then
+          (if err_code <> "" then err_code else "Error")
+        else
+          node_json |> member "class" |> to_string
+      in
+      let cn_path =
+        if status = "Errored" then ""
+        else node_json |> member "path" |> to_string
+      in
+      let node_hash =
+        match node_json |> member "hash" with
+        | `String s -> s
+        | _ -> ""
+      in
+      let cn = {
+        Ast.cn_name = name;
+        cn_runtime = node_json |> member "runtime" |> to_string;
+        cn_path;
+        cn_serializer = node_json |> member "serializer" |> to_string;
+        cn_class;
+        cn_dependencies = node_json |> member "dependencies" |> to_list |> filter_string;
+        cn_p_exprs = None;
+        cn_flake = None;
+      } in
+      (name, cn, node_hash)
+    ) nodes in
+    Ok (entries_and_hashes, timestamp, top_hash)
+  with exn -> Error (Printexc.to_string exn)
+
 let list_logs () =
   let logs_arr = Array.of_list (get_logs ()) in
   let nrows = Array.length logs_arr in

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -832,35 +832,58 @@ let cmd_diff ?(json=false) ?(log_a=2) ?(log_b=1) filename env =
       Printf.eprintf "No pipeline found in %s.\n" filename;
       exit 1
   | (_, p) :: _ ->
-      let logs = Builder.get_logs () in
-      let try_log log_file =
-        let full_path = Filename.concat Builder.pipeline_dir log_file in
-        match Builder.read_log full_path with
-        | Ok entries when Builder_read_node.pipeline_matches_logged_entries p entries -> Some full_path
-        | _ -> None
-      in
-      let matching = List.filter_map try_log logs in
-      let n_matching = List.length matching in
-      if n_matching < 2 then begin
-        Printf.eprintf "Need at least 2 matching build logs to diff. Found %d.\n" n_matching;
-        Printf.eprintf "Run build_pipeline(p) at least twice first.\n";
-        exit 0
-      end else begin
-        let idx_a = min log_a n_matching in
-        let idx_b = min log_b n_matching in
-        let path_a = List.nth matching (idx_a - 1) in
-        let path_b = List.nth matching (idx_b - 1) in
-        match Builder.compute_diff path_a path_b with
-        | Error msg ->
-            Printf.eprintf "Error computing diff: %s\n" msg;
+      let is_default = (log_a = 2 && log_b = 1) in
+      if is_default then
+        match Builder_diff.find_two_matching_logs p with
+        | None ->
+            Printf.eprintf "Need at least 2 matching build logs to diff.\n";
+            Printf.eprintf "Run build_pipeline(p) at least twice first.\n";
             exit 1
-        | Ok diff_result ->
-            if json then
-              print_string (Yojson.Safe.pretty_to_string (Builder.diff_result_to_yojson diff_result))
-            else
-              Builder.print_diff_result diff_result;
-            exit 0
-      end
+        | Some (path_a, path_b) ->
+            (match Builder_diff.compute_diff path_a path_b with
+             | Error msg ->
+                 Printf.eprintf "Error computing diff: %s\n" msg;
+                 exit 1
+             | Ok diff_result ->
+                 if json then
+                   print_string (Yojson.Safe.pretty_to_string (Builder_diff.diff_result_to_yojson diff_result))
+                 else
+                   Builder_diff.print_diff_result diff_result;
+                 exit 0)
+      else
+        let logs = Builder.get_logs () in
+        let try_log log_file =
+          let full_path = Filename.concat Builder.pipeline_dir log_file in
+          match Builder.read_log full_path with
+          | Ok entries when Builder_read_node.pipeline_matches_logged_entries p entries -> Some full_path
+          | _ -> None
+        in
+        let matching = List.filter_map try_log logs in
+        let n_matching = List.length matching in
+        if n_matching < 2 then begin
+          Printf.eprintf "Need at least 2 matching build logs to diff. Found %d.\n" n_matching;
+          Printf.eprintf "Run build_pipeline(p) at least twice first.\n";
+          exit 1
+        end else if log_a < 1 || log_b < 1 then begin
+          Printf.eprintf "Invalid rank: --log-a and --log-b must be >= 1 (got --log-a %d --log-b %d).\n" log_a log_b;
+          exit 1
+        end else if log_a > n_matching || log_b > n_matching then begin
+          Printf.eprintf "Requested rank exceeds available builds: --log-a %d --log-b %d but only %d matching builds found.\n" log_a log_b n_matching;
+          exit 1
+        end else begin
+          let path_a = List.nth matching (log_a - 1) in
+          let path_b = List.nth matching (log_b - 1) in
+          match Builder_diff.compute_diff path_a path_b with
+          | Error msg ->
+              Printf.eprintf "Error computing diff: %s\n" msg;
+              exit 1
+          | Ok diff_result ->
+              if json then
+                print_string (Yojson.Safe.pretty_to_string (Builder_diff.diff_result_to_yojson diff_result))
+              else
+                Builder_diff.print_diff_result diff_result;
+              exit 0
+        end
 
 let cmd_debug ?(unsafe=false) ?failfast mode filename node_name env =
   let _ = unsafe in
@@ -1594,12 +1617,17 @@ let () =
       in
       let log_a = extract_int_flag "--log-a" 2 in
       let log_b = extract_int_flag "--log-b" 1 in
-      let filename = List.find_opt (fun s -> not (String.length s > 0 && s.[0] = '-')) rest in
-      (match filename with
-       | None ->
-           Printf.eprintf "Usage: t diff [--json] [--log-a <n>] [--log-b <n>] <file.t>\n";
-           exit 1
-       | Some f -> cmd_diff ~json ~log_a ~log_b f env)
+      if log_a < 1 || log_b < 1 then begin
+        Printf.eprintf "Invalid rank: --log-a and --log-b must be >= 1 (got --log-a %d --log-b %d).\n" log_a log_b;
+        exit 1
+      end else begin
+        let filename = List.find_opt (fun s -> not (String.length s > 0 && s.[0] = '-')) rest in
+        (match filename with
+         | None ->
+             Printf.eprintf "Usage: t diff [--json] [--log-a <n>] [--log-b <n>] <file.t>\n";
+             exit 1
+         | Some f -> cmd_diff ~json ~log_a ~log_b f env)
+      end
   | _ :: "repl" :: _ -> cmd_repl ~failfast mode_parse.mode env
   | _ :: "explain" :: rest -> cmd_explain ~failfast mode_parse.mode rest env
   | _ :: "init" :: "--package" :: rest -> cmd_init_package rest

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -1634,12 +1634,14 @@ let () =
   | _ :: "fix" :: rest ->
       let dry_run = List.mem "--dry-run" rest in
       let filename = List.find_opt (fun s -> not (String.length s > 0 && s.[0] = '-')) rest in
+      let script_mode = if mode_parse.mode = Typecheck.Repl && not mode_parse.mode_flag then Typecheck.Strict else mode_parse.mode in
       (match filename with
        | None ->
            Printf.eprintf "Usage: t fix [--dry-run] <file.t>\n";
            exit 1
        | Some f ->
-           let result = Fix.cmd_fix ~dry_run f in
+           let check_fn = fun file -> run_check ~schema:true script_mode file env in
+           let result = Fix.cmd_fix ~dry_run ~check_fn f in
            if result.Fix.applied = 0 && result.Fix.skipped = 0 then
              Printf.printf "No fixes to apply.\n"
            else begin

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -1527,16 +1527,19 @@ let () =
            Printf.eprintf "Usage: t fix [--dry-run] <file.t>\n";
            exit 1
        | Some f ->
-           let check_fn = fun file -> run_check ~schema:true script_mode file env in
-           let result = Fix.cmd_fix ~dry_run ~check_fn f in
-           if result.Fix.applied = 0 && result.Fix.skipped = 0 then
-             Printf.printf "No fixes to apply.\n"
-           else begin
-             Printf.printf "Applied %d fix(es), skipped %d.\n" result.Fix.applied result.Fix.skipped;
-             if not dry_run then
-               Printf.printf "Run 't check %s' to verify.\n" f
-           end;
-           exit 0)
+            let check_fn = fun file -> run_check ~schema:true script_mode file env in
+            let result = Fix.cmd_fix ~dry_run ~check_fn f in
+            if result.Fix.applied = 0 && result.Fix.would_apply = 0 && result.Fix.skipped = 0 then
+              Printf.printf "No fixes to apply.\n"
+            else begin
+              if dry_run then
+                Printf.printf "Would apply %d fix(es), skipped %d.\n" result.Fix.would_apply result.Fix.skipped
+              else begin
+                Printf.printf "Applied %d fix(es), skipped %d.\n" result.Fix.applied result.Fix.skipped;
+                Printf.printf "Run 't check %s' to verify.\n" f
+              end
+            end;
+            exit 0)
   | _ :: "repl" :: _ -> cmd_repl ~failfast mode_parse.mode env
   | _ :: "explain" :: rest -> cmd_explain ~failfast mode_parse.mode rest env
   | _ :: "init" :: "--package" :: rest -> cmd_init_package rest

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -17,73 +17,13 @@ let () =
   ignore (LNoise.history_load ~filename:history_file)
 
 (* --- Parsing and Evaluation --- *)
+(* Delegated to Check_utils (library module) so both the CLI and
+   REPL-callable functions share the same implementation. *)
 
-let source_location ?file pos : Ast.source_location =
-  {
-    file;
-    line = pos.Lexing.pos_lnum;
-    column = max 1 (pos.Lexing.pos_cnum - pos.Lexing.pos_bol + 1);
-  }
-
-let make_located_error ?file code message pos =
-  Ast.VError {
-    code;
-    message;
-    context = [];
-    location = Some (source_location ?file pos);
-    na_count = 0;
-  }
-
-let interrupt_error () =
-  Ast.VError {
-    code = Ast.RuntimeError;
-    message = "Interrupted.";
-    context = [];
-    location = None;
-    na_count = 0;
-  }
-
-let parse_and_eval ?filename ?(failfast=false) mode env input =
-  let lexbuf = Lexing.from_string input in
-  (match filename with
-   | Some file -> lexbuf.lex_curr_p <- { lexbuf.lex_curr_p with pos_fname = file }
-   | None -> ());
-  try
-    let program = Parser.program Lexer.token lexbuf in
-    match Typecheck.validate_program ~mode program with
-    | Error err -> (Ast.VError err, env)
-    | Ok () -> Eval.eval_program ~resilient:(not failfast) program env
-  with
-  | Lexer.SyntaxError msg ->
-      let pos = Lexing.lexeme_start_p lexbuf in
-      (make_located_error ?file:filename Ast.SyntaxError ("Syntax Error: " ^ msg) pos, env)
-  | Parser.Error ->
-      let pos = Lexing.lexeme_start_p lexbuf in
-      (make_located_error ?file:filename Ast.SyntaxError "Parse Error" pos, env)
-  | Ast.Mixed_bracket_form ->
-      let pos = Lexing.lexeme_start_p lexbuf in
-      (make_located_error ?file:filename Ast.SyntaxError "Mixed bracket literal (found both single elements and key-value pairs)" pos, env)
-  | Ast.Invalid_match_pattern msg ->
-      let pos = Lexing.lexeme_start_p lexbuf in
-      (make_located_error ?file:filename Ast.SyntaxError msg pos, env)
-  | Sys.Break ->
-      (interrupt_error (), env)
-
-let run_file ?failfast mode filename env =
-  try
-    let ch = open_in filename in
-    let content = really_input_string ch (in_channel_length ch) in
-    close_in ch;
-    parse_and_eval ~filename ?failfast mode env content
-  with
-  | Sys_error msg ->
-      (Ast.VError {
-         code = Ast.FileError;
-         message = "File Error: " ^ msg;
-         context = [];
-         location = None;
-         na_count = 0;
-       }, env)
+let make_located_error = Check_utils.make_located_error
+let interrupt_error = Check_utils.interrupt_error
+let parse_and_eval = Check_utils.parse_and_eval
+let run_file = Check_utils.run_file
 
 (* --- Pipeline Detection --- *)
 
@@ -712,67 +652,14 @@ let cmd_run_expr ?failfast mode expr env =
 let run_check ?(schema=false) ?(env_check=false) mode filename env =
   Packages.ensure_docs_loaded ();
   ensure_file_path filename;
-  let run () =
-    Ast.check_mode := true;
-    Fun.protect ~finally:(fun () -> Ast.check_mode := false)
-      (fun () -> run_file ~failfast:true mode filename env)
-  in
-  let (result, new_env) = run () in
-  let check_result =
-    (* Collect pipeline_result values: from the return value or from env bindings *)
-    let pipelines : (string * Ast.pipeline_result) list = match result with
-      | Ast.VPipeline p -> [("pipeline", p)]
-      | Ast.VError _ -> []
-      | _ ->
-          (* Scan environment for pipeline values *)
-          let bindings = Ast.Env.bindings new_env in
-          List.filter_map (fun (name, v) ->
-            match v with
-            | Ast.VPipeline p -> Some (name, p)
-            | _ -> None
-          ) bindings
-    in
-    let diag_list : Diagnostics.diagnostic list =
-      (* Always collect error diagnostics from the result *)
-      let error_diags = match result with
-        | Ast.VError err -> [Diagnostics.of_verror ~file:filename err]
-        | _ -> []
-      in
-      (* Collect pipeline diagnostics, schema checks, and env checks *)
-      let pipeline_diags = List.concat_map (fun (_name, p) ->
-        let wire_diags = Diagnostics.of_pipeline_result ~file:filename p in
-        let schema_diags =
-          if schema then Schema_check.check_pipeline_schemas ~file:filename p
-          else []
-        in
-        let env_diags =
-          if env_check then Env_check.check_env ~file:filename p
-          else []
-        in
-        wire_diags @ schema_diags @ env_diags
-      ) pipelines in
-      error_diags @ pipeline_diags
-    in
-    let check_phase = Diagnostics.worst_phase diag_list in
-    let tier = Diagnostics.worst_tier diag_list in
-    Diagnostics.make_result ~tier ~phase:check_phase diag_list
-  in
-  check_result
+  Check_utils.run_check ~schema ~env_check mode filename env
 
 let print_check_result ?(json=false) check_result =
+  let output = Check_utils.format_check_result ~json check_result in
   if json then
-    print_string (Yojson.Safe.pretty_to_string (Diagnostics.check_result_to_yojson check_result))
-  else begin
-    let cr_diags = Diagnostics.check_result_entries check_result in
-    List.iter (fun d ->
-      Printf.eprintf "%s [%s] %s\n"
-        (Diagnostics.severity_to_string (Diagnostics.diagnostic_severity d))
-        (Diagnostics.diagnostic_error_class d)
-        (Diagnostics.diagnostic_message d)
-    ) cr_diags;
-    if cr_diags <> [] then
-      Printf.eprintf "\n"
-  end
+    print_string output
+  else
+    Printf.eprintf "%s" output
 
 let cmd_check ?(json=false) ?(schema=false) ?(env_check=false) mode filename env =
   let check_result = run_check ~schema ~env_check mode filename env in

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -507,6 +507,7 @@ let print_help () =
   Printf.printf "  run <file.t>      Execute a T source file\n";
   Printf.printf "  run --expr <expr> Execute a T expression directly\n";
   Printf.printf "  check [--json] [--schema] [--env] <file.t>  Validate pipeline structure (no Nix builds)\n";
+  Printf.printf "  diff [--json] [--log-a <n>] [--log-b <n>] <file.t>  Compare two builds (output diff)\n";
   Printf.printf "  debug <node>      Start a subshell to debug a pipeline node\n";
   Printf.printf "  --mode <m>        Type-check mode: repl or strict\n";
   Printf.printf "  --failfast        Stop execution on first error\n";
@@ -805,6 +806,61 @@ let cmd_check_watch ?(json=false) ?(schema=false) ?(env_check=false) mode filena
   done;
   Printf.eprintf "\nStopped watching.\n%!";
   exit !last_exit_code
+
+let cmd_diff ?(json=false) ?(log_a=2) ?(log_b=1) filename env =
+  Packages.ensure_docs_loaded ();
+  ensure_file_path filename;
+  let (result, new_env) =
+    Ast.check_mode := true;
+    Fun.protect ~finally:(fun () -> Ast.check_mode := false)
+      (fun () -> run_file ~failfast:true Typecheck.Strict filename env)
+  in
+  let pipelines =
+    match result with
+    | Ast.VPipeline p -> [("pipeline", p)]
+    | Ast.VError _ -> []
+    | _ ->
+        let bindings = Ast.Env.bindings new_env in
+        List.filter_map (fun (name, v) ->
+          match v with
+          | Ast.VPipeline p -> Some (name, p)
+          | _ -> None
+        ) bindings
+  in
+  match pipelines with
+  | [] ->
+      Printf.eprintf "No pipeline found in %s.\n" filename;
+      exit 1
+  | (_, p) :: _ ->
+      let logs = Builder.get_logs () in
+      let try_log log_file =
+        let full_path = Filename.concat Builder.pipeline_dir log_file in
+        match Builder.read_log full_path with
+        | Ok entries when Builder_read_node.pipeline_matches_logged_entries p entries -> Some full_path
+        | _ -> None
+      in
+      let matching = List.filter_map try_log logs in
+      let n_matching = List.length matching in
+      if n_matching < 2 then begin
+        Printf.eprintf "Need at least 2 matching build logs to diff. Found %d.\n" n_matching;
+        Printf.eprintf "Run build_pipeline(p) at least twice first.\n";
+        exit 0
+      end else begin
+        let idx_a = min log_a n_matching in
+        let idx_b = min log_b n_matching in
+        let path_a = List.nth matching (idx_a - 1) in
+        let path_b = List.nth matching (idx_b - 1) in
+        match Builder.compute_diff path_a path_b with
+        | Error msg ->
+            Printf.eprintf "Error computing diff: %s\n" msg;
+            exit 1
+        | Ok diff_result ->
+            if json then
+              print_string (Yojson.Safe.pretty_to_string (Builder.diff_result_to_yojson diff_result))
+            else
+              Builder.print_diff_result diff_result;
+            exit 0
+      end
 
 let cmd_debug ?(unsafe=false) ?failfast mode filename node_name env =
   let _ = unsafe in
@@ -1523,6 +1579,27 @@ let () =
              cmd_check_watch ~json ~schema ~env_check:check_env script_mode f env
            else
              cmd_check ~json ~schema ~env_check:check_env script_mode f env)
+  | _ :: "diff" :: [] ->
+      Printf.eprintf "Usage: t diff [--json] [--log-a <n>] [--log-b <n>] <file.t>\n";
+      exit 1
+  | _ :: "diff" :: rest ->
+      let json = List.mem "--json" rest in
+      let extract_int_flag flag default =
+        let rec find_val = function
+          | [] -> default
+          | x :: y :: _ when x = flag -> (try int_of_string y with _ -> default)
+          | _ :: xs -> find_val xs
+        in
+        find_val rest
+      in
+      let log_a = extract_int_flag "--log-a" 2 in
+      let log_b = extract_int_flag "--log-b" 1 in
+      let filename = List.find_opt (fun s -> not (String.length s > 0 && s.[0] = '-')) rest in
+      (match filename with
+       | None ->
+           Printf.eprintf "Usage: t diff [--json] [--log-a <n>] [--log-b <n>] <file.t>\n";
+           exit 1
+       | Some f -> cmd_diff ~json ~log_a ~log_b f env)
   | _ :: "repl" :: _ -> cmd_repl ~failfast mode_parse.mode env
   | _ :: "explain" :: rest -> cmd_explain ~failfast mode_parse.mode rest env
   | _ :: "init" :: "--package" :: rest -> cmd_init_package rest

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -1622,12 +1622,32 @@ let () =
         exit 1
       end else begin
         let filename = List.find_opt (fun s -> not (String.length s > 0 && s.[0] = '-')) rest in
-        (match filename with
-         | None ->
-             Printf.eprintf "Usage: t diff [--json] [--log-a <n>] [--log-b <n>] <file.t>\n";
-             exit 1
-         | Some f -> cmd_diff ~json ~log_a ~log_b f env)
+       (match filename with
+        | None ->
+            Printf.eprintf "Usage: t diff [--json] [--log-a <n>] [--log-b <n>] <file.t>\n";
+            exit 1
+        | Some f -> cmd_diff ~json ~log_a ~log_b f env)
       end
+  | _ :: "fix" :: [] ->
+      Printf.eprintf "Usage: t fix [--dry-run] <file.t>\n";
+      exit 1
+  | _ :: "fix" :: rest ->
+      let dry_run = List.mem "--dry-run" rest in
+      let filename = List.find_opt (fun s -> not (String.length s > 0 && s.[0] = '-')) rest in
+      (match filename with
+       | None ->
+           Printf.eprintf "Usage: t fix [--dry-run] <file.t>\n";
+           exit 1
+       | Some f ->
+           let result = Fix.cmd_fix ~dry_run f in
+           if result.Fix.applied = 0 && result.Fix.skipped = 0 then
+             Printf.printf "No fixes to apply.\n"
+           else begin
+             Printf.printf "Applied %d fix(es), skipped %d.\n" result.Fix.applied result.Fix.skipped;
+             if not dry_run then
+               Printf.printf "Run 't check %s' to verify.\n" f
+           end;
+           exit 0)
   | _ :: "repl" :: _ -> cmd_repl ~failfast mode_parse.mode env
   | _ :: "explain" :: rest -> cmd_explain ~failfast mode_parse.mode rest env
   | _ :: "init" :: "--package" :: rest -> cmd_init_package rest

--- a/src/schema_check.ml
+++ b/src/schema_check.ml
@@ -323,7 +323,12 @@ let validate_contracts ~file (p : pipeline_result) schemas =
                     diag_message = Printf.sprintf "Node '%s' type contract for column '%s' expects ~ %s but output schema has type %s"
                       node_name col expected_type actual_type;
                     diag_caused_by = [];
-                    diag_suggested_fix = NoFix;
+                    diag_suggested_fix = Cast {
+                      column = col;
+                      cast_to = expected_type;
+                      file = Some file;
+                      line = None;
+                    };
                   })
                 else None
           ) type_specs

--- a/src/schema_check.ml
+++ b/src/schema_check.ml
@@ -254,6 +254,8 @@ let validate_col_refs ~node_name ~(file : string option) ~schema expr =
    Checks that all declared contract columns exist in the output schema,
    and that type contracts match inferred column types. *)
 let validate_contracts ~file (p : pipeline_result) schemas =
+  let contract_line c = match c.Ast.contract_loc with Some l -> Some l.Ast.line | None -> None in
+  let contract_column c = match c.Ast.contract_loc with Some l -> Some l.Ast.column | None -> None in
   List.concat_map (fun (node_name, contract) ->
     let output_schema =
       try Hashtbl.find schemas node_name with Not_found -> []
@@ -273,8 +275,8 @@ let validate_contracts ~file (p : pipeline_result) schemas =
               diag_node_id = Some node_name;
               diag_node_lang = None;
               diag_file = Some file;
-              diag_line = None;
-              diag_column = None;
+              diag_line = contract_line contract;
+              diag_column = contract_column contract;
               diag_message = Printf.sprintf "Node '%s' contract expects columns [%s] but output schema is [%s]. Missing: [%s]"
                 node_name
                 (String.concat ", " required_cols)
@@ -301,8 +303,8 @@ let validate_contracts ~file (p : pipeline_result) schemas =
                   diag_node_id = Some node_name;
                   diag_node_lang = None;
                   diag_file = Some file;
-                  diag_line = None;
-                  diag_column = None;
+                  diag_line = contract_line contract;
+                  diag_column = contract_column contract;
                   diag_message = Printf.sprintf "Node '%s' type contract for column '%s' (~ %s) cannot be verified statically: column type is unknown"
                     node_name col expected_type;
                   diag_caused_by = [];
@@ -318,8 +320,8 @@ let validate_contracts ~file (p : pipeline_result) schemas =
                     diag_node_id = Some node_name;
                     diag_node_lang = None;
                     diag_file = Some file;
-                    diag_line = None;
-                    diag_column = None;
+                    diag_line = contract_line contract;
+                    diag_column = contract_column contract;
                     diag_message = Printf.sprintf "Node '%s' type contract for column '%s' expects ~ %s but output schema has type %s"
                       node_name col expected_type actual_type;
                     diag_caused_by = [];
@@ -327,7 +329,7 @@ let validate_contracts ~file (p : pipeline_result) schemas =
                       column = col;
                       cast_to = expected_type;
                       file = Some file;
-                      line = None;
+                      line = contract_line contract;
                     };
                   })
                 else None
@@ -346,8 +348,8 @@ let validate_contracts ~file (p : pipeline_result) schemas =
               diag_node_id = Some node_name;
               diag_node_lang = None;
               diag_file = Some file;
-              diag_line = None;
-              diag_column = None;
+              diag_line = contract_line contract;
+              diag_column = contract_column contract;
               diag_message = Printf.sprintf "Node '%s' null-rate contract for column '%s' (< %.2f) cannot be verified statically: requires runtime data"
                 node_name col threshold;
               diag_caused_by = [];

--- a/src/schema_check.ml
+++ b/src/schema_check.ml
@@ -3,8 +3,26 @@
 
 open Ast
 
-(* A schema is a list of column names. Types are not tracked statically. *)
-type schema = string list
+(* A schema tracks column names with optional type information.
+   Types are inferred from CSV headers and propagated through pipe chains. *)
+type schema_col = { sc_name : string; sc_type : string option }
+type schema = schema_col list
+
+let schema_names (s : schema) : string list = List.map (fun c -> c.sc_name) s
+
+let schema_has_col (col : string) (s : schema) : bool =
+  List.exists (fun c -> c.sc_name = col) s
+
+let schema_find_type (col : string) (s : schema) : string option =
+  match List.find_opt (fun c -> c.sc_name = col) s with
+  | Some c -> c.sc_type
+  | None -> None
+
+let make_schema ?(typed=[]) (cols : string list) : schema =
+  List.map (fun name ->
+    let sc_type = List.assoc_opt name typed in
+    { sc_name = name; sc_type }
+  ) cols
 
 (* ---------- AST column reference extraction ---------- *)
 
@@ -152,28 +170,37 @@ let infer_output_schema input_schema expr =
   | Select ->
       let cols = extract_select_cols
           (match expr.node with Call { args; _ } -> args | _ -> []) in
-      if cols = [] then input_schema else cols
+      if cols = [] then input_schema
+      else List.filter_map (fun c ->
+        if schema_has_col c input_schema then
+          Some { sc_name = c; sc_type = schema_find_type c input_schema }
+        else
+          Some { sc_name = c; sc_type = None }
+      ) cols
   | Filter | Ungroup | Slice | Arrange | GroupBy ->
       input_schema
   | Mutate ->
       let new_cols = extract_mutate_new_cols
           (match expr.node with Call { args; _ } -> args | _ -> []) in
       (* Remove any input cols being overwritten, then append new *)
-      let old_cols = List.filter (fun c -> not (List.mem c new_cols)) input_schema in
-      old_cols @ new_cols
+      let old_cols = List.filter (fun c -> not (List.mem c.sc_name new_cols)) input_schema in
+      old_cols @ List.map (fun name -> { sc_name = name; sc_type = None }) new_cols
   | Rename ->
       (* rename(df, $old, "new") — we can't fully parse this statically,
          just return input schema unchanged *)
       input_schema
   | Summarize ->
-      extract_summarize_cols
-        (match expr.node with Call { args; _ } -> args | _ -> [])
+      let cols = extract_summarize_cols
+          (match expr.node with Call { args; _ } -> args | _ -> []) in
+      List.map (fun name -> { sc_name = name; sc_type = None }) cols
   | Distinct ->
       input_schema
   | Count ->
       let named = extract_summarize_cols
           (match expr.node with Call { args; _ } -> args | _ -> []) in
-      if named <> [] then named else input_schema @ ["n"]
+      if named <> [] then
+        List.map (fun name -> { sc_name = name; sc_type = None }) named
+      else input_schema @ [{ sc_name = "n"; sc_type = Some "int" }]
   | Other _ ->
       (* Unknown function — schema is unknown *)
       []
@@ -202,7 +229,7 @@ let validate_col_refs ~node_name ~(file : string option) ~schema expr =
     if Hashtbl.mem seen col then None
     else begin
       Hashtbl.add seen col ();
-      if List.mem col schema then None
+      if schema_has_col col schema then None
       else Some (Diagnostics.{
         diag_id = Diagnostics.gen_id ();
         diag_error_class = "schema_mismatch";
@@ -214,7 +241,7 @@ let validate_col_refs ~node_name ~(file : string option) ~schema expr =
         diag_line = (match expr.loc with Some l -> Some l.line | None -> None);
         diag_column = (match expr.loc with Some l -> Some l.column | None -> None);
         diag_message = Printf.sprintf "Column '%s' referenced in node '%s' not found in input schema [%s]"
-          col node_name (String.concat ", " schema);
+          col node_name (String.concat ", " (schema_names schema));
         diag_caused_by = [];
         diag_suggested_fix = NoFix;
       })
@@ -224,36 +251,106 @@ let validate_col_refs ~node_name ~(file : string option) ~schema expr =
 (* ---------- Contract validation ---------- *)
 
 (* Validate contracts attached via expect() against inferred schemas.
-   Checks that all declared contract columns exist in the output schema. *)
+   Checks that all declared contract columns exist in the output schema,
+   and that type contracts match inferred column types. *)
 let validate_contracts ~file (p : pipeline_result) schemas =
-  List.filter_map (fun (node_name, contract) ->
+  List.concat_map (fun (node_name, contract) ->
     let output_schema =
       try Hashtbl.find schemas node_name with Not_found -> []
     in
-    match contract.contract_columns with
-    | None -> None
-    | Some required_cols ->
-        let missing = List.filter (fun col -> not (List.mem col output_schema)) required_cols in
-        if missing <> [] then
-          Some (Diagnostics.{
-            diag_id = Diagnostics.gen_id ();
-            diag_error_class = "contract_violation";
-            diag_severity = Error;
-            diag_phase = Schema;
-            diag_node_id = Some node_name;
-            diag_node_lang = None;
-            diag_file = Some file;
-            diag_line = None;
-            diag_column = None;
-            diag_message = Printf.sprintf "Node '%s' contract expects columns [%s] but output schema is [%s]. Missing: [%s]"
-              node_name
-              (String.concat ", " required_cols)
-              (String.concat ", " output_schema)
-              (String.concat ", " missing);
-            diag_caused_by = [];
-            diag_suggested_fix = NoFix;
-          })
-        else None
+    let col_names = schema_names output_schema in
+    (* Column presence check *)
+    let col_diag = match contract.contract_columns with
+      | None -> None
+      | Some required_cols ->
+          let missing = List.filter (fun col -> not (schema_has_col col output_schema)) required_cols in
+          if missing <> [] then
+            Some (Diagnostics.{
+              diag_id = Diagnostics.gen_id ();
+              diag_error_class = "contract_violation";
+              diag_severity = Error;
+              diag_phase = Schema;
+              diag_node_id = Some node_name;
+              diag_node_lang = None;
+              diag_file = Some file;
+              diag_line = None;
+              diag_column = None;
+              diag_message = Printf.sprintf "Node '%s' contract expects columns [%s] but output schema is [%s]. Missing: [%s]"
+                node_name
+                (String.concat ", " required_cols)
+                (String.concat ", " col_names)
+                (String.concat ", " missing);
+              diag_caused_by = [];
+              diag_suggested_fix = NoFix;
+            })
+          else None
+    in
+    (* Type contract check *)
+    let type_diags = match contract.contract_types with
+      | None -> []
+      | Some type_specs ->
+          List.filter_map (fun (col, expected_type) ->
+            match schema_find_type col output_schema with
+            | None ->
+                (* Type unknown — emit warning, not error *)
+                Some (Diagnostics.{
+                  diag_id = Diagnostics.gen_id ();
+                  diag_error_class = "contract_unverifiable";
+                  diag_severity = Warning;
+                  diag_phase = Schema;
+                  diag_node_id = Some node_name;
+                  diag_node_lang = None;
+                  diag_file = Some file;
+                  diag_line = None;
+                  diag_column = None;
+                  diag_message = Printf.sprintf "Node '%s' type contract for column '%s' (~ %s) cannot be verified statically: column type is unknown"
+                    node_name col expected_type;
+                  diag_caused_by = [];
+                  diag_suggested_fix = NoFix;
+                })
+            | Some actual_type ->
+                if actual_type <> expected_type then
+                  Some (Diagnostics.{
+                    diag_id = Diagnostics.gen_id ();
+                    diag_error_class = "contract_violation";
+                    diag_severity = Error;
+                    diag_phase = Schema;
+                    diag_node_id = Some node_name;
+                    diag_node_lang = None;
+                    diag_file = Some file;
+                    diag_line = None;
+                    diag_column = None;
+                    diag_message = Printf.sprintf "Node '%s' type contract for column '%s' expects ~ %s but output schema has type %s"
+                      node_name col expected_type actual_type;
+                    diag_caused_by = [];
+                    diag_suggested_fix = NoFix;
+                  })
+                else None
+          ) type_specs
+    in
+    (* Null-rate contract: emit unverifiable warning (needs runtime data) *)
+    let null_rate_diags = match contract.contract_null_rates with
+      | None -> []
+      | Some specs ->
+          List.map (fun (col, threshold) ->
+            Diagnostics.{
+              diag_id = Diagnostics.gen_id ();
+              diag_error_class = "contract_unverifiable";
+              diag_severity = Warning;
+              diag_phase = Schema;
+              diag_node_id = Some node_name;
+              diag_node_lang = None;
+              diag_file = Some file;
+              diag_line = None;
+              diag_column = None;
+              diag_message = Printf.sprintf "Node '%s' null-rate contract for column '%s' (< %.2f) cannot be verified statically: requires runtime data"
+                node_name col threshold;
+              diag_caused_by = [];
+              diag_suggested_fix = NoFix;
+            }
+          ) specs
+    in
+    Option.to_list col_diag @ type_diags @ null_rate_diags
   ) p.p_contracts
 
 (* ---------- Main entry point ---------- *)
@@ -303,11 +400,11 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
               let dir = Filename.dirname file in
               let full_path = Filename.concat dir path in
               (match read_csv_header full_path with
-               | Some cols -> Some cols
+               | Some cols -> Some (make_schema cols)
                | None ->
                    (* Try the path as-is *)
                    match read_csv_header path with
-                   | Some cols -> Some cols
+                   | Some cols -> Some (make_schema cols)
                    | None -> None)
           | None -> None
         else None
@@ -380,26 +477,26 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
                    | d :: _ -> (try Hashtbl.find schemas d with Not_found -> [])
                    | [] -> []
                in
-               if validation_schema <> [] then begin
-                 let errors = List.filter_map (fun var ->
-                   if not (List.mem var validation_schema) then
-                     Some (Diagnostics.{
-                       diag_id = Diagnostics.gen_id ();
-                       diag_error_class = "schema_mismatch";
-                       diag_severity = Error;
-                       diag_phase = Schema;
-                       diag_node_id = Some name;
-                       diag_node_lang = None;
-                       diag_file = Some file;
-                       diag_line = (match expr.loc with Some l -> Some l.line | None -> None);
-                       diag_column = (match expr.loc with Some l -> Some l.column | None -> None);
-                       diag_message = Printf.sprintf "Formula variable '%s' in %s() not found in input schema [%s]"
-                         var fn_name (String.concat ", " validation_schema);
-                       diag_caused_by = [];
-                       diag_suggested_fix = NoFix;
-                     })
-                   else None
-                 ) all_vars in
+                if validation_schema <> [] then begin
+                  let errors = List.filter_map (fun var ->
+                    if not (schema_has_col var validation_schema) then
+                      Some (Diagnostics.{
+                        diag_id = Diagnostics.gen_id ();
+                        diag_error_class = "schema_mismatch";
+                        diag_severity = Error;
+                        diag_phase = Schema;
+                        diag_node_id = Some name;
+                        diag_node_lang = None;
+                        diag_file = Some file;
+                        diag_line = (match expr.loc with Some l -> Some l.line | None -> None);
+                        diag_column = (match expr.loc with Some l -> Some l.column | None -> None);
+                        diag_message = Printf.sprintf "Formula variable '%s' in %s() not found in input schema [%s]"
+                          var fn_name (String.concat ", " (schema_names validation_schema));
+                        diag_caused_by = [];
+                        diag_suggested_fix = NoFix;
+                      })
+                    else None
+                  ) all_vars in
                  diagnostics := errors @ !diagnostics
                end
            | None -> ())

--- a/summary.md
+++ b/summary.md
@@ -83,6 +83,9 @@ t check --watch path/to/script.t           # run immediately, then re-run on fil
 t diff path/to/script.t                   # compare last two builds (per-node content hashes)
 t diff path/to/script.t --json            # structured JSON output
 
+t fix path/to/script.t                    # apply suggested fixes from t check diagnostics
+t fix --dry-run path/to/script.t          # preview fixes without applying
+
 t test
 
 t doc --parse --generate
@@ -460,6 +463,11 @@ Purpose: node construction, pipeline execution, graph inspection, graph rewritin
 - **CLI (`t diff <file.t>`)**: Compares the two most recent builds of a pipeline by reading per-node Nix content hashes from build logs. Reports unchanged, changed, added, and removed nodes. Supports `--json` for structured output and `--log-a`/`--log-b` flags to compare specific build ranks.
 - **T function (`diff_summary(p)`)**: Returns a DataFrame summarizing per-node differences between the two most recent builds, with columns `name`, `status`, `hash_a`, `hash_b`, `class_a`, `class_b`.
 - **Per-node hashes**: Extracted from `node_store_paths` after `nix-instantiate --eval` and stored in build log JSON alongside the top-level `pipeline_output` hash.
+
+### Mechanical Fix Application (`t fix`)
+
+- **CLI (`t fix <file.t>`)**: Runs `t check --json` internally, collects diagnostics with `suggested_fix` values, and applies them to the source file. Currently supports `cast` (inserts `mutate()` for type conversion) and `rename_column` (replaces column name). Use `--dry-run` to preview without modifying.
+- **Supported fix types**: `cast`, `rename_column`. `add_node_arg` and `pin_package_version` are planned.
 
 Important LLM rule: when the goal is reproducible execution, prefer generating or editing pipeline nodes rather than a monolithic script.
 

--- a/summary.md
+++ b/summary.md
@@ -80,6 +80,9 @@ t check --env path/to/script.t             # + environment/lockfile checks + Nix
 t check --json path/to/script.t            # machine-readable diagnostics
 t check --watch path/to/script.t           # run immediately, then re-run on file save
 
+t diff path/to/script.t                   # compare last two builds (per-node content hashes)
+t diff path/to/script.t --json            # structured JSON output
+
 t test
 
 t doc --parse --generate
@@ -426,7 +429,7 @@ Purpose: node construction, pipeline execution, graph inspection, graph rewritin
 - Node constructors: `node(command = ..., script = na(), runtime = T, serializer = default, deserializer = default, args = [:], functions = [], include = [], noop = false, flake = na())`, `rn(...)`, `pyn(...)`, `jln(command = ..., script = na(), serializer = ^csv, deserializer = ^csv, functions = [], include = [], noop = false, flake = na())`, `shn(command = ..., script = na(), serializer = text, deserializer = default, args = [], shell = "sh", shell_args = [], functions = [], include = [], noop = false, flake = na())`
 - Per-node flake environments: nodes accept an optional `flake` parameter (e.g. `flake = "github:jbedo/rshells"`) to override the project-level Nix environment. Each runtime component (T binary, R packages, Julia path, nixpkgs) is resolved independently from the custom flake when available, falling back to the project-level binding otherwise. Supports `github:`, `gitlab:`, `sourcehut:`, `path:` (absolute and relative) references.
 - Static conditionals: `node_when(condition, node_value)` excludes a node from the DAG if condition is falsy at pipeline construction time. `node_fork(cond1, val1, cond2, val2, ..., .default = ...)` selects the first matching branch.
-- Execution and artifacts: `populate_pipeline(p, build = false, dry_run = false)`, `build_pipeline(p, targets = na(), force = na(), dry_run = false, max_jobs = na(), cache = na(), builders = na(), keep_env = na(), sandbox = na())`, `pipeline_run(p)`, `read_pipeline(p)`, `read_node(p.name)`, `pipeline_copy(...)`, `inspect_pipeline(p)`, `list_logs()`, `trace_nodes(p)`, `inspect_node(name)`, `rebuild_node(name)`, `warning_msg(node)`, `suppress_warnings(node)`, `build_log_history(p, n = na())`, `node_diff(node_a, node_b, log_a = "latest", log_b = "latest")`, `debug_node(node)`, `build_log(p)`, `build_log_to_frame(log)`, `collect_errors(p)`, `error_summary(errors)`, `error_chain(err1, err2)`, `pipeline_to_drv(p)`, `pipeline_to_store(p)`, `set_nix_defaults(nix_options)`, `pipeline_cache_status(p)`, `pipeline_gc(p, dry_run = false)`, `t_gc()`, `export_artifacts(target, archive_path)`, `import_artifacts(target_or_archive, archive_path = na())`, `inspect_artifacts(archive_path)`
+- Execution and artifacts: `populate_pipeline(p, build = false, dry_run = false)`, `build_pipeline(p, targets = na(), force = na(), dry_run = false, max_jobs = na(), cache = na(), builders = na(), keep_env = na(), sandbox = na())`, `pipeline_run(p)`, `read_pipeline(p)`, `read_node(p.name)`, `pipeline_copy(...)`, `inspect_pipeline(p)`, `list_logs()`, `trace_nodes(p)`, `inspect_node(name)`, `rebuild_node(name)`, `warning_msg(node)`, `suppress_warnings(node)`, `build_log_history(p, n = na())`, `node_diff(node_a, node_b, log_a = "latest", log_b = "latest")`, `diff_summary(p)`, `debug_node(node)`, `build_log(p)`, `build_log_to_frame(log)`, `collect_errors(p)`, `error_summary(errors)`, `error_chain(err1, err2)`, `pipeline_to_drv(p)`, `pipeline_to_store(p)`, `set_nix_defaults(nix_options)`, `pipeline_cache_status(p)`, `pipeline_gc(p, dry_run = false)`, `t_gc()`, `export_artifacts(target, archive_path)`, `import_artifacts(target_or_archive, archive_path = na())`, `inspect_artifacts(archive_path)`
 - Auto-expansion of dynamic branching patterns: pipelines with `map_pattern(...)`, `cross_pattern(...)`, `slice_pattern(...)`, `head_pattern(...)`, `tail_pattern(...)`, or `sample_pattern(...)` are automatically expanded on `populate_pipeline`, `build_pipeline`, `chain`, `parallel`, `union`, `difference`, `intersect`, and `patch`. `expand_pipeline(p)` still available for explicit use. Supports List, Vector, and DataFrame dependencies; non-T runtime branching requires explicit serializer/deserializer configuration.
 - Pipeline structure: `pipeline_nodes(p)`, `pipeline_deps(p)`, `pipeline_node(p, name)`, `pipeline_to_frame(p)`, `pipeline_edges(p)`, `pipeline_roots(p)`, `pipeline_leaves(p)`, `pipeline_depth(p)`, `pipeline_cycles(p)`, `pipeline_validate(p)`, `pipeline_assert(p)`, `pipeline_print(p)`, `pipeline_to_dot(p, title = na())`, `pipeline_to_mermaid(p, title = na(), flatten = false)`
 - Node-level transforms: `filter_node(p, predicate)`, `which_nodes(p, predicate)`, `errored_nodes(p)`,
@@ -442,6 +445,12 @@ Purpose: node construction, pipeline execution, graph inspection, graph rewritin
   - *PMML Models*: Compares model regression coefficients and intercepts for linear models, falling back to structural tree comparisons for tree-based models.
   - *Text & Strings*: Computes a colorized, unified diff showing exact line additions and removals.
   - *Scalars/Generic*: Direct value structural equivalence and numeric difference calculations.
+
+### Content-Addressed Build Diffing (`t diff` / `diff_summary`)
+
+- **CLI (`t diff <file.t>`)**: Compares the two most recent builds of a pipeline by reading per-node Nix content hashes from build logs. Reports unchanged, changed, added, and removed nodes. Supports `--json` for structured output and `--log-a`/`--log-b` flags to compare specific build ranks.
+- **T function (`diff_summary(p)`)**: Returns a DataFrame summarizing per-node differences between the two most recent builds, with columns `name`, `status`, `hash_a`, `hash_b`, `class_a`, `class_b`.
+- **Per-node hashes**: Extracted from `node_store_paths` after `nix-instantiate --eval` and stored in build log JSON alongside the top-level `pipeline_output` hash.
 
 Important LLM rule: when the goal is reproducible execution, prefer generating or editing pipeline nodes rather than a monolithic script.
 

--- a/summary.md
+++ b/summary.md
@@ -80,11 +80,23 @@ t check --env path/to/script.t             # + environment/lockfile checks + Nix
 t check --json path/to/script.t            # machine-readable diagnostics
 t check --watch path/to/script.t           # run immediately, then re-run on file save
 
+# REPL-callable versions (same options, returns String):
+result = t_check("path/to/script.t")
+result = t_check("path/to/script.t", schema = true, json = true)
+
 t diff path/to/script.t                   # compare last two builds (per-node content hashes)
 t diff path/to/script.t --json            # structured JSON output
 
+# REPL-callable version (same options, returns String):
+result = t_diff("path/to/script.t")
+result = t_diff("path/to/script.t", json = true, log_a = 1, log_b = 2)
+
 t fix path/to/script.t                    # apply suggested fixes from t check diagnostics
 t fix --dry-run path/to/script.t          # preview fixes without applying
+
+# REPL-callable version (same options, returns String):
+result = t_fix("path/to/script.t")
+result = t_fix("path/to/script.t", dry_run = true)
 
 t test
 
@@ -461,12 +473,14 @@ Purpose: node construction, pipeline execution, graph inspection, graph rewritin
 ### Content-Addressed Build Diffing (`t diff` / `diff_summary`)
 
 - **CLI (`t diff <file.t>`)**: Compares the two most recent builds of a pipeline by reading per-node Nix content hashes from build logs. Reports unchanged, changed, added, and removed nodes. Supports `--json` for structured output and `--log-a`/`--log-b` flags to compare specific build ranks.
+- **T function (`t_diff(file, json = false, log_a = 2, log_b = 1)`)**: REPL-callable version of `t diff`. Returns the formatted diff as a string. Same options as CLI.
 - **T function (`diff_summary(p)`)**: Returns a DataFrame summarizing per-node differences between the two most recent builds, with columns `name`, `status`, `hash_a`, `hash_b`, `class_a`, `class_b`.
 - **Per-node hashes**: Extracted from `node_store_paths` after `nix-instantiate --eval` and stored in build log JSON alongside the top-level `pipeline_output` hash.
 
 ### Mechanical Fix Application (`t fix`)
 
 - **CLI (`t fix <file.t>`)**: Runs `t check --json` internally, collects diagnostics with `suggested_fix` values, and applies them to the source file. Currently supports `cast` (inserts `mutate()` for type conversion) and `rename_column` (replaces column name). Use `--dry-run` to preview without modifying.
+- **T function (`t_fix(file, dry_run = false)`)**: REPL-callable version of `t fix`. Returns the fix summary as a string. Same options as CLI.
 - **Supported fix types**: `cast`, `rename_column`. `add_node_arg` and `pin_package_version` are planned.
 
 Important LLM rule: when the goal is reproducible execution, prefer generating or editing pipeline nodes rather than a monolithic script.

--- a/summary.md
+++ b/summary.md
@@ -210,11 +210,20 @@ build_pipeline(p)
 
 Pipelines are DAGs. Nodes can be declared in any order; dependencies are resolved automatically.
 
-**Shape Contracts**: Use `expect(columns = [...])` at the end of a pipe chain to declare expected output columns. Contracts are checked statically via `t check --schema`.
+**Shape Contracts**: Use `expect(...)` at the end of a pipe chain to declare expected output properties. Contracts are checked statically via `t check --schema`.
 
 ```t
+-- Column presence contract
 clean = raw |> filter($age > 18) |> expect(columns = ["id", "name", "age"])
+
+-- Type contract + null-rate contract
+clean = raw |> expect(columns = ["id", "amount"], amount ~ double(), null_rate("amount") < 0.02)
 ```
+
+Three contract types:
+- **Column contracts** (`columns = [...]`): verified statically — missing columns produce `contract_violation` errors
+- **Type contracts** (`col ~ type()`): verified statically when column type is known — mismatches produce `contract_violation` errors, unknown types produce `contract_unverifiable` warnings
+- **Null-rate contracts** (`null_rate("col") < threshold`): produce `contract_unverifiable` warnings at check time; runtime enforcement planned
 
 **Block Evaluation**: Blocks (`{ ... }`) abort immediately on encountering a `VError`, returning the error rather than continuing evaluation of remaining statements. Nodes that soft-fail and return `VError` conditionally fall back to binary serialization rather than triggering custom serializers like Arrow, preventing crashes.
 

--- a/tests/diff/test_builder_diff.ml
+++ b/tests/diff/test_builder_diff.ml
@@ -233,4 +233,76 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
          (try let _ = Str.search_forward (Str.regexp_string "\"summary\"") json_str 0 in true with Not_found -> false));
   remove_path dir5;
 
+  (* Test 6: errored node in both builds -> Errored, not Unchanged *)
+  Printf.printf "\nBuilder_diff — errored node handling:\n";
+  let dir6 = make_temp_dir () in
+  let log_a6 = Filename.concat dir6 "build_log_20260101_120000_aaa.json" in
+  let log_b6 = Filename.concat dir6 "build_log_20260101_130000_kkk.json" in
+  let log_both_errored = {|{
+    "timestamp": "20260101_120000",
+    "hash": "aaa111",
+    "out_path": "/nix/store/aaa111-pipeline_output",
+    "duration": 1.0,
+    "pipeline": "test_pipeline",
+    "nodes": [
+      {"node": "good_node", "path": "/nix/store/aaa111-pipeline_output/good_node/artifact", "hash": "aaa111", "runtime": "T", "serializer": "default", "class": "VDataFrame", "dependencies": [], "status": "Completed", "success": true, "warnings": false, "duration": 0.3},
+      {"node": "bad_node", "path": "", "hash": "no_hash", "runtime": "T", "serializer": "default", "class": "Error", "dependencies": [], "status": "Errored", "success": false, "warnings": false, "duration": 0.1}
+    ]
+  }|} in
+  write_file log_a6 log_both_errored;
+  write_file log_b6 log_both_errored;
+  (match Builder_diff.compute_diff log_a6 log_b6 with
+   | Error msg ->
+       Printf.printf "  \xe2\x9c\x97 errored both builds: %s\n" msg;
+       incr fail_count
+   | Ok result ->
+       check_eq "errored both: total nodes" (string_of_int result.dr_total) "2";
+       check_eq "errored both: unchanged count" (string_of_int result.dr_unchanged) "1";
+       check_eq "errored both: errored count" (string_of_int result.dr_errored) "1";
+       check_eq "errored both: changed count" (string_of_int result.dr_changed) "0";
+       let errored_node = List.find (fun e -> e.Builder_diff.nde_name = "bad_node") result.dr_nodes in
+       (match errored_node.Builder_diff.nde_status with
+        | Builder_diff.Errored _ -> check "errored both: bad_node is Errored" true
+        | _ -> check "errored both: bad_node should be Errored, not changed/unchanged" false));
+  remove_path dir6;
+
+  (* Test 7: errored in one build, succeeded in other -> Errored *)
+  let dir7 = make_temp_dir () in
+  let log_a7 = Filename.concat dir7 "build_log_20260101_120000_aaa.json" in
+  let log_b7 = Filename.concat dir7 "build_log_20260101_130000_lll.json" in
+  let log_errored_a = {|{
+    "timestamp": "20260101_120000",
+    "hash": "aaa111",
+    "out_path": "/nix/store/aaa111-pipeline_output",
+    "duration": 1.0,
+    "pipeline": "test_pipeline",
+    "nodes": [
+      {"node": "flaky_node", "path": "", "hash": "no_hash", "runtime": "T", "serializer": "default", "class": "Error", "dependencies": [], "status": "Errored", "success": false, "warnings": false, "duration": 0.1}
+    ]
+  }|} in
+  let log_succeeded_b = {|{
+    "timestamp": "20260101_130000",
+    "hash": "mmm999",
+    "out_path": "/nix/store/mmm999-pipeline_output",
+    "duration": 1.0,
+    "pipeline": "test_pipeline",
+    "nodes": [
+      {"node": "flaky_node", "path": "/nix/store/mmm999-pipeline_output/flaky_node/artifact", "hash": "mmm999", "runtime": "T", "serializer": "default", "class": "VDataFrame", "dependencies": [], "status": "Completed", "success": true, "warnings": false, "duration": 0.3}
+    ]
+  }|} in
+  write_file log_a7 log_errored_a;
+  write_file log_b7 log_succeeded_b;
+  (match Builder_diff.compute_diff log_a7 log_b7 with
+   | Error msg ->
+       Printf.printf "  \xe2\x9c\x97 errored then succeeded: %s\n" msg;
+       incr fail_count
+   | Ok result ->
+       check_eq "errored then succeeded: total nodes" (string_of_int result.dr_total) "1";
+       check_eq "errored then succeeded: errored count" (string_of_int result.dr_errored) "1";
+       let node = List.find (fun e -> e.Builder_diff.nde_name = "flaky_node") result.dr_nodes in
+       (match node.Builder_diff.nde_status with
+        | Builder_diff.Errored _ -> check "errored then succeeded: flaky_node is Errored" true
+        | _ -> check "errored then succeeded: flaky_node should be Errored" false));
+  remove_path dir7;
+
   Printf.printf "\n"

--- a/tests/diff/test_builder_diff.ml
+++ b/tests/diff/test_builder_diff.ml
@@ -1,0 +1,236 @@
+(* tests/diff/test_builder_diff.ml *)
+(* Tests for builder_diff: per-node hash comparison between builds *)
+
+let run_tests pass_count fail_count failures _eval_string _eval_string_env _test =
+  Printf.printf "=== Builder_diff tests ===\n\n";
+  let check name condition =
+    if condition then begin
+      incr pass_count;
+      Printf.printf "  \xe2\x9c\x93 %s\n" name
+    end else begin
+      incr fail_count;
+      let msg = Printf.sprintf "  \xe2\x9c\x97 %s\n" name in
+      failures := msg :: !failures;
+      Printf.printf "%s" msg
+    end
+  in
+  let check_eq name got expected =
+    if got = expected then begin
+      incr pass_count;
+      Printf.printf "  \xe2\x9c\x93 %s\n" name
+    end else begin
+      incr fail_count;
+      let msg = Printf.sprintf "  \xe2\x9c\x97 %s\n    Expected: %s\n    Got: %s\n" name expected got in
+      failures := msg :: !failures;
+      Printf.printf "%s" msg
+    end
+  in
+
+  Printf.printf "Builder_diff — compute_diff:\n";
+
+  let rec remove_path path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path
+        |> Array.iter (fun name -> remove_path (Filename.concat path name));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  let make_temp_dir () =
+    let candidate =
+      Filename.concat
+        (Filename.get_temp_dir_name ())
+        (Printf.sprintf "tlang-bdiff-test-%d-%06d" (Unix.getpid ()) (Random.int 1_000_000))
+    in
+    Unix.mkdir candidate 0o755;
+    candidate
+  in
+
+  let write_file path content =
+    let oc = open_out path in
+    output_string oc content;
+    close_out oc
+  in
+
+  (* Test 1: identical builds -> all unchanged *)
+  let dir1 = make_temp_dir () in
+  let log_a1 = Filename.concat dir1 "build_log_20260101_120000_aaa.json" in
+  let log_b1 = Filename.concat dir1 "build_log_20260101_130000_bbb.json" in
+  let same_log = {|{
+    "timestamp": "20260101_120000",
+    "hash": "aaa111",
+    "out_path": "/nix/store/aaa111-pipeline_output",
+    "duration": 1.5,
+    "pipeline": "test_pipeline",
+    "nodes": [
+      {"node": "read_data", "path": "/nix/store/aaa111-pipeline_output/read_data/artifact", "hash": "aaa111", "runtime": "T", "serializer": "default", "class": "VDataFrame", "dependencies": [], "status": "Completed", "success": true, "warnings": false, "duration": 0.5},
+      {"node": "clean", "path": "/nix/store/bbb222-pipeline_output/clean/artifact", "hash": "bbb222", "runtime": "T", "serializer": "default", "class": "VDataFrame", "dependencies": ["read_data"], "status": "Completed", "success": true, "warnings": false, "duration": 0.3}
+    ]
+  }|} in
+  write_file log_a1 same_log;
+  write_file log_b1 same_log;
+  (match Builder_diff.compute_diff log_a1 log_b1 with
+   | Error msg ->
+       Printf.printf "  \xe2\x9c\x97 identical builds: %s\n" msg;
+       incr fail_count
+   | Ok result ->
+       check_eq "identical builds: total nodes" (string_of_int result.dr_total) "2";
+       check_eq "identical builds: unchanged count" (string_of_int result.dr_unchanged) "2";
+       check_eq "identical builds: changed count" (string_of_int result.dr_changed) "0";
+       check_eq "identical builds: added count" (string_of_int result.dr_added) "0";
+       check_eq "identical builds: removed count" (string_of_int result.dr_removed) "0";
+       check "identical builds: all nodes are Unchanged"
+         (List.for_all (fun e -> match e.Builder_diff.nde_status with Builder_diff.Unchanged _ -> true | _ -> false) result.dr_nodes));
+  remove_path dir1;
+
+  (* Test 2: one node changed -> detects change *)
+  let dir2 = make_temp_dir () in
+  let log_a2 = Filename.concat dir2 "build_log_20260101_120000_aaa.json" in
+  let log_b2 = Filename.concat dir2 "build_log_20260101_130000_ccc.json" in
+  let log_build_a = {|{
+    "timestamp": "20260101_120000",
+    "hash": "aaa111",
+    "out_path": "/nix/store/aaa111-pipeline_output",
+    "duration": 1.0,
+    "pipeline": "test_pipeline",
+    "nodes": [
+      {"node": "read_data", "path": "/nix/store/aaa111-pipeline_output/read_data/artifact", "hash": "aaa111", "runtime": "T", "serializer": "default", "class": "VDataFrame", "dependencies": [], "status": "Completed", "success": true, "warnings": false, "duration": 0.3},
+      {"node": "clean", "path": "/nix/store/bbb222-pipeline_output/clean/artifact", "hash": "bbb222", "runtime": "T", "serializer": "default", "class": "VDataFrame", "dependencies": ["read_data"], "status": "Completed", "success": true, "warnings": false, "duration": 0.2}
+    ]
+  }|} in
+  let log_build_b = {|{
+    "timestamp": "20260101_130000",
+    "hash": "ccc333",
+    "out_path": "/nix/store/ccc333-pipeline_output",
+    "duration": 1.0,
+    "pipeline": "test_pipeline",
+    "nodes": [
+      {"node": "read_data", "path": "/nix/store/aaa111-pipeline_output/read_data/artifact", "hash": "aaa111", "runtime": "T", "serializer": "default", "class": "VDataFrame", "dependencies": [], "status": "Completed", "success": true, "warnings": false, "duration": 0.3},
+      {"node": "clean", "path": "/nix/store/ddd444-pipeline_output/clean/artifact", "hash": "ddd444", "runtime": "T", "serializer": "default", "class": "VDataFrame", "dependencies": ["read_data"], "status": "Completed", "success": true, "warnings": false, "duration": 0.2}
+    ]
+  }|} in
+  write_file log_a2 log_build_a;
+  write_file log_b2 log_build_b;
+  (match Builder_diff.compute_diff log_a2 log_b2 with
+   | Error msg ->
+       Printf.printf "  \xe2\x9c\x97 changed node: %s\n" msg;
+       incr fail_count
+   | Ok result ->
+       check_eq "changed node: total nodes" (string_of_int result.dr_total) "2";
+       check_eq "changed node: unchanged count" (string_of_int result.dr_unchanged) "1";
+       check_eq "changed node: changed count" (string_of_int result.dr_changed) "1";
+       let changed_node = List.find (fun e -> e.Builder_diff.nde_name = "clean") result.dr_nodes in
+       (match changed_node.Builder_diff.nde_status with
+        | Builder_diff.Changed { hash_a; hash_b } ->
+            check_eq "changed node: hash_a" hash_a "bbb222";
+            check_eq "changed node: hash_b" hash_b "ddd444"
+        | _ -> check "changed node: clean is Changed" false));
+  remove_path dir2;
+
+  (* Test 3: node added *)
+  let dir3 = make_temp_dir () in
+  let log_a3 = Filename.concat dir3 "build_log_20260101_120000_aaa.json" in
+  let log_b3 = Filename.concat dir3 "build_log_20260101_130000_eee.json" in
+  let log_a_only = {|{
+    "timestamp": "20260101_120000",
+    "hash": "aaa111",
+    "out_path": "/nix/store/aaa111-pipeline_output",
+    "duration": 1.0,
+    "pipeline": "test_pipeline",
+    "nodes": [
+      {"node": "read_data", "path": "/nix/store/aaa111-pipeline_output/read_data/artifact", "hash": "aaa111", "runtime": "T", "serializer": "default", "class": "VDataFrame", "dependencies": [], "status": "Completed", "success": true, "warnings": false, "duration": 0.3}
+    ]
+  }|} in
+  let log_b_with_new = {|{
+    "timestamp": "20260101_130000",
+    "hash": "eee555",
+    "out_path": "/nix/store/eee555-pipeline_output",
+    "duration": 1.0,
+    "pipeline": "test_pipeline",
+    "nodes": [
+      {"node": "read_data", "path": "/nix/store/aaa111-pipeline_output/read_data/artifact", "hash": "aaa111", "runtime": "T", "serializer": "default", "class": "VDataFrame", "dependencies": [], "status": "Completed", "success": true, "warnings": false, "duration": 0.3},
+      {"node": "new_node", "path": "/nix/store/fff666-pipeline_output/new_node/artifact", "hash": "fff666", "runtime": "T", "serializer": "default", "class": "VDataFrame", "dependencies": [], "status": "Completed", "success": true, "warnings": false, "duration": 0.1}
+    ]
+  }|} in
+  write_file log_a3 log_a_only;
+  write_file log_b3 log_b_with_new;
+  (match Builder_diff.compute_diff log_a3 log_b3 with
+   | Error msg ->
+       Printf.printf "  \xe2\x9c\x97 added node: %s\n" msg;
+       incr fail_count
+   | Ok result ->
+       check_eq "added node: total nodes" (string_of_int result.dr_total) "2";
+       check_eq "added node: added count" (string_of_int result.dr_added) "1";
+       let added_node = List.find (fun e -> e.Builder_diff.nde_name = "new_node") result.dr_nodes in
+       (match added_node.Builder_diff.nde_status with
+        | Builder_diff.Added { hash } -> check_eq "added node: hash" hash "fff666"
+        | _ -> check "added node: new_node is Added" false));
+  remove_path dir3;
+
+  (* Test 4: node removed *)
+  let dir4 = make_temp_dir () in
+  let log_a4 = Filename.concat dir4 "build_log_20260101_120000_aaa.json" in
+  let log_b4 = Filename.concat dir4 "build_log_20260101_130000_ggg.json" in
+  let log_a_full = {|{
+    "timestamp": "20260101_120000",
+    "hash": "aaa111",
+    "out_path": "/nix/store/aaa111-pipeline_output",
+    "duration": 1.0,
+    "pipeline": "test_pipeline",
+    "nodes": [
+      {"node": "read_data", "path": "/nix/store/aaa111-pipeline_output/read_data/artifact", "hash": "aaa111", "runtime": "T", "serializer": "default", "class": "VDataFrame", "dependencies": [], "status": "Completed", "success": true, "warnings": false, "duration": 0.3},
+      {"node": "removed_node", "path": "/nix/store/hhh777-pipeline_output/removed_node/artifact", "hash": "hhh777", "runtime": "T", "serializer": "default", "class": "VDataFrame", "dependencies": [], "status": "Completed", "success": true, "warnings": false, "duration": 0.1}
+    ]
+  }|} in
+  let log_b_smaller = {|{
+    "timestamp": "20260101_130000",
+    "hash": "ggg888",
+    "out_path": "/nix/store/ggg888-pipeline_output",
+    "duration": 1.0,
+    "pipeline": "test_pipeline",
+    "nodes": [
+      {"node": "read_data", "path": "/nix/store/aaa111-pipeline_output/read_data/artifact", "hash": "aaa111", "runtime": "T", "serializer": "default", "class": "VDataFrame", "dependencies": [], "status": "Completed", "success": true, "warnings": false, "duration": 0.3}
+    ]
+  }|} in
+  write_file log_a4 log_a_full;
+  write_file log_b4 log_b_smaller;
+  (match Builder_diff.compute_diff log_a4 log_b4 with
+   | Error msg ->
+       Printf.printf "  \xe2\x9c\x97 removed node: %s\n" msg;
+       incr fail_count
+   | Ok result ->
+       check_eq "removed node: total nodes" (string_of_int result.dr_total) "2";
+       check_eq "removed node: removed count" (string_of_int result.dr_removed) "1";
+       let removed_node = List.find (fun e -> e.Builder_diff.nde_name = "removed_node") result.dr_nodes in
+       (match removed_node.Builder_diff.nde_status with
+        | Builder_diff.Removed { hash } -> check_eq "removed node: hash" hash "hhh777"
+        | _ -> check "removed node: removed_node is Removed" false));
+  remove_path dir4;
+
+  (* Test 5: JSON output *)
+  Printf.printf "\nBuilder_diff — JSON output:\n";
+  let dir5 = make_temp_dir () in
+  let log_a5 = Filename.concat dir5 "build_log_20260101_120000_aaa.json" in
+  let log_b5 = Filename.concat dir5 "build_log_20260101_130000_jjj.json" in
+  write_file log_a5 log_build_a;
+  write_file log_b5 log_build_b;
+  (match Builder_diff.compute_diff log_a5 log_b5 with
+   | Error msg ->
+       Printf.printf "  \xe2\x9c\x97 JSON output: %s\n" msg;
+       incr fail_count
+   | Ok result ->
+       let json_str = Yojson.Safe.pretty_to_string (Builder.diff_result_to_yojson result) in
+       check "JSON output: contains schema_version"
+         (try let _ = Str.search_forward (Str.regexp_string "\"schema_version\"") json_str 0 in true with Not_found -> false);
+       check "JSON output: contains phase diff"
+         (try let _ = Str.search_forward (Str.regexp_string "\"phase\"") json_str 0 in true with Not_found -> false);
+       check "JSON output: contains build_a"
+         (try let _ = Str.search_forward (Str.regexp_string "\"build_a\"") json_str 0 in true with Not_found -> false);
+       check "JSON output: contains build_b"
+         (try let _ = Str.search_forward (Str.regexp_string "\"build_b\"") json_str 0 in true with Not_found -> false);
+       check "JSON output: contains summary"
+         (try let _ = Str.search_forward (Str.regexp_string "\"summary\"") json_str 0 in true with Not_found -> false));
+  remove_path dir5;
+
+  Printf.printf "\n"

--- a/tests/dune
+++ b/tests/dune
@@ -47,7 +47,7 @@
     test_agent_scaffold
     test_coverage_boost
     test_misc_coverage
-    test_dataframe_diff test_model_diff test_scalar_diff test_generic_diff test_pipeline_diff
+    test_dataframe_diff test_model_diff test_scalar_diff test_generic_diff test_pipeline_diff test_builder_diff
     test_check
   )
   (libraries t_lang menhirLib otoml unix str)

--- a/tests/dune
+++ b/tests/dune
@@ -48,7 +48,7 @@
     test_coverage_boost
     test_misc_coverage
     test_dataframe_diff test_model_diff test_scalar_diff test_generic_diff test_pipeline_diff test_builder_diff
-    test_check
+    test_check test_fix
   )
   (libraries t_lang menhirLib otoml unix str)
 )

--- a/tests/test_check.ml
+++ b/tests/test_check.ml
@@ -158,23 +158,23 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
 
   (* Test infer_output_schema for select *)
   let select_expr = { node = Call { fn = { node = Var "select"; loc = None }; args = [(None, { node = ColumnRef "a"; loc = None }); (None, { node = ColumnRef "b"; loc = None })] }; loc = None } in
-  let out = Schema_check.infer_output_schema ["a"; "b"; "c"] select_expr in
-  check_eq "infer_output_schema: select" (String.concat "," out) "a,b";
+  let out = Schema_check.infer_output_schema (Schema_check.make_schema ["a"; "b"; "c"]) select_expr in
+  check_eq "infer_output_schema: select" (String.concat "," (Schema_check.schema_names out)) "a,b";
 
   (* Test infer_output_schema for filter *)
   let filter_expr = { node = Call { fn = { node = Var "filter"; loc = None }; args = [(None, { node = ColumnRef "x"; loc = None })] }; loc = None } in
-  let out = Schema_check.infer_output_schema ["a"; "b"] filter_expr in
-  check_eq "infer_output_schema: filter passes through" (String.concat "," out) "a,b";
+  let out = Schema_check.infer_output_schema (Schema_check.make_schema ["a"; "b"]) filter_expr in
+  check_eq "infer_output_schema: filter passes through" (String.concat "," (Schema_check.schema_names out)) "a,b";
 
   (* Test infer_output_schema for mutate adds columns *)
   let mutate_expr = { node = Call { fn = { node = Var "mutate"; loc = None }; args = [(Some "new_col", { node = Value (VInt 1); loc = None })] }; loc = None } in
-  let out = Schema_check.infer_output_schema ["a"; "b"] mutate_expr in
-  check_eq "infer_output_schema: mutate adds new col" (String.concat "," out) "a,b,new_col";
+  let out = Schema_check.infer_output_schema (Schema_check.make_schema ["a"; "b"]) mutate_expr in
+  check_eq "infer_output_schema: mutate adds new col" (String.concat "," (Schema_check.schema_names out)) "a,b,new_col";
 
   (* Test infer_output_schema for summarize *)
   let sum_expr = { node = Call { fn = { node = Var "summarize"; loc = None }; args = [(Some "avg", { node = Value (VInt 1); loc = None })] }; loc = None } in
-  let out = Schema_check.infer_output_schema ["a"; "b"] sum_expr in
-  check_eq "infer_output_schema: summarize" (String.concat "," out) "avg";
+  let out = Schema_check.infer_output_schema (Schema_check.make_schema ["a"; "b"]) sum_expr in
+  check_eq "infer_output_schema: summarize" (String.concat "," (Schema_check.schema_names out)) "avg";
 
   (* Test read_csv_header *)
   let header = Schema_check.read_csv_header "/tmp/schema_test/data.csv" in
@@ -189,7 +189,7 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
 
   (* Test validate_contracts detects missing columns *)
   let schemas_tbl = Hashtbl.create 4 in
-  Hashtbl.add schemas_tbl "clean" ["mpg"; "cyl"];
+  Hashtbl.add schemas_tbl "clean" (Schema_check.make_schema ["mpg"; "cyl"]);
   let p_with_contract = {
     p_nodes = []; p_exprs = []; p_deps = []; p_imports = [];
     p_runtimes = []; p_serializers = []; p_deserializers = [];
@@ -200,6 +200,8 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
     p_flakes = [];
     p_contracts = ["clean", {
       contract_columns = Some ["mpg"; "cyl"; "hp"];
+      contract_types = None;
+      contract_null_rates = None;
     }];
   } in
   let contract_diags = Schema_check.validate_contracts
@@ -212,7 +214,7 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
 
   (* Test validate_contracts passes when all columns present *)
   let schemas_tbl2 = Hashtbl.create 4 in
-  Hashtbl.add schemas_tbl2 "clean" ["mpg"; "cyl"; "hp"];
+  Hashtbl.add schemas_tbl2 "clean" (Schema_check.make_schema ["mpg"; "cyl"; "hp"]);
   let p_pass = {
     p_nodes = []; p_exprs = []; p_deps = []; p_imports = [];
     p_runtimes = []; p_serializers = []; p_deserializers = [];
@@ -223,6 +225,8 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
     p_flakes = [];
     p_contracts = ["clean", {
       contract_columns = Some ["mpg"; "cyl"];
+      contract_types = None;
+      contract_null_rates = None;
     }];
   } in
   let pass_diags = Schema_check.validate_contracts
@@ -291,5 +295,148 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
   ) e2e_terminal_diags) in
   check "of_pipeline_result: no spurious diagnostic for terminal expect" e2e_no_spurious;
   Ast.check_mode := false;
+
+  (* ---- Expanded contract tests ---- *)
+  Printf.printf "\nExpanded contracts (type + null-rate):\n";
+
+  (* Test that type contract is extracted from expect() *)
+  Ast.check_mode := true;
+  let type_result = eval_string "pipeline { a = 1 |> expect(mpg ~ double()) }" in
+  let has_type_contract = match type_result with
+    | VPipeline p ->
+        List.exists (fun (_, c) ->
+          c.Ast.contract_types = Some [("mpg", "double")]
+        ) p.p_contracts
+    | _ -> false
+  in
+  check "expect: type contract extracted (mpg ~ double())" has_type_contract;
+  Ast.check_mode := false;
+
+  (* Test that null-rate contract is extracted from expect() *)
+  Ast.check_mode := true;
+  let nr_result = eval_string "pipeline { a = 1 |> expect(null_rate(\"mpg\") < 0.05) }" in
+  let has_nr_contract = match nr_result with
+    | VPipeline p ->
+        List.exists (fun (_, c) ->
+          match c.Ast.contract_null_rates with
+          | Some [("mpg", t)] -> t < 0.06 && t > 0.04
+          | _ -> false
+        ) p.p_contracts
+    | _ -> false
+  in
+  check "expect: null-rate contract extracted (null_rate(\"mpg\") < 0.05)" has_nr_contract;
+  Ast.check_mode := false;
+
+  (* Test mixed contracts: columns + type + null-rate *)
+  Ast.check_mode := true;
+  let mixed_result = eval_string "pipeline { a = 1 |> expect(columns = [\"mpg\"], cyl ~ int(), null_rate(\"hp\") < 0.1) }" in
+  let has_mixed = match mixed_result with
+    | VPipeline p ->
+        List.exists (fun (_, c) ->
+          c.Ast.contract_columns = Some ["mpg"]
+          && c.Ast.contract_types = Some [("cyl", "int")]
+          && (match c.Ast.contract_null_rates with Some [("hp", t)] -> t < 0.11 | _ -> false)
+        ) p.p_contracts
+    | _ -> false
+  in
+  check "expect: mixed contracts (columns + type + null-rate)" has_mixed;
+  Ast.check_mode := false;
+
+  (* Test type contract validation: matching type *)
+  Printf.printf "\nType contract validation:\n";
+  let type_match_tbl = Hashtbl.create 4 in
+  Hashtbl.add type_match_tbl "clean" (Schema_check.make_schema ~typed:[("mpg", "float")] ["mpg"; "cyl"]);
+  let p_type_match = {
+    p_nodes = []; p_exprs = []; p_deps = []; p_imports = [];
+    p_runtimes = []; p_serializers = []; p_deserializers = [];
+    p_env_vars = []; p_args = []; p_shells = []; p_shell_args = [];
+    p_functions = []; p_includes = []; p_noops = []; p_scripts = [];
+    p_explicit_deps = []; p_node_diagnostics = [];
+    p_has_patterns = false; p_patterns = []; p_iterations = [];
+    p_flakes = [];
+    p_contracts = ["clean", {
+      contract_columns = None;
+      contract_types = Some [("mpg", "float")];
+      contract_null_rates = None;
+    }];
+  } in
+  let type_match_diags = Schema_check.validate_contracts
+    ~file:"test.t" p_type_match type_match_tbl in
+  check_eq "type contract: matching type produces no error"
+    (string_of_int (List.length type_match_diags)) "0";
+
+  (* Test type contract validation: mismatching type *)
+  let p_type_mismatch = {
+    p_nodes = []; p_exprs = []; p_deps = []; p_imports = [];
+    p_runtimes = []; p_serializers = []; p_deserializers = [];
+    p_env_vars = []; p_args = []; p_shells = []; p_shell_args = [];
+    p_functions = []; p_includes = []; p_noops = []; p_scripts = [];
+    p_explicit_deps = []; p_node_diagnostics = [];
+    p_has_patterns = false; p_patterns = []; p_iterations = [];
+    p_flakes = [];
+    p_contracts = ["clean", {
+      contract_columns = None;
+      contract_types = Some [("mpg", "string")];
+      contract_null_rates = None;
+    }];
+  } in
+  let type_mismatch_diags = Schema_check.validate_contracts
+    ~file:"test.t" p_type_mismatch type_match_tbl in
+  check_eq "type contract: mismatching type produces 1 error"
+    (string_of_int (List.length type_mismatch_diags)) "1";
+
+  (* Test type contract validation: unknown type produces warning *)
+  let type_unknown_tbl = Hashtbl.create 4 in
+  Hashtbl.add type_unknown_tbl "clean" (Schema_check.make_schema ["mpg"]);
+  let p_type_unknown = {
+    p_nodes = []; p_exprs = []; p_deps = []; p_imports = [];
+    p_runtimes = []; p_serializers = []; p_deserializers = [];
+    p_env_vars = []; p_args = []; p_shells = []; p_shell_args = [];
+    p_functions = []; p_includes = []; p_noops = []; p_scripts = [];
+    p_explicit_deps = []; p_node_diagnostics = [];
+    p_has_patterns = false; p_patterns = []; p_iterations = [];
+    p_flakes = [];
+    p_contracts = ["clean", {
+      contract_columns = None;
+      contract_types = Some [("mpg", "double")];
+      contract_null_rates = None;
+    }];
+  } in
+  let type_unknown_diags = Schema_check.validate_contracts
+    ~file:"test.t" p_type_unknown type_unknown_tbl in
+  check_eq "type contract: unknown type produces 1 warning"
+    (string_of_int (List.length type_unknown_diags)) "1";
+  let is_warning = match type_unknown_diags with
+    | d :: _ -> d.Diagnostics.diag_severity = Diagnostics.Warning
+    | [] -> false
+  in
+  check "type contract: unknown type is Warning not Error" is_warning;
+
+  (* Test null-rate contract produces unverifiable warning *)
+  let p_null_rate = {
+    p_nodes = []; p_exprs = []; p_deps = []; p_imports = [];
+    p_runtimes = []; p_serializers = []; p_deserializers = [];
+    p_env_vars = []; p_args = []; p_shells = []; p_shell_args = [];
+    p_functions = []; p_includes = []; p_noops = []; p_scripts = [];
+    p_explicit_deps = []; p_node_diagnostics = [];
+    p_has_patterns = false; p_patterns = []; p_iterations = [];
+    p_flakes = [];
+    p_contracts = ["clean", {
+      contract_columns = None;
+      contract_types = None;
+      contract_null_rates = Some [("mpg", 0.05)];
+    }];
+  } in
+  let nr_diags = Schema_check.validate_contracts
+    ~file:"test.t" p_null_rate type_unknown_tbl in
+  check_eq "null-rate contract: produces 1 unverifiable warning"
+    (string_of_int (List.length nr_diags)) "1";
+  let nr_is_warning = match nr_diags with
+    | d :: _ ->
+        d.Diagnostics.diag_severity = Diagnostics.Warning
+        && d.Diagnostics.diag_error_class = "contract_unverifiable"
+    | [] -> false
+  in
+  check "null-rate contract: warning has contract_unverifiable class" nr_is_warning;
 
   Printf.printf "\n";

--- a/tests/test_check.ml
+++ b/tests/test_check.ml
@@ -202,6 +202,7 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
       contract_columns = Some ["mpg"; "cyl"; "hp"];
       contract_types = None;
       contract_null_rates = None;
+      contract_loc = None;
     }];
   } in
   let contract_diags = Schema_check.validate_contracts
@@ -227,6 +228,7 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
       contract_columns = Some ["mpg"; "cyl"];
       contract_types = None;
       contract_null_rates = None;
+      contract_loc = None;
     }];
   } in
   let pass_diags = Schema_check.validate_contracts
@@ -358,6 +360,7 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
       contract_columns = None;
       contract_types = Some [("mpg", "float")];
       contract_null_rates = None;
+      contract_loc = None;
     }];
   } in
   let type_match_diags = Schema_check.validate_contracts
@@ -378,6 +381,7 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
       contract_columns = None;
       contract_types = Some [("mpg", "string")];
       contract_null_rates = None;
+      contract_loc = None;
     }];
   } in
   let type_mismatch_diags = Schema_check.validate_contracts
@@ -400,6 +404,7 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
       contract_columns = None;
       contract_types = Some [("mpg", "double")];
       contract_null_rates = None;
+      contract_loc = None;
     }];
   } in
   let type_unknown_diags = Schema_check.validate_contracts
@@ -425,6 +430,7 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
       contract_columns = None;
       contract_types = None;
       contract_null_rates = Some [("mpg", 0.05)];
+      contract_loc = None;
     }];
   } in
   let nr_diags = Schema_check.validate_contracts

--- a/tests/test_check.ml
+++ b/tests/test_check.ml
@@ -445,4 +445,49 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
   in
   check "null-rate contract: warning has contract_unverifiable class" nr_is_warning;
 
+  (* === t_check / t_diff / t_fix REPL function tests === *)
+
+  Printf.printf "\nt_check (REPL function):\n";
+
+  (* t_check with nonexistent file returns error *)
+  let result = eval_string "t_check(\"nonexistent_file_xyz.t\")" in
+  let _result_str = Ast.Utils.value_to_string result in
+  check "t_check nonexistent file returns non-empty String"
+    (match result with Ast.VString s -> String.length s > 0 | _ -> false);
+
+  (* t_check with valid T file returns string *)
+  let result = eval_string "t_check(\"tests/golden/t_scripts/mtcars_select_mpg.t\")" in
+  check "t_check valid file returns String"
+    (match result with Ast.VString _ -> true | _ -> false);
+
+  (* t_check with schema flag *)
+  let result = eval_string "t_check(\"tests/golden/t_scripts/mtcars_select_mpg.t\", schema=true)" in
+  check "t_check with schema=true returns String"
+    (match result with Ast.VString _ -> true | _ -> false);
+
+  (* t_check with json flag returns JSON string *)
+  let result = eval_string "t_check(\"tests/golden/t_scripts/mtcars_select_mpg.t\", json=true)" in
+  let result_str = match result with Ast.VString s -> s | _ -> "" in
+  check_eq "t_check with json=true contains schema_version"
+    (if String.length result_str > 0 then "has_content" else "empty") "has_content";
+
+  Printf.printf "\nt_diff (REPL function):\n";
+
+  (* t_diff with nonexistent file returns VError *)
+  let result = eval_string "t_diff(\"nonexistent_file_xyz.t\")" in
+  check "t_diff nonexistent file returns VError"
+    (match result with Ast.VError _ -> true | _ -> false);
+
+  Printf.printf "\nt_fix (REPL function):\n";
+
+  (* t_fix with nonexistent file returns error *)
+  let result = eval_string "t_fix(\"nonexistent_file_xyz.t\")" in
+  check "t_fix nonexistent file returns non-empty String"
+    (match result with Ast.VString s -> String.length s > 0 | _ -> false);
+
+  (* t_fix with valid file and dry_run *)
+  let result = eval_string "t_fix(\"tests/golden/t_scripts/mtcars_select_mpg.t\", dry_run=true)" in
+  check "t_fix dry_run returns String"
+    (match result with Ast.VString _ -> true | _ -> false);
+
   Printf.printf "\n";

--- a/tests/test_fix.ml
+++ b/tests/test_fix.ml
@@ -1,0 +1,91 @@
+(* tests/test_fix.ml *)
+(* Tests for src/fix.ml — mechanical application of suggested_fix *)
+
+let run_tests pass_count fail_count failures _eval_string _eval_string_env _test =
+  Printf.printf "\n=== t fix tests ===\n\n";
+
+  let check name condition =
+    if condition then begin
+      incr pass_count;
+      Printf.printf "  ✓ %s\n" name
+    end else begin
+      incr fail_count;
+      let msg = Printf.sprintf "  ✗ %s\n" name in
+      failures := msg :: !failures;
+      Printf.printf "%s" msg
+    end
+  in
+
+  Printf.printf "apply_cast:\n";
+  let test_apply_cast () =
+    let tmp = Filename.temp_file "test_fix" ".t" in
+    let oc = open_out tmp in
+    output_string oc "clean = raw\n  |> read_csv(\"data.csv\")\n  |> expect(columns = [\"id\"])\n";
+    close_out oc;
+    Fix.apply_cast ~file:tmp ~line:3 ~column:"amount" ~cast_to:"double";
+    let ch = open_in tmp in
+    let content = really_input_string ch (in_channel_length ch) in
+    close_in ch;
+    Sys.remove tmp;
+    let lines = String.split_on_char '\n' content in
+    let line3 = List.nth lines 2 in
+    check "cast inserts mutate() before expect()" (String.length line3 > 0 && (try let _ = Str.search_forward (Str.regexp "mutate") line3 0 in true with Not_found -> false))
+  in
+  test_apply_cast ();
+
+  Printf.printf "\napply_rename_column:\n";
+  let test_apply_rename () =
+    let tmp = Filename.temp_file "test_fix" ".t" in
+    let oc = open_out tmp in
+    output_string oc "clean = raw |> expect(columns = [\"old_name\"])\n";
+    close_out oc;
+    Fix.apply_rename_column ~file:tmp ~old_name:"old_name" ~new_name:"new_name";
+    let ch = open_in tmp in
+    let content = really_input_string ch (in_channel_length ch) in
+    close_in ch;
+    Sys.remove tmp;
+    let has_new = (try let _ = Str.search_forward (Str.regexp_string "new_name") content 0 in true with Not_found -> false) in
+    check "rename_column replaces old with new" has_new
+  in
+  test_apply_rename ();
+
+  Printf.printf "\nsuggested_fix roundtrip:\n";
+  let test_roundtrip () =
+    let fixes : Diagnostics.suggested_fix list = [
+      Cast { column = "x"; cast_to = "double"; file = Some "test.t"; line = Some 5 };
+      Rename_column { old_name = "a"; new_name = "b"; file = Some "test.t"; line = None };
+      Add_node_arg { node = "filter"; arg = "na_rm=true"; file = Some "test.t"; line = None };
+      Pin_package_version { pkg = "dplyr"; version = "1.0.0"; file = Some "tproject.toml" };
+      NoFix;
+    ] in
+    let all_ok = List.for_all (fun fix ->
+      let json = Diagnostics.suggested_fix_to_yojson fix in
+      let roundtrip = Diagnostics.suggested_fix_of_yojson json in
+      match fix, roundtrip with
+      | NoFix, NoFix -> true
+      | Cast { column = c1; cast_to = t1; _ }, Cast { column = c2; cast_to = t2; _ } ->
+          c1 = c2 && t1 = t2
+      | Rename_column { old_name = o1; new_name = n1; _ }, Rename_column { old_name = o2; new_name = n2; _ } ->
+          o1 = o2 && n1 = n2
+      | Add_node_arg { node = n1; arg = a1; _ }, Add_node_arg { node = n2; arg = a2; _ } ->
+          n1 = n2 && a1 = a2
+      | Pin_package_version { pkg = p1; version = v1; _ }, Pin_package_version { pkg = p2; version = v2; _ } ->
+          p1 = p2 && v1 = v2
+      | _ -> false
+    ) fixes in
+    check "suggested_fix roundtrips through JSON" all_ok
+  in
+  test_roundtrip ();
+
+  Printf.printf "\napply_fix dispatch:\n";
+  let test_apply_fix_noop () =
+    let r = Fix.apply_fix ~file:"/dev/null" Diagnostics.NoFix in
+    check "apply_fix returns false for NoFix" (r = false)
+  in
+  test_apply_fix_noop ();
+
+  let test_apply_fix_node_arg () =
+    let r = Fix.apply_fix ~file:"/dev/null" (Diagnostics.Add_node_arg { node = "x"; arg = "y"; file = None; line = None }) in
+    check "apply_fix returns false for Add_node_arg (unimplemented)" (r = false)
+  in
+  test_apply_fix_node_arg ()

--- a/tests/test_fix.ml
+++ b/tests/test_fix.ml
@@ -37,15 +37,17 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
   let test_apply_rename () =
     let tmp = Filename.temp_file "test_fix" ".t" in
     let oc = open_out tmp in
-    output_string oc "clean = raw |> expect(columns = [\"old_name\"])\n";
+    output_string oc "clean = raw\n  |> filter($id > 1)\n  |> mutate(valid = $id + 1)\n  |> expect(columns = [\"id\"])\n";
     close_out oc;
-    Fix.apply_rename_column ~file:tmp ~old_name:"old_name" ~new_name:"new_name";
+    Fix.apply_rename_column ~file:tmp ~old_name:"id" ~new_name:"record_id";
     let ch = open_in tmp in
     let content = really_input_string ch (in_channel_length ch) in
     close_in ch;
     Sys.remove tmp;
-    let has_new = (try let _ = Str.search_forward (Str.regexp_string "new_name") content 0 in true with Not_found -> false) in
-    check "rename_column replaces old with new" has_new
+    let has_new_ref = (try let _ = Str.search_forward (Str.regexp "\\$record_id") content 0 in true with Not_found -> false) in
+    let has_unchanged_valid = (try let _ = Str.search_forward (Str.regexp_string "valid") content 0 in true with Not_found -> false) in
+    check "rename_column replaces $id with $record_id" has_new_ref;
+    check "rename_column does not corrupt 'valid'" has_unchanged_valid
   in
   test_apply_rename ();
 
@@ -88,4 +90,27 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
     let r = Fix.apply_fix ~file:"/dev/null" (Diagnostics.Add_node_arg { node = "x"; arg = "y"; file = None; line = None }) in
     check "apply_fix returns false for Add_node_arg (unimplemented)" (r = false)
   in
-  test_apply_fix_node_arg ()
+  test_apply_fix_node_arg ();
+
+  Printf.printf "\nsort_fixes_by_descending_line:\n";
+  let test_sort_fixes () =
+    let d1 = { Diagnostics.
+      diag_id = "T0001"; diag_error_class = "contract_violation"; diag_severity = Error;
+      diag_phase = Schema; diag_node_id = None; diag_node_lang = None;
+      diag_file = Some "test.t"; diag_line = Some 3; diag_column = None;
+      diag_message = "first"; diag_caused_by = [];
+      diag_suggested_fix = Cast { column = "x"; cast_to = "double"; file = Some "test.t"; line = Some 3 };
+    } in
+    let d2 = { d1 with diag_id = "T0002"; diag_line = Some 10;
+      diag_message = "second";
+      diag_suggested_fix = Cast { column = "y"; cast_to = "double"; file = Some "test.t"; line = Some 10 };
+    } in
+    let d3 = { d1 with diag_id = "T0003"; diag_line = Some 5;
+      diag_message = "third";
+      diag_suggested_fix = Cast { column = "z"; cast_to = "double"; file = Some "test.t"; line = Some 5 };
+    } in
+    let sorted = Fix.sort_fixes_by_descending_line [d1; d2; d3] in
+    let lines = List.filter_map (fun d -> d.Diagnostics.diag_line) sorted in
+    check "sort_descending: first element has highest line" (lines = [10; 5; 3])
+  in
+  test_sort_fixes ()

--- a/tests/test_fix.ml
+++ b/tests/test_fix.ml
@@ -113,4 +113,70 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
     let lines = List.filter_map (fun d -> d.Diagnostics.diag_line) sorted in
     check "sort_descending: first element has highest line" (lines = [10; 5; 3])
   in
-  test_sort_fixes ()
+  test_sort_fixes ();
+
+  Printf.printf "\nword-boundary rename:\n";
+  let test_rename_word_boundary () =
+    let tmp = Filename.temp_file "test_fix_wb" ".t" in
+    let oc = open_out tmp in
+    output_string oc "clean = raw\n  |> filter($id > 1)\n  |> mutate($identity = $id + 1)\n";
+    close_out oc;
+    Fix.apply_rename_column ~file:tmp ~old_name:"id" ~new_name:"record_id";
+    let ch = open_in tmp in
+    let content = really_input_string ch (in_channel_length ch) in
+    close_in ch;
+    Sys.remove tmp;
+    let has_record_id = (try let _ = Str.search_forward (Str.regexp_string "$record_id") content 0 in true with Not_found -> false) in
+    let has_identity_unchanged = (try let _ = Str.search_forward (Str.regexp_string "$identity") content 0 in true with Not_found -> false) in
+    let no_record_identity = not (try let _ = Str.search_forward (Str.regexp_string "$record_identity") content 0 in true with Not_found -> false) in
+    check "rename replaces $id with $record_id" has_record_id;
+    check "rename does not corrupt $identity" has_identity_unchanged;
+    check "rename does not produce $record_identity" no_record_identity
+  in
+  test_rename_word_boundary ();
+
+  Printf.printf "\ndry-run counting:\n";
+  let test_dry_run_counting () =
+    let d1 = { Diagnostics.
+      diag_id = "T1001"; diag_error_class = "contract_violation"; diag_severity = Error;
+      diag_phase = Schema; diag_node_id = None; diag_node_lang = None;
+      diag_file = Some "test.t"; diag_line = Some 5; diag_column = None;
+      diag_message = "Column 'x' expected double, got int"; diag_caused_by = [];
+      diag_suggested_fix = Cast { column = "x"; cast_to = "double"; file = Some "test.t"; line = Some 5 };
+    } in
+    let d2 = { d1 with diag_id = "T1002"; diag_line = Some 8;
+      diag_message = "Column 'y' expected string, got int";
+      diag_suggested_fix = Cast { column = "y"; cast_to = "string"; file = Some "test.t"; line = Some 8 };
+    } in
+    let fixes = [d1; d2] in
+    let result = Fix.apply_fixes ~dry_run:true ~default_file:"test.t" fixes in
+    check "dry_run: applied = 0" (result.Fix.applied = 0);
+    check "dry_run: would_apply = 2" (result.Fix.would_apply = 2);
+    check "dry_run: skipped = 0" (result.Fix.skipped = 0)
+  in
+  test_dry_run_counting ();
+
+  Printf.printf "\napply_fixes non-dry-run:\n";
+  let test_apply_fixes_real () =
+    let tmp_cast = Filename.temp_file "test_fix_af" ".t" in
+    let oc = open_out tmp_cast in
+    output_string oc "clean = raw\n  |> read_csv(\"data.csv\")\n  |> expect(x = \"double\")\n";
+    close_out oc;
+    let d1 = { Diagnostics.
+      diag_id = "T1003"; diag_error_class = "contract_violation"; diag_severity = Error;
+      diag_phase = Schema; diag_node_id = None; diag_node_lang = None;
+      diag_file = Some tmp_cast; diag_line = Some 3; diag_column = None;
+      diag_message = "type mismatch"; diag_caused_by = [];
+      diag_suggested_fix = Cast { column = "x"; cast_to = "double"; file = Some tmp_cast; line = Some 3 };
+    } in
+    let result = Fix.apply_fixes ~dry_run:false ~default_file:tmp_cast [d1] in
+    check "non-dry-run: applied = 1" (result.Fix.applied = 1);
+    check "non-dry-run: would_apply = 0" (result.Fix.would_apply = 0);
+    let ch = open_in tmp_cast in
+    let content = really_input_string ch (in_channel_length ch) in
+    close_in ch;
+    Sys.remove tmp_cast;
+    let has_mutate = (try let _ = Str.search_forward (Str.regexp "mutate") content 0 in true with Not_found -> false) in
+    check "non-dry-run: file patched with mutate()" has_mutate
+  in
+  test_apply_fixes_real ();

--- a/tests/test_runner.ml
+++ b/tests/test_runner.ml
@@ -164,6 +164,7 @@ let () =
 
   (* t check / Diagnostics tests *)
   Test_check.run_tests pass_count fail_count failures eval_string eval_string_env test;
+  Test_fix.run_tests pass_count fail_count failures eval_string eval_string_env test;
 
   (* Summary *)
   let total = !pass_count + !fail_count in

--- a/tests/test_runner.ml
+++ b/tests/test_runner.ml
@@ -160,6 +160,7 @@ let () =
   Test_scalar_diff.run_tests pass_count fail_count failures eval_string eval_string_env test;
   Test_generic_diff.run_tests pass_count fail_count failures eval_string eval_string_env test;
   Test_pipeline_diff.run_tests pass_count fail_count failures eval_string eval_string_env test;
+  Test_builder_diff.run_tests pass_count fail_count failures eval_string eval_string_env test;
 
   (* t check / Diagnostics tests *)
   Test_check.run_tests pass_count fail_count failures eval_string eval_string_env test;


### PR DESCRIPTION
Implements §3.3 of path-to-0.54.1 spec. Compares two builds using per-node Nix content hashes stored in build logs. Reports unchanged, changed, added, and removed nodes without loading artifacts.

- New: src/pipeline/builder_diff.ml (compute_diff, find_two_matching_logs, JSON output)
- New: src/packages/pipeline/diff_summary.ml (diff_summary(p) T function)
- New: tests/diff/test_builder_diff.ml (5 unit tests)
- Modified: builder_internal.ml extracts per-node hashes from node_store_paths
- Modified: builder_logs.ml adds read_log_with_hashes
- Modified: repl.ml adds cmd_diff + CLI dispatch
- Modified: docs/api-reference.md, summary.md, AGENTS.md

All 2602 tests pass.