### PR TITLE
refactor: migrate from nix-instantiate to nix eval

### DIFF
--- a/src/check_utils.ml
+++ b/src/check_utils.ml
@@ -77,7 +77,7 @@ let run_file ?failfast mode filename env =
 
 (* --- Check mode --- *)
 
-let run_check ?(schema=false) ?(env_check=false) mode filename env =
+let run_check ?(schema=false) ?(env_check=false) ?(offline=false) mode filename env =
   let run () =
     Ast.check_mode := true;
     Fun.protect ~finally:(fun () -> Ast.check_mode := false)
@@ -108,7 +108,7 @@ let run_check ?(schema=false) ?(env_check=false) mode filename env =
           else []
         in
         let env_diags =
-          if env_check then Env_check.check_env ~file:filename p
+          if env_check then Env_check.check_env ~offline ~file:filename p
           else []
         in
         wire_diags @ schema_diags @ env_diags

--- a/src/env_check.ml
+++ b/src/env_check.ml
@@ -143,6 +143,7 @@ let check_nix_evaluation ?(offline = false) ~file (p : Ast.pipeline_result) =
         List.map (fun name ->
           let parts = String.split_on_char '.' name in
           let quoted_path = List.map (fun part -> Printf.sprintf "\"%s\"" part) parts |> String.concat "." in
+          (* toString p.<name> produces a string; the resulting attrset is trivially JSON-encodable *)
           Printf.sprintf "\"%s\" = toString p.%s;" name quoted_path
         ) node_names
         |> String.concat " "

--- a/src/env_check.ml
+++ b/src/env_check.ml
@@ -118,8 +118,8 @@ let check_lockfile_consistency ~file ~tproject_cfg (p : Ast.pipeline_result) =
          ) missing)
   | _ -> []
 
-(* Validate Nix evaluation via nix-instantiate --eval *)
-let check_nix_evaluation ~file (p : Ast.pipeline_result) =
+(* Validate Nix evaluation via nix eval *)
+let check_nix_evaluation ?(offline = false) ~file (p : Ast.pipeline_result) =
   match Builder_populate.generate_nix p with
   | Error msg ->
       [Diagnostics.{
@@ -148,7 +148,12 @@ let check_nix_evaluation ~file (p : Ast.pipeline_result) =
         |> String.concat " "
       in
       let expr = Printf.sprintf "let p = import ./%s {}; in { %s }" nix_path assignments in
-      let argv = [| "nix-instantiate"; "--impure"; "--eval"; "--strict"; "--expr"; expr |] in
+      let argv =
+        if offline then
+          [| "nix"; "eval"; "--offline"; "--impure"; "--json"; "--expr"; expr |]
+        else
+          [| "nix"; "eval"; "--impure"; "--json"; "--expr"; expr |]
+      in
       match Builder_utils.run_command_argv_capture argv with
       | Ok _output -> []
       | Error msg ->
@@ -168,11 +173,11 @@ let check_nix_evaluation ~file (p : Ast.pipeline_result) =
           }]
 
 (* Main entry point: run all tier 3 env checks *)
-let check_env ~file (p : Ast.pipeline_result) =
+let check_env ?(offline = false) ~file (p : Ast.pipeline_result) =
   let project_root = Builder_utils.get_project_root () in
   let tproject_path = Filename.concat project_root "tproject.toml" in
   let tproject_cfg = parse_tproject ~project_root in
   let declared_diags = check_declared_requirements ~file ~tproject_path ~project_root ~tproject_cfg p in
   let lockfile_diags = check_lockfile_consistency ~file ~tproject_cfg p in
-  let nix_diags = check_nix_evaluation ~file p in
+  let nix_diags = check_nix_evaluation ~offline ~file p in
   declared_diags @ lockfile_diags @ nix_diags

--- a/src/packages/pipeline/pipeline_to_drv.ml
+++ b/src/packages/pipeline/pipeline_to_drv.ml
@@ -26,16 +26,17 @@ let register env =
            | Ok _ ->
                let drv_pairs =
                  List.map (fun (name, _) ->
-                   let argv = [| "nix-instantiate"; "--impure"; Builder_utils.pipeline_nix_path; "-A"; name |] in
-                   let v = match Builder_utils.run_command_argv_capture argv with
-                     | Error msg ->
-                         Error.make_error RuntimeError
-                           (Printf.sprintf "pipeline_to_drv: `nix-instantiate` failed for node '%s': %s" name msg)
-                     | Ok "" ->
-                         Error.make_error RuntimeError
-                           (Printf.sprintf "pipeline_to_drv: `nix-instantiate` returned empty output for node '%s'" name)
-                     | Ok drv_path ->
-                         VString (String.trim drv_path)
+                    let artifact_attr = name ^ ".drvPath" in
+                    let argv = [| "nix"; "eval"; "--impure"; "--raw"; "-f"; Builder_utils.pipeline_nix_path; artifact_attr |] in
+                    let v = match Builder_utils.run_command_argv_capture argv with
+                      | Error msg ->
+                          Error.make_error RuntimeError
+                            (Printf.sprintf "pipeline_to_drv: nix eval failed for node '%s': %s" name msg)
+                      | Ok "" ->
+                          Error.make_error RuntimeError
+                            (Printf.sprintf "pipeline_to_drv: nix eval returned empty output for node '%s'" name)
+                      | Ok drv_path ->
+                          VString (String.trim drv_path)
                    in
                    (name, v)
                  ) p.p_nodes

--- a/src/packages/pipeline/pipeline_to_drv.ml
+++ b/src/packages/pipeline/pipeline_to_drv.ml
@@ -26,8 +26,8 @@ let register env =
            | Ok _ ->
                let drv_pairs =
                  List.map (fun (name, _) ->
-                    let artifact_attr = name ^ ".drvPath" in
-                    let argv = [| "nix"; "eval"; "--impure"; "--raw"; "-f"; Builder_utils.pipeline_nix_path; artifact_attr |] in
+                   let artifact_attr = name ^ ".drvPath" in
+                   let argv = [| "nix"; "eval"; "--impure"; "--raw"; "-f"; Builder_utils.pipeline_nix_path; artifact_attr |] in
                     let v = match Builder_utils.run_command_argv_capture argv with
                       | Error msg ->
                           Error.make_error RuntimeError

--- a/src/packages/pipeline/t_check.ml
+++ b/src/packages/pipeline/t_check.ml
@@ -15,6 +15,7 @@ open Ast
 --# @param json :: Bool = false Output diagnostics as JSON.
 --# @param schema :: Bool = false Enable column-level schema validation.
 --# @param env :: Bool = false Enable tproject.toml environment checks.
+--# @param offline :: Bool = false Prevent network access during env checks.
 --# @return :: String The formatted diagnostics (text or JSON).
 --# @family pipeline
 --# @export
@@ -25,7 +26,7 @@ let register env =
     (make_builtin_named ~name:"t_check" ~variadic:true 1 (fun named_args _env ->
       let named_keys = List.filter_map (fun (k, _) -> k) named_args in
       let positional_count = List.length (List.filter (fun (k, _) -> k = None) named_args) in
-      match List.find_opt (fun k -> not (List.mem k ["file"; "json"; "schema"; "env"])) named_keys with
+      match List.find_opt (fun k -> not (List.mem k ["file"; "json"; "schema"; "env"; "offline"])) named_keys with
       | Some k ->
           Error.type_error (Printf.sprintf "t_check: unknown argument '%s'" k)
       | None when positional_count > 1 ->
@@ -37,6 +38,7 @@ let register env =
             let (_, json_val) = Pipeline_args.get_arg "json" 2 (VBool false) named_args in
             let (_, schema_val) = Pipeline_args.get_arg "schema" 3 (VBool false) named_args in
             let (_, env_val) = Pipeline_args.get_arg "env" 4 (VBool false) named_args in
+            let (_, offline_val) = Pipeline_args.get_arg "offline" 5 (VBool false) named_args in
 
             let json_result =
               match json_val with
@@ -53,13 +55,19 @@ let register env =
               | VBool b -> Ok b
               | _ -> Error (Error.type_error "Function `t_check` expects `env` to be a Bool.")
             in
+            let offline_result =
+              match offline_val with
+              | VBool b -> Ok b
+              | _ -> Error (Error.type_error "Function `t_check` expects `offline` to be a Bool.")
+            in
 
             let (let*) x f = match x with Ok v -> f v | Error e -> e in
             let* do_json = json_result in
             let* do_schema = schema_result in
             let* do_env = env_result in
+            let* do_offline = offline_result in
 
-            let check_result = Check_utils.run_check ~schema:do_schema ~env_check:do_env Typecheck.Strict filename Env.empty in
+            let check_result = Check_utils.run_check ~schema:do_schema ~env_check:do_env ~offline:do_offline Typecheck.Strict filename Env.empty in
             VString (Check_utils.format_check_result ~json:do_json check_result)
         | (_, other) ->
             Error.type_error

--- a/src/pipeline/builder_inspect.ml
+++ b/src/pipeline/builder_inspect.ml
@@ -69,7 +69,8 @@ let read_node_log node_name =
   | `Found None | `Missing ->
       (* Fallback: try to instantiate the derivation path from pipeline.nix *)
       if Sys.file_exists pipeline_nix_path then
-        let argv = [| "nix-instantiate"; "--impure"; pipeline_nix_path; "-A"; node_name |] in
+        let artifact_attr = node_name ^ ".drvPath" in
+        let argv = [| "nix"; "eval"; "--impure"; "--raw"; "-f"; pipeline_nix_path; artifact_attr |] in
         (match run_command_argv_capture argv with
          | Ok output ->
              let drv = String.trim output in
@@ -79,9 +80,9 @@ let read_node_log node_name =
                 | Ok log_output -> VString log_output
                 | Error msg -> Error.make_error ShellError (Printf.sprintf "Failed to fetch nix log: %s" msg))
              else
-               Error.make_error ValueError (Printf.sprintf "Node `%s` not found in last build attempt and could not be instantiated from `%s`." node_name pipeline_nix_path)
+               Error.make_error ValueError (Printf.sprintf "Node `%s` not found in last build attempt and could not be evaluated from `%s`." node_name pipeline_nix_path)
          | Error msg ->
-             Error.make_error ValueError (Printf.sprintf "Node `%s` not found in last build attempt and instantiation failed: %s" node_name msg))
+             Error.make_error ValueError (Printf.sprintf "Node `%s` not found in last build attempt and evaluation failed: %s" node_name msg))
       else
         Error.make_error FileError (Printf.sprintf "Node `%s` not found in last build attempt and `%s` is missing. Run `build_pipeline` first." node_name pipeline_nix_path)
 

--- a/src/pipeline/builder_internal.ml
+++ b/src/pipeline/builder_internal.ml
@@ -281,7 +281,9 @@ let build_pipeline_internal ?verbose ?pipeline_name ?(nix_options : nix_opts opt
                      | _ -> ()
                    ) pairs
                | _ -> ()
-             with Yojson.Json_error _ -> ())
+             with Yojson.Json_error msg ->
+               if verbose > 0 then
+                 Printf.eprintf "[Debug] nix eval JSON parse failed: %s\n%!" msg)
         | Error msg ->
             if verbose > 0 then
               Printf.eprintf "[Debug] nix eval failed: %s\n%!" msg

--- a/src/pipeline/builder_internal.ml
+++ b/src/pipeline/builder_internal.ml
@@ -268,23 +268,23 @@ let build_pipeline_internal ?verbose ?pipeline_name ?(nix_options : nix_opts opt
           in
           Printf.sprintf "let p = import ./%s {}; in { %s }" pipeline_nix_path assignments
         in
-        let argv_eval = [| "nix-instantiate"; "--impure"; "--eval"; "--strict"; "--expr"; expr |] in
+        let argv_eval = [| "nix"; "eval"; "--impure"; "--json"; "--expr"; expr |] in
         match run_command_argv_capture argv_eval with
         | Ok output ->
-            let re = Str.regexp "\"?\\([a-zA-Z0-9_.-]+\\)\"?[ \t]*=[ \t]*\"\\([^\"]+\\)\"" in
-            let pos = ref 0 in
             (try
-               while true do
-                 let _ = Str.search_forward re output !pos in
-                 let name = Str.matched_group 1 output in
-                 let path = Str.matched_group 2 output in
-                 Hashtbl.replace node_store_paths name path;
-                 pos := Str.match_end ()
-               done
-             with Not_found -> ())
+               let json = Yojson.Safe.from_string output in
+               match json with
+               | `Assoc pairs ->
+                   List.iter (fun (name, path) ->
+                     match path with
+                     | `String p -> Hashtbl.replace node_store_paths name p
+                     | _ -> ()
+                   ) pairs
+               | _ -> ()
+             with Yojson.Json_error _ -> ())
         | Error msg ->
             if verbose > 0 then
-              Printf.eprintf "[Debug] nix-instantiate eval failed: %s\n%!" msg
+              Printf.eprintf "[Debug] nix eval failed: %s\n%!" msg
       )
     in
     if dry_run then begin

--- a/src/pipeline/builder_utils.ml
+++ b/src/pipeline/builder_utils.ml
@@ -555,14 +555,14 @@ let escape_nix_string s =
 let eval_node_store_path name : (string, Ast.value) result =
   let abs_path = Filename.concat (Sys.getcwd ()) pipeline_nix_path in
   let expr = Printf.sprintf "(import %s {}).%s.outPath" (escape_nix_string abs_path) name in
-  let argv = [| "nix-instantiate"; "--eval"; "--impure"; "--json"; "-E"; expr |] in
+  let argv = [| "nix"; "eval"; "--impure"; "--json"; "--expr"; expr |] in
   match run_command_argv_capture argv with
   | Error msg ->
       Error (Error.make_error RuntimeError
-        (Printf.sprintf "nix-instantiate failed for node '%s': %s" name msg))
+        (Printf.sprintf "nix eval failed for node '%s': %s" name msg))
   | Ok "" ->
       Error (Error.make_error RuntimeError
-        (Printf.sprintf "nix-instantiate returned empty output for node '%s'" name))
+        (Printf.sprintf "nix eval returned empty output for node '%s'" name))
   | Ok res ->
       let len = String.length res in
       let clean =

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -649,10 +649,10 @@ let cmd_run_expr ?failfast mode expr env =
   | Ast.(VNA NAGeneric) -> ()
   | v -> print_string (Pretty_print.pretty_print_value v)
 
-let run_check ?(schema=false) ?(env_check=false) mode filename env =
+let run_check ?(schema=false) ?(env_check=false) ?(offline=false) mode filename env =
   Packages.ensure_docs_loaded ();
   ensure_file_path filename;
-  Check_utils.run_check ~schema ~env_check mode filename env
+  Check_utils.run_check ~schema ~env_check ~offline mode filename env
 
 let print_check_result ?(json=false) check_result =
   let output = Check_utils.format_check_result ~json check_result in
@@ -661,12 +661,12 @@ let print_check_result ?(json=false) check_result =
   else
     Printf.eprintf "%s" output
 
-let cmd_check ?(json=false) ?(schema=false) ?(env_check=false) mode filename env =
-  let check_result = run_check ~schema ~env_check mode filename env in
+let cmd_check ?(json=false) ?(schema=false) ?(env_check=false) ?(offline=false) mode filename env =
+  let check_result = run_check ~schema ~env_check ~offline mode filename env in
   print_check_result ~json check_result;
   exit (Diagnostics.exit_code_of_diagnostics (Diagnostics.check_result_entries check_result))
 
-let cmd_check_watch ?(json=false) ?(schema=false) ?(env_check=false) mode filename env =
+let cmd_check_watch ?(json=false) ?(schema=false) ?(env_check=false) ?(offline=false) mode filename env =
   let get_mtime path =
     try (Unix.stat path).Unix.st_mtime with Unix.Unix_error _ -> 0.0
   in
@@ -675,7 +675,7 @@ let cmd_check_watch ?(json=false) ?(schema=false) ?(env_check=false) mode filena
   let last_exit_code = ref 0 in
   Printf.eprintf "Watching %s for changes (Ctrl+C to stop)...\n%!" filename;
   (* Initial run *)
-  let check_result = run_check ~schema ~env_check mode filename env in
+  let check_result = run_check ~schema ~env_check ~offline mode filename env in
   print_check_result ~json check_result;
   last_exit_code := Diagnostics.exit_code_of_diagnostics (Diagnostics.check_result_entries check_result);
   let forever = ref true in
@@ -686,7 +686,7 @@ let cmd_check_watch ?(json=false) ?(schema=false) ?(env_check=false) mode filena
     if current_mtime > !last_mtime then begin
       last_mtime := current_mtime;
       Printf.eprintf "\n--- file changed, re-checking ---\n%!";
-      let check_result = run_check ~schema ~env_check mode filename env in
+      let check_result = run_check ~schema ~env_check ~offline mode filename env in
       print_check_result ~json check_result;
       last_exit_code := Diagnostics.exit_code_of_diagnostics (Diagnostics.check_result_entries check_result)
     end
@@ -1471,24 +1471,25 @@ let () =
       Printf.eprintf "Unexpected arguments after `t run <file.t>`.\n";
       exit 1
   | _ :: "check" :: [] ->
-      Printf.eprintf "Usage: t check [--json] [--schema] [--env] [--watch] <file.t>\n";
+      Printf.eprintf "Usage: t check [--json] [--schema] [--env] [--offline] [--watch] <file.t>\n";
       exit 1
   | _ :: "check" :: rest ->
       let json = List.mem "--json" rest in
       let schema = List.mem "--schema" rest in
       let check_env = List.mem "--env" rest in
+      let offline = List.mem "--offline" rest in
       let watch = List.mem "--watch" rest in
       let filename = List.find_opt (fun s -> not (String.length s > 0 && s.[0] = '-')) rest in
       let script_mode = if mode_parse.mode = Typecheck.Repl && not mode_parse.mode_flag then Typecheck.Strict else mode_parse.mode in
       (match filename with
        | None ->
-           Printf.eprintf "Usage: t check [--json] [--schema] [--env] [--watch] <file.t>\n";
+           Printf.eprintf "Usage: t check [--json] [--schema] [--env] [--offline] [--watch] <file.t>\n";
            exit 1
        | Some f ->
            if watch then
-             cmd_check_watch ~json ~schema ~env_check:check_env script_mode f env
+             cmd_check_watch ~json ~schema ~env_check:check_env ~offline script_mode f env
            else
-             cmd_check ~json ~schema ~env_check:check_env script_mode f env)
+             cmd_check ~json ~schema ~env_check:check_env ~offline script_mode f env)
   | _ :: "diff" :: [] ->
       Printf.eprintf "Usage: t diff [--json] [--log-a <n>] [--log-b <n>] <file.t>\n";
       exit 1


### PR DESCRIPTION
All nix-instantiate call sites migrated to nix eval:

Phase 1 (env_check.ml): nix eval --impure --json --expr
  - Added --offline flag support, threaded through check_env, Check_utils.run_check, cmd_check, cmd_check_watch, CLI, and t_check() REPL function
  - CLI: t check [--json] [--schema] [--env] [--offline] [--watch] <file.t>

Phase 2 (builder_utils.ml): nix eval --impure --json --expr
  - eval_node_store_path: transparent migration, same JSON string output

Phase 3 (builder_internal.ml): nix eval --impure --json --expr
  - Replaced fragile regex parsing with Yojson.Safe.from_string JSON parse

Phase 4 (pipeline_to_drv.ml, builder_inspect.ml):
  - nix-instantiate -A <name> -> nix eval --impure --raw -f <path> <name>.drvPath

Zero remaining nix-instantiate references. 2642/2642 tests pass.