### PR TITLE
feat(diagnostics): add target_node field to suggested_fix

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3679,6 +3679,7 @@ $ t check --json pipeline.t | jq '.diagnostics[].suggested_fix'
   "kind": "cast",
   "column": "amount",
   "cast_to": "double",
+  "target_node": "clean",
   "file": "pipeline.t",
   "line": 5
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,7 @@
 - **`t fix <file>`**: Runs `t check --schema`, extracts diagnostics with `suggested_fix`, and applies them mechanically. Supports `Cast` (inserts `|> mutate(...)`) and `Rename_column` (replaces `$old` with `$new` in column references).
 - **`t_fix(file, dry_run)` REPL function**: Invoke `t fix` from within a T session.
 - **Word-boundary-safe rename**: Column renames only affect `$col` and `` $`col` `` forms, avoiding corruption of identifiers like `valid` when renaming `id`.
+- **`target_node` on `suggested_fix`**: `Cast`, `Rename_column`, and `Add_node_arg` fixes now include a `target_node` field indicating which pipeline node the fix applies to.
 
 ### `t check` Environment Validation
 

--- a/src/diagnostics.ml
+++ b/src/diagnostics.ml
@@ -6,9 +6,9 @@ type diagnostic_phase = Parse | Wire | Schema | Env | Build | Exec
 type severity = Error | Warning
 
 type suggested_fix =
-  | Cast of { column: string; cast_to: string; file: string option; line: int option }
-  | Rename_column of { old_name: string; new_name: string; file: string option; line: int option }
-  | Add_node_arg of { node: string; arg: string; file: string option; line: int option }
+  | Cast of { column: string; cast_to: string; target_node: string option; file: string option; line: int option }
+  | Rename_column of { old_name: string; new_name: string; target_node: string option; file: string option; line: int option }
+  | Add_node_arg of { node: string; arg: string; target_node: string option; file: string option; line: int option }
   | Pin_package_version of { pkg: string; version: string; file: string option }
   | NoFix
 
@@ -65,27 +65,30 @@ let opt_int_to_yojson = function
   | None -> `Null
 
 let suggested_fix_to_yojson = function
-  | Cast { column; cast_to; file; line } ->
+  | Cast { column; cast_to; target_node; file; line } ->
       `Assoc [
         ("kind", `String "cast");
         ("column", `String column);
         ("cast_to", `String cast_to);
+        ("target_node", opt_string_to_yojson target_node);
         ("file", opt_string_to_yojson file);
         ("line", opt_int_to_yojson line);
       ]
-  | Rename_column { old_name; new_name; file; line } ->
+  | Rename_column { old_name; new_name; target_node; file; line } ->
       `Assoc [
         ("kind", `String "rename_column");
         ("old_name", `String old_name);
         ("new_name", `String new_name);
+        ("target_node", opt_string_to_yojson target_node);
         ("file", opt_string_to_yojson file);
         ("line", opt_int_to_yojson line);
       ]
-  | Add_node_arg { node; arg; file; line } ->
+  | Add_node_arg { node; arg; target_node; file; line } ->
       `Assoc [
         ("kind", `String "add_node_arg");
         ("node", `String node);
         ("arg", `String arg);
+        ("target_node", opt_string_to_yojson target_node);
         ("file", opt_string_to_yojson file);
         ("line", opt_int_to_yojson line);
       ]
@@ -118,23 +121,27 @@ let suggested_fix_of_yojson json =
       let kind = json |> member "kind" |> to_string in
       let file = json |> member "file" |> opt_string_of_yojson in
       let line = json |> member "line" |> opt_int_of_yojson in
+      let target_node = json |> member "target_node" |> opt_string_of_yojson in
       match kind with
       | "cast" ->
           Cast {
             column = json |> member "column" |> to_string;
             cast_to = json |> member "cast_to" |> to_string;
+            target_node;
             file; line;
           }
       | "rename_column" ->
           Rename_column {
             old_name = json |> member "old_name" |> to_string;
             new_name = json |> member "new_name" |> to_string;
+            target_node;
             file; line;
           }
       | "add_node_arg" ->
           Add_node_arg {
             node = json |> member "node" |> to_string;
             arg = json |> member "arg" |> to_string;
+            target_node;
             file; line;
           }
       | "pin_package_version" ->

--- a/src/fix.ml
+++ b/src/fix.ml
@@ -82,11 +82,11 @@ let apply_rename_column ~file ~old_name ~new_name =
 
 let apply_fix ~file (fix : Diagnostics.suggested_fix) =
   match fix with
-  | Cast { column; cast_to; file = _; line } ->
+  | Cast { column; cast_to; file = _; line; target_node = _ } ->
       (match line with
        | Some l -> apply_cast ~file ~line:l ~column ~cast_to; true
        | None -> false)
-  | Rename_column { old_name; new_name; file = _; line = _ } ->
+  | Rename_column { old_name; new_name; file = _; line = _; target_node = _ } ->
       apply_rename_column ~file ~old_name ~new_name; true
   | Add_node_arg _ -> false
   | Pin_package_version _ -> false

--- a/src/schema_check.ml
+++ b/src/schema_check.ml
@@ -328,6 +328,7 @@ let validate_contracts ~file (p : pipeline_result) schemas =
                     diag_suggested_fix = Cast {
                       column = col;
                       cast_to = expected_type;
+                      target_node = Some node_name;
                       file = Some file;
                       line = contract_line contract;
                     };

--- a/tests/test_fix.ml
+++ b/tests/test_fix.ml
@@ -54,9 +54,10 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
   Printf.printf "\nsuggested_fix roundtrip:\n";
   let test_roundtrip () =
     let fixes : Diagnostics.suggested_fix list = [
-      Cast { column = "x"; cast_to = "double"; file = Some "test.t"; line = Some 5 };
-      Rename_column { old_name = "a"; new_name = "b"; file = Some "test.t"; line = None };
-      Add_node_arg { node = "filter"; arg = "na_rm=true"; file = Some "test.t"; line = None };
+      Cast { column = "x"; cast_to = "double"; target_node = Some "clean"; file = Some "test.t"; line = Some 5 };
+      Cast { column = "y"; cast_to = "string"; target_node = None; file = Some "test.t"; line = Some 6 };
+      Rename_column { old_name = "a"; new_name = "b"; target_node = Some "step2"; file = Some "test.t"; line = None };
+      Add_node_arg { node = "filter"; arg = "na_rm=true"; target_node = None; file = Some "test.t"; line = None };
       Pin_package_version { pkg = "dplyr"; version = "1.0.0"; file = Some "tproject.toml" };
       NoFix;
     ] in
@@ -65,12 +66,12 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
       let roundtrip = Diagnostics.suggested_fix_of_yojson json in
       match fix, roundtrip with
       | NoFix, NoFix -> true
-      | Cast { column = c1; cast_to = t1; _ }, Cast { column = c2; cast_to = t2; _ } ->
-          c1 = c2 && t1 = t2
-      | Rename_column { old_name = o1; new_name = n1; _ }, Rename_column { old_name = o2; new_name = n2; _ } ->
-          o1 = o2 && n1 = n2
-      | Add_node_arg { node = n1; arg = a1; _ }, Add_node_arg { node = n2; arg = a2; _ } ->
-          n1 = n2 && a1 = a2
+      | Cast { column = c1; cast_to = t1; target_node = tn1; _ }, Cast { column = c2; cast_to = t2; target_node = tn2; _ } ->
+          c1 = c2 && t1 = t2 && tn1 = tn2
+      | Rename_column { old_name = o1; new_name = n1; target_node = tn1; _ }, Rename_column { old_name = o2; new_name = n2; target_node = tn2; _ } ->
+          o1 = o2 && n1 = n2 && tn1 = tn2
+      | Add_node_arg { node = n1; arg = a1; target_node = tn1; _ }, Add_node_arg { node = n2; arg = a2; target_node = tn2; _ } ->
+          n1 = n2 && a1 = a2 && tn1 = tn2
       | Pin_package_version { pkg = p1; version = v1; _ }, Pin_package_version { pkg = p2; version = v2; _ } ->
           p1 = p2 && v1 = v2
       | _ -> false
@@ -87,7 +88,7 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
   test_apply_fix_noop ();
 
   let test_apply_fix_node_arg () =
-    let r = Fix.apply_fix ~file:"/dev/null" (Diagnostics.Add_node_arg { node = "x"; arg = "y"; file = None; line = None }) in
+    let r = Fix.apply_fix ~file:"/dev/null" (Diagnostics.Add_node_arg { node = "x"; arg = "y"; target_node = None; file = None; line = None }) in
     check "apply_fix returns false for Add_node_arg (unimplemented)" (r = false)
   in
   test_apply_fix_node_arg ();
@@ -99,15 +100,15 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
       diag_phase = Schema; diag_node_id = None; diag_node_lang = None;
       diag_file = Some "test.t"; diag_line = Some 3; diag_column = None;
       diag_message = "first"; diag_caused_by = [];
-      diag_suggested_fix = Cast { column = "x"; cast_to = "double"; file = Some "test.t"; line = Some 3 };
+      diag_suggested_fix = Cast { column = "x"; cast_to = "double"; target_node = None; file = Some "test.t"; line = Some 3 };
     } in
     let d2 = { d1 with diag_id = "T0002"; diag_line = Some 10;
       diag_message = "second";
-      diag_suggested_fix = Cast { column = "y"; cast_to = "double"; file = Some "test.t"; line = Some 10 };
+      diag_suggested_fix = Cast { column = "y"; cast_to = "double"; target_node = None; file = Some "test.t"; line = Some 10 };
     } in
     let d3 = { d1 with diag_id = "T0003"; diag_line = Some 5;
       diag_message = "third";
-      diag_suggested_fix = Cast { column = "z"; cast_to = "double"; file = Some "test.t"; line = Some 5 };
+      diag_suggested_fix = Cast { column = "z"; cast_to = "double"; target_node = None; file = Some "test.t"; line = Some 5 };
     } in
     let sorted = Fix.sort_fixes_by_descending_line [d1; d2; d3] in
     let lines = List.filter_map (fun d -> d.Diagnostics.diag_line) sorted in
@@ -142,11 +143,11 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
       diag_phase = Schema; diag_node_id = None; diag_node_lang = None;
       diag_file = Some "test.t"; diag_line = Some 5; diag_column = None;
       diag_message = "Column 'x' expected double, got int"; diag_caused_by = [];
-      diag_suggested_fix = Cast { column = "x"; cast_to = "double"; file = Some "test.t"; line = Some 5 };
+      diag_suggested_fix = Cast { column = "x"; cast_to = "double"; target_node = None; file = Some "test.t"; line = Some 5 };
     } in
     let d2 = { d1 with diag_id = "T1002"; diag_line = Some 8;
       diag_message = "Column 'y' expected string, got int";
-      diag_suggested_fix = Cast { column = "y"; cast_to = "string"; file = Some "test.t"; line = Some 8 };
+      diag_suggested_fix = Cast { column = "y"; cast_to = "string"; target_node = None; file = Some "test.t"; line = Some 8 };
     } in
     let fixes = [d1; d2] in
     let result = Fix.apply_fixes ~dry_run:true ~default_file:"test.t" fixes in
@@ -167,7 +168,7 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
       diag_phase = Schema; diag_node_id = None; diag_node_lang = None;
       diag_file = Some tmp_cast; diag_line = Some 3; diag_column = None;
       diag_message = "type mismatch"; diag_caused_by = [];
-      diag_suggested_fix = Cast { column = "x"; cast_to = "double"; file = Some tmp_cast; line = Some 3 };
+      diag_suggested_fix = Cast { column = "x"; cast_to = "double"; target_node = None; file = Some tmp_cast; line = Some 3 };
     } in
     let result = Fix.apply_fixes ~dry_run:false ~default_file:tmp_cast [d1] in
     check "non-dry-run: applied = 1" (result.Fix.applied = 1);


### PR DESCRIPTION
Add optional target_node field to Cast, Rename_column, and Add_node_arg variants of suggested_fix. The field indicates which pipeline node the fix applies to. Currently populated for Cast (contract violations in schema_check.ml); other variants set it to None until context is available.

- Cast/Rename_column/Add_node_arg: add target_node: string option
- suggested_fix_to_yojson/of_yojson: serialize/deserialize target_node
- schema_check.ml: thread node_name into Cast constructor
- fix.ml: update explicit record patterns with target_node = _
- tests/test_fix.ml: roundtrip test covers Some and None target_node
- docs/api-reference.md, docs/changelog.md: document the new field