### PR TITLE
feat(diagnostics): add expected/actual fields to diagnostic type

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3309,7 +3309,7 @@ t check --schema --env --json path/to/script.t  # combined: tier 1+2+3 in JSON
 
 The `tier` field is derived from the deepest phase that produced diagnostics: parse/wire errors yield `tier: 1`, schema errors yield `tier: 2`, and env/build/exec errors yield `tier: 3`. A clean run reports `"tier": 1` and `"phase": "wire"` as the default.
 
-Each diagnostic entry contains: `id`, `error_class`, `severity`, `phase`, `node`, `file`, `span`, `message`, `caused_by`, and `suggested_fix`.
+Each diagnostic entry contains: `id`, `error_class`, `severity`, `phase`, `node`, `file`, `span`, `message`, `expected`, `actual`, `caused_by`, and `suggested_fix`.
 
 **Examples:**
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,7 @@
 
 - **Tier 1 CLI (`t check <file>`)**: Structural pipeline validation without triggering Nix builds. Catches parse errors, DAG cycles, dangling node references, arity errors, and built-in name resolution. Exit codes: 0=clean, 1=wire error, 2=schema error, 3=env error.
 - **Tier 2 Schema Validation (`t check --schema`)**: Static column-name and type propagation through the pipeline DAG. Validates column references against inferred upstream schemas, checks `expect()` type contracts, and reports contract violations with `Cast` suggested fixes.
-- **Structured JSON Diagnostics (`--json`)**: Machine-readable output for all tiers, with `schema_version`, `status`, `phase`, `tier`, and per-diagnostic `error_class`, `severity`, `caused_by`, and `suggested_fix` fields. Designed for agent tooling.
+- **Structured JSON Diagnostics (`--json`)**: Machine-readable output for all tiers, with `schema_version`, `status`, `phase`, `tier`, and per-diagnostic `error_class`, `severity`, `expected`, `actual`, `caused_by`, and `suggested_fix` fields. Designed for agent tooling.
 - **`t_check(file, json, schema, env)` REPL function**: Invoke `t check` from within a T session.
 
 ### `t diff` — Content-Addressed Output Diffing

--- a/src/diagnostics.ml
+++ b/src/diagnostics.ml
@@ -23,6 +23,8 @@ type diagnostic = {
   diag_line : int option;
   diag_column : int option;
   diag_message : string;
+  diag_expected : string option;
+  diag_actual : string option;
   diag_caused_by : string list;
   diag_suggested_fix : suggested_fix;
 }
@@ -171,6 +173,12 @@ let diagnostic_to_yojson d =
         ]
       | None -> `Null));
     ("message", `String d.diag_message);
+    ("expected", (match d.diag_expected with
+      | Some v -> `Assoc [("kind", `String "arrow_type"); ("value", `String v)]
+      | None -> `Null));
+    ("actual", (match d.diag_actual with
+      | Some v -> `Assoc [("kind", `String "arrow_type"); ("value", `String v)]
+      | None -> `Null));
     ("caused_by", `List (List.map (fun s -> `String s) d.diag_caused_by));
     ("suggested_fix", suggested_fix_to_yojson d.diag_suggested_fix);
   ]
@@ -272,6 +280,8 @@ let of_verror ?file (err : Ast.error_info) : diagnostic =
     diag_line = (match err.location with Some l -> Some l.Ast.line | None -> None);
     diag_column = (match err.location with Some l -> Some l.Ast.column | None -> None);
     diag_message = err.message;
+    diag_expected = None;
+    diag_actual = None;
     diag_caused_by = caused_by;
     diag_suggested_fix = suggested_fix;
   }
@@ -291,6 +301,8 @@ let of_pipeline_result ?file (p : Ast.pipeline_result) : diagnostic list =
             diag_line = None;
             diag_column = None;
             diag_message = ne.Ast.ne_message;
+            diag_expected = None;
+            diag_actual = None;
             diag_caused_by = nd.Ast.nd_upstream_errors;
             diag_suggested_fix = NoFix;
           }]
@@ -319,6 +331,8 @@ let of_pipeline_result ?file (p : Ast.pipeline_result) : diagnostic list =
           diag_line = None;
           diag_column = None;
           diag_message = nw.Ast.nw_message;
+          diag_expected = None;
+          diag_actual = None;
           diag_caused_by = (match nw.Ast.nw_source with
             | Ast.WarningUpstream upstream -> [upstream]
             | Ast.WarningOwn -> []);

--- a/src/env_check.ml
+++ b/src/env_check.ml
@@ -39,6 +39,8 @@ let check_declared_requirements ~file ~tproject_path ~project_root ~tproject_cfg
         diag_line = None;
         diag_column = None;
         diag_message = Printf.sprintf "Pipeline requires R/Python/Julia packages but tproject.toml not found at %s" tproject_path;
+        diag_expected = None;
+        diag_actual = None;
         diag_caused_by = [];
         diag_suggested_fix = NoFix;
       }]
@@ -72,6 +74,8 @@ let check_declared_requirements ~file ~tproject_path ~project_root ~tproject_cfg
             diag_line = None;
             diag_column = None;
             diag_message = Printf.sprintf "Package '%s' required by pipeline not declared in %s %s" pkg tproject_path section;
+            diag_expected = None;
+            diag_actual = None;
             diag_caused_by = [];
             diag_suggested_fix = NoFix;
           } :: !missing_diags
@@ -111,9 +115,11 @@ let check_lockfile_consistency ~file ~tproject_cfg (p : Ast.pipeline_result) =
              diag_file = Some file;
              diag_line = None;
              diag_column = None;
-             diag_message = Printf.sprintf "R package '%s' required by pipeline not found in renv.lock" pkg;
-             diag_caused_by = [];
-             diag_suggested_fix = NoFix;
+              diag_message = Printf.sprintf "R package '%s' required by pipeline not found in renv.lock" pkg;
+              diag_expected = None;
+              diag_actual = None;
+              diag_caused_by = [];
+              diag_suggested_fix = NoFix;
            }
          ) missing)
   | _ -> []
@@ -133,6 +139,8 @@ let check_nix_evaluation ?(offline = false) ~file (p : Ast.pipeline_result) =
         diag_line = None;
         diag_column = None;
         diag_message = Printf.sprintf "Failed to generate pipeline.nix for evaluation: %s" msg;
+        diag_expected = None;
+        diag_actual = None;
         diag_caused_by = [];
         diag_suggested_fix = NoFix;
       }]
@@ -169,6 +177,8 @@ let check_nix_evaluation ?(offline = false) ~file (p : Ast.pipeline_result) =
             diag_line = None;
             diag_column = None;
             diag_message = Printf.sprintf "Nix expression evaluation failed: %s" msg;
+            diag_expected = None;
+            diag_actual = None;
             diag_caused_by = [];
             diag_suggested_fix = NoFix;
           }]

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -1941,11 +1941,13 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
          diag_file = None;
          diag_line = (match node_expr.loc with Some l -> Some l.line | None -> None);
          diag_column = (match node_expr.loc with Some l -> Some l.column | None -> None);
-         diag_message = Printf.sprintf
-           "expect() in node '%s' appears mid-chain and will be ignored. \
-            Move it to the end of the pipe chain." name;
-         diag_caused_by = [];
-         diag_suggested_fix = NoFix;
+          diag_message = Printf.sprintf
+            "expect() in node '%s' appears mid-chain and will be ignored. \
+             Move it to the end of the pipe chain." name;
+          diag_expected = None;
+          diag_actual = None;
+          diag_caused_by = [];
+          diag_suggested_fix = NoFix;
        }]
     in
     let node_expr, contract_opt, expect_warnings =

--- a/src/schema_check.ml
+++ b/src/schema_check.ml
@@ -242,6 +242,8 @@ let validate_col_refs ~node_name ~(file : string option) ~schema expr =
         diag_column = (match expr.loc with Some l -> Some l.column | None -> None);
         diag_message = Printf.sprintf "Column '%s' referenced in node '%s' not found in input schema [%s]"
           col node_name (String.concat ", " (schema_names schema));
+        diag_expected = None;
+        diag_actual = None;
         diag_caused_by = [];
         diag_suggested_fix = NoFix;
       })
@@ -282,6 +284,8 @@ let validate_contracts ~file (p : pipeline_result) schemas =
                 (String.concat ", " required_cols)
                 (String.concat ", " col_names)
                 (String.concat ", " missing);
+              diag_expected = None;
+              diag_actual = None;
               diag_caused_by = [];
               diag_suggested_fix = NoFix;
             })
@@ -307,6 +311,8 @@ let validate_contracts ~file (p : pipeline_result) schemas =
                   diag_column = contract_column contract;
                   diag_message = Printf.sprintf "Node '%s' type contract for column '%s' (~ %s) cannot be verified statically: column type is unknown"
                     node_name col expected_type;
+                  diag_expected = None;
+                  diag_actual = None;
                   diag_caused_by = [];
                   diag_suggested_fix = NoFix;
                 })
@@ -324,6 +330,8 @@ let validate_contracts ~file (p : pipeline_result) schemas =
                     diag_column = contract_column contract;
                     diag_message = Printf.sprintf "Node '%s' type contract for column '%s' expects ~ %s but output schema has type %s"
                       node_name col expected_type actual_type;
+                    diag_expected = Some expected_type;
+                    diag_actual = Some actual_type;
                     diag_caused_by = [];
                     diag_suggested_fix = Cast {
                       column = col;
@@ -353,6 +361,8 @@ let validate_contracts ~file (p : pipeline_result) schemas =
               diag_column = contract_column contract;
               diag_message = Printf.sprintf "Node '%s' null-rate contract for column '%s' (< %.2f) cannot be verified statically: requires runtime data"
                 node_name col threshold;
+              diag_expected = None;
+              diag_actual = None;
               diag_caused_by = [];
               diag_suggested_fix = NoFix;
             }
@@ -500,6 +510,8 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
                         diag_column = (match expr.loc with Some l -> Some l.column | None -> None);
                         diag_message = Printf.sprintf "Formula variable '%s' in %s() not found in input schema [%s]"
                           var fn_name (String.concat ", " (schema_names validation_schema));
+                        diag_expected = None;
+                        diag_actual = None;
                         diag_caused_by = [];
                         diag_suggested_fix = NoFix;
                       })

--- a/tests/test_check.ml
+++ b/tests/test_check.ml
@@ -121,6 +121,8 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
     diag_line = Some 5;
     diag_column = Some 10;
     diag_message = "test message";
+    diag_expected = None;
+    diag_actual = None;
     diag_caused_by = ["upstream_node"];
     diag_suggested_fix = Diagnostics.NoFix;
   } in
@@ -132,6 +134,26 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
     (Diagnostics.diagnostic_error_class test_diag) "test_error";
   check_eq "diagnostic_message accessor"
     (Diagnostics.diagnostic_message test_diag) "test message";
+
+  Printf.printf "\nexpected/actual fields:\n";
+  let test_diag_with_types = { test_diag with
+    Diagnostics.diag_expected = Some "double";
+    diag_actual = Some "string";
+  } in
+  let json = Diagnostics.diagnostic_to_yojson test_diag_with_types in
+  let expected_json = Yojson.Safe.Util.(json |> member "expected" |> member "value" |> to_string) in
+  let actual_json = Yojson.Safe.Util.(json |> member "actual" |> member "value" |> to_string) in
+  check_eq "expected field serializes correctly" expected_json "double";
+  check_eq "actual field serializes correctly" actual_json "string";
+  let test_diag_none_types = { test_diag with
+    Diagnostics.diag_expected = None;
+    diag_actual = None;
+  } in
+  let json_none = Diagnostics.diagnostic_to_yojson test_diag_none_types in
+  let expected_null = Yojson.Safe.Util.(json_none |> member "expected") in
+  let actual_null = Yojson.Safe.Util.(json_none |> member "actual") in
+  check "expected is null when None" (expected_null = `Null);
+  check "actual is null when None" (actual_null = `Null);
 
   Printf.printf "\nSchema check module:\n";
 

--- a/tests/test_fix.ml
+++ b/tests/test_fix.ml
@@ -99,7 +99,8 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
       diag_id = "T0001"; diag_error_class = "contract_violation"; diag_severity = Error;
       diag_phase = Schema; diag_node_id = None; diag_node_lang = None;
       diag_file = Some "test.t"; diag_line = Some 3; diag_column = None;
-      diag_message = "first"; diag_caused_by = [];
+      diag_message = "first"; diag_expected = None; diag_actual = None;
+      diag_caused_by = [];
       diag_suggested_fix = Cast { column = "x"; cast_to = "double"; target_node = None; file = Some "test.t"; line = Some 3 };
     } in
     let d2 = { d1 with diag_id = "T0002"; diag_line = Some 10;
@@ -142,7 +143,8 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
       diag_id = "T1001"; diag_error_class = "contract_violation"; diag_severity = Error;
       diag_phase = Schema; diag_node_id = None; diag_node_lang = None;
       diag_file = Some "test.t"; diag_line = Some 5; diag_column = None;
-      diag_message = "Column 'x' expected double, got int"; diag_caused_by = [];
+      diag_message = "Column 'x' expected double, got int";
+      diag_expected = None; diag_actual = None; diag_caused_by = [];
       diag_suggested_fix = Cast { column = "x"; cast_to = "double"; target_node = None; file = Some "test.t"; line = Some 5 };
     } in
     let d2 = { d1 with diag_id = "T1002"; diag_line = Some 8;
@@ -167,7 +169,8 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
       diag_id = "T1003"; diag_error_class = "contract_violation"; diag_severity = Error;
       diag_phase = Schema; diag_node_id = None; diag_node_lang = None;
       diag_file = Some tmp_cast; diag_line = Some 3; diag_column = None;
-      diag_message = "type mismatch"; diag_caused_by = [];
+      diag_message = "type mismatch"; diag_expected = None; diag_actual = None;
+      diag_caused_by = [];
       diag_suggested_fix = Cast { column = "x"; cast_to = "double"; target_node = None; file = Some tmp_cast; line = Some 3 };
     } in
     let result = Fix.apply_fixes ~dry_run:false ~default_file:tmp_cast [d1] in


### PR DESCRIPTION
Add diag_expected and diag_actual (both string option) to the diagnostic type. These fields carry structured type information for contract violations, so agents can branch on specific types without parsing the human-readable message.

- diagnostics.ml: add fields to type, serialize as {kind, value} objects in diagnostic_to_yojson (Null when None)
- schema_check.ml: populate expected/actual with the expected and actual types in the contract_violation branch (6 constructor sites updated)
- env_check.ml, eval.ml: pass None for new fields (5+1 constructors)
- test_check.ml: new test verifying expected/actual roundtrip through JSON
- test_fix.ml: update all diagnostic record constructions
- docs/api-reference.md, docs/changelog.md: document new fields