### PR TITLE
feat(diagnostics): centralize error_class as OCaml variant type

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3311,6 +3311,8 @@ The `tier` field is derived from the deepest phase that produced diagnostics: pa
 
 Each diagnostic entry contains: `id`, `error_class`, `severity`, `phase`, `node`, `file`, `span`, `message`, `expected`, `actual`, `caused_by`, and `suggested_fix`.
 
+**`error_class` enum values:** `structural_error`, `name_error`, `arity_error`, `type_error`, `parse_error`, `file_error`, `key_error`, `index_error`, `value_error`, `runtime_error`, `division_by_zero`, `assertion_error`, `match_error`, `shell_error`, `aggregation_error`, `na_predicate_error`, `missing_artifact`, `generic_error`, `schema_mismatch`, `contract_violation`, `contract_unverifiable`, `missing_tproject`, `missing_package`, `missing_from_lockfile`, `nix_generation_error`, `nix_eval_error`, `invalid_expect_placement`, `na_warning`, `unknown_error`.
+
 **Examples:**
 
 ```bash

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,7 @@
 
 - **Tier 1 CLI (`t check <file>`)**: Structural pipeline validation without triggering Nix builds. Catches parse errors, DAG cycles, dangling node references, arity errors, and built-in name resolution. Exit codes: 0=clean, 1=wire error, 2=schema error, 3=env error.
 - **Tier 2 Schema Validation (`t check --schema`)**: Static column-name and type propagation through the pipeline DAG. Validates column references against inferred upstream schemas, checks `expect()` type contracts, and reports contract violations with `Cast` suggested fixes.
-- **Structured JSON Diagnostics (`--json`)**: Machine-readable output for all tiers, with `schema_version`, `status`, `phase`, `tier`, and per-diagnostic `error_class`, `severity`, `expected`, `actual`, `caused_by`, and `suggested_fix` fields. Designed for agent tooling.
+- **Structured JSON Diagnostics (`--json`)**: Machine-readable output for all tiers, with `schema_version`, `status`, `phase`, `tier`, and per-diagnostic `error_class` (stable enum), `severity`, `expected`, `actual`, `caused_by`, and `suggested_fix` fields. Designed for agent tooling.
 - **`t_check(file, json, schema, env)` REPL function**: Invoke `t check` from within a T session.
 
 ### `t diff` — Content-Addressed Output Diffing

--- a/src/check_utils.ml
+++ b/src/check_utils.ml
@@ -133,7 +133,7 @@ let format_check_result ?(json=false) check_result =
       Buffer.add_string buf
         (Printf.sprintf "%s [%s] %s\n"
            (Diagnostics.severity_to_string (Diagnostics.diagnostic_severity d))
-           (Diagnostics.diagnostic_error_class d)
+           (Diagnostics.error_class_to_string (Diagnostics.diagnostic_error_class d))
            (Diagnostics.diagnostic_message d))
     ) cr_diags;
     if cr_diags <> [] then Buffer.add_char buf '\n';

--- a/src/diagnostics.ml
+++ b/src/diagnostics.ml
@@ -5,6 +5,99 @@ type diagnostic_phase = Parse | Wire | Schema | Env | Build | Exec
 
 type severity = Error | Warning
 
+type error_class =
+  | Structural_error
+  | Name_error
+  | Arity_error
+  | Type_error
+  | Parse_error
+  | File_error
+  | Key_error
+  | Index_error
+  | Value_error
+  | Runtime_error
+  | Division_by_zero
+  | Assertion_error
+  | Match_error
+  | Shell_error
+  | Aggregation_error
+  | Na_predicate_error
+  | Missing_artifact
+  | Generic_error
+  | Schema_mismatch
+  | Contract_violation
+  | Contract_unverifiable
+  | Missing_tproject
+  | Missing_package
+  | Missing_from_lockfile
+  | Nix_generation_error
+  | Nix_eval_error
+  | Invalid_expect_placement
+  | Na_warning
+  | Unknown_error
+
+let error_class_to_string = function
+  | Structural_error -> "structural_error"
+  | Name_error -> "name_error"
+  | Arity_error -> "arity_error"
+  | Type_error -> "type_error"
+  | Parse_error -> "parse_error"
+  | File_error -> "file_error"
+  | Key_error -> "key_error"
+  | Index_error -> "index_error"
+  | Value_error -> "value_error"
+  | Runtime_error -> "runtime_error"
+  | Division_by_zero -> "division_by_zero"
+  | Assertion_error -> "assertion_error"
+  | Match_error -> "match_error"
+  | Shell_error -> "shell_error"
+  | Aggregation_error -> "aggregation_error"
+  | Na_predicate_error -> "na_predicate_error"
+  | Missing_artifact -> "missing_artifact"
+  | Generic_error -> "generic_error"
+  | Schema_mismatch -> "schema_mismatch"
+  | Contract_violation -> "contract_violation"
+  | Contract_unverifiable -> "contract_unverifiable"
+  | Missing_tproject -> "missing_tproject"
+  | Missing_package -> "missing_package"
+  | Missing_from_lockfile -> "missing_from_lockfile"
+  | Nix_generation_error -> "nix_generation_error"
+  | Nix_eval_error -> "nix_eval_error"
+  | Invalid_expect_placement -> "invalid_expect_placement"
+  | Na_warning -> "na_warning"
+  | Unknown_error -> "unknown_error"
+
+let error_class_of_string = function
+  | "structural_error" | "StructuralError" -> Structural_error
+  | "name_error" | "NameError" -> Name_error
+  | "arity_error" | "ArityError" -> Arity_error
+  | "type_error" | "TypeError" -> Type_error
+  | "parse_error" | "SyntaxError" -> Parse_error
+  | "file_error" | "FileError" -> File_error
+  | "key_error" | "KeyError" -> Key_error
+  | "index_error" | "IndexError" -> Index_error
+  | "value_error" | "ValueError" -> Value_error
+  | "runtime_error" | "RuntimeError" -> Runtime_error
+  | "division_by_zero" | "DivisionByZero" -> Division_by_zero
+  | "assertion_error" | "AssertionError" -> Assertion_error
+  | "match_error" | "MatchError" -> Match_error
+  | "shell_error" | "ShellError" -> Shell_error
+  | "aggregation_error" | "AggregationError" -> Aggregation_error
+  | "na_predicate_error" | "NAPredicateError" -> Na_predicate_error
+  | "missing_artifact" | "MissingArtifactError" -> Missing_artifact
+  | "generic_error" | "GenericError" -> Generic_error
+  | "schema_mismatch" -> Schema_mismatch
+  | "contract_violation" -> Contract_violation
+  | "contract_unverifiable" -> Contract_unverifiable
+  | "missing_tproject" -> Missing_tproject
+  | "missing_package" -> Missing_package
+  | "missing_from_lockfile" -> Missing_from_lockfile
+  | "nix_generation_error" -> Nix_generation_error
+  | "nix_eval_error" -> Nix_eval_error
+  | "invalid_expect_placement" -> Invalid_expect_placement
+  | "na_warning" | "NAExcluded" -> Na_warning
+  | _ -> Unknown_error
+
 type suggested_fix =
   | Cast of { column: string; cast_to: string; target_node: string option; file: string option; line: int option }
   | Rename_column of { old_name: string; new_name: string; target_node: string option; file: string option; line: int option }
@@ -14,7 +107,7 @@ type suggested_fix =
 
 type diagnostic = {
   diag_id : string;
-  diag_error_class : string;
+  diag_error_class : error_class;
   diag_severity : severity;
   diag_phase : diagnostic_phase;
   diag_node_id : string option;
@@ -157,7 +250,7 @@ let suggested_fix_of_yojson json =
 let diagnostic_to_yojson d =
   `Assoc [
     ("id", `String d.diag_id);
-    ("error_class", `String d.diag_error_class);
+    ("error_class", `String (error_class_to_string d.diag_error_class));
     ("severity", severity_to_yojson d.diag_severity);
     ("phase", phase_to_yojson d.diag_phase);
     ("node", (match d.diag_node_id with
@@ -205,24 +298,24 @@ let error_code_to_phase code =
 
 let error_code_to_error_class code =
   match code with
-  | Ast.StructuralError -> "structural_error"
-  | Ast.NameError -> "name_error"
-  | Ast.ArityError -> "arity_error"
-  | Ast.TypeError -> "type_error"
-  | Ast.SyntaxError -> "parse_error"
-  | Ast.FileError -> "file_error"
-  | Ast.KeyError -> "key_error"
-  | Ast.IndexError -> "index_error"
-  | Ast.ValueError -> "value_error"
-  | Ast.RuntimeError -> "runtime_error"
-  | Ast.DivisionByZero -> "division_by_zero"
-  | Ast.AssertionError -> "assertion_error"
-  | Ast.MatchError -> "match_error"
-  | Ast.ShellError -> "shell_error"
-  | Ast.AggregationError -> "aggregation_error"
-  | Ast.NAPredicateError -> "na_predicate_error"
-  | Ast.MissingArtifactError -> "missing_artifact"
-  | Ast.GenericError -> "generic_error"
+  | Ast.StructuralError -> Structural_error
+  | Ast.NameError -> Name_error
+  | Ast.ArityError -> Arity_error
+  | Ast.TypeError -> Type_error
+  | Ast.SyntaxError -> Parse_error
+  | Ast.FileError -> File_error
+  | Ast.KeyError -> Key_error
+  | Ast.IndexError -> Index_error
+  | Ast.ValueError -> Value_error
+  | Ast.RuntimeError -> Runtime_error
+  | Ast.DivisionByZero -> Division_by_zero
+  | Ast.AssertionError -> Assertion_error
+  | Ast.MatchError -> Match_error
+  | Ast.ShellError -> Shell_error
+  | Ast.AggregationError -> Aggregation_error
+  | Ast.NAPredicateError -> Na_predicate_error
+  | Ast.MissingArtifactError -> Missing_artifact
+  | Ast.GenericError -> Generic_error
 
 let extract_node_name_from_message msg =
   let patterns = [
@@ -292,7 +385,7 @@ let of_pipeline_result ?file (p : Ast.pipeline_result) : diagnostic list =
       | Some ne ->
           [{
             diag_id = gen_id ();
-            diag_error_class = ne.Ast.ne_kind;
+            diag_error_class = error_class_of_string ne.Ast.ne_kind;
             diag_severity = Error;
             diag_phase = Exec;
             diag_node_id = Some name;
@@ -316,9 +409,9 @@ let of_pipeline_result ?file (p : Ast.pipeline_result) : diagnostic list =
       else
         let diag_error_class, diag_phase =
           match nw.Ast.nw_kind with
-          | "invalid_expect_placement" -> nw.Ast.nw_kind, Wire
-          | "NAExcluded" -> "na_warning", Exec
-          | other -> other, Exec
+          | "invalid_expect_placement" -> Invalid_expect_placement, Wire
+          | "NAExcluded" -> Na_warning, Exec
+          | other -> error_class_of_string other, Exec
         in
         Some ({
           diag_id = gen_id ();

--- a/src/env_check.ml
+++ b/src/env_check.ml
@@ -30,7 +30,7 @@ let check_declared_requirements ~file ~tproject_path ~project_root ~tproject_cfg
     if has_any_requirements then
       [Diagnostics.{
         diag_id = Diagnostics.gen_id ();
-        diag_error_class = "missing_tproject";
+        diag_error_class = Missing_tproject;
         diag_severity = Error;
         diag_phase = Env;
         diag_node_id = None;
@@ -65,7 +65,7 @@ let check_declared_requirements ~file ~tproject_path ~project_root ~tproject_cfg
         List.iter (fun pkg ->
           missing_diags := Diagnostics.{
             diag_id = Diagnostics.gen_id ();
-            diag_error_class = "missing_package";
+            diag_error_class = Missing_package;
             diag_severity = Error;
             diag_phase = Env;
             diag_node_id = None;
@@ -107,7 +107,7 @@ let check_lockfile_consistency ~file ~tproject_cfg (p : Ast.pipeline_result) =
          List.map (fun pkg ->
            Diagnostics.{
              diag_id = Diagnostics.gen_id ();
-             diag_error_class = "missing_from_lockfile";
+             diag_error_class = Missing_from_lockfile;
              diag_severity = Error;
              diag_phase = Env;
              diag_node_id = None;
@@ -130,7 +130,7 @@ let check_nix_evaluation ?(offline = false) ~file (p : Ast.pipeline_result) =
   | Error msg ->
       [Diagnostics.{
         diag_id = Diagnostics.gen_id ();
-        diag_error_class = "nix_generation_error";
+        diag_error_class = Nix_generation_error;
         diag_severity = Error;
         diag_phase = Env;
         diag_node_id = None;
@@ -168,7 +168,7 @@ let check_nix_evaluation ?(offline = false) ~file (p : Ast.pipeline_result) =
       | Error msg ->
           [Diagnostics.{
             diag_id = Diagnostics.gen_id ();
-            diag_error_class = "nix_eval_error";
+            diag_error_class = Nix_eval_error;
             diag_severity = Error;
             diag_phase = Env;
             diag_node_id = None;

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -1933,7 +1933,7 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
     let make_mid_chain_warn () =
       [{ Diagnostics.
          diag_id = Diagnostics.gen_id ();
-         diag_error_class = "invalid_expect_placement";
+         diag_error_class = Invalid_expect_placement;
          diag_severity = Warning;
          diag_phase = Wire;
          diag_node_id = Some name;
@@ -2176,7 +2176,7 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
       List.iter (fun d ->
         match d.Diagnostics.diag_node_id with
         | Some node_name ->
-            let nw = { Ast.nw_kind = d.Diagnostics.diag_error_class;
+            let nw = { Ast.nw_kind = Diagnostics.error_class_to_string d.Diagnostics.diag_error_class;
                         nw_fn = "expect";
                         nw_na_count = 0;
                         nw_na_indices = [];

--- a/src/schema_check.ml
+++ b/src/schema_check.ml
@@ -232,7 +232,7 @@ let validate_col_refs ~node_name ~(file : string option) ~schema expr =
       if schema_has_col col schema then None
       else Some (Diagnostics.{
         diag_id = Diagnostics.gen_id ();
-        diag_error_class = "schema_mismatch";
+        diag_error_class = Schema_mismatch;
         diag_severity = Error;
         diag_phase = Schema;
         diag_node_id = Some node_name;
@@ -271,7 +271,7 @@ let validate_contracts ~file (p : pipeline_result) schemas =
           if missing <> [] then
             Some (Diagnostics.{
               diag_id = Diagnostics.gen_id ();
-              diag_error_class = "contract_violation";
+              diag_error_class = Contract_violation;
               diag_severity = Error;
               diag_phase = Schema;
               diag_node_id = Some node_name;
@@ -301,7 +301,7 @@ let validate_contracts ~file (p : pipeline_result) schemas =
                 (* Type unknown — emit warning, not error *)
                 Some (Diagnostics.{
                   diag_id = Diagnostics.gen_id ();
-                  diag_error_class = "contract_unverifiable";
+                  diag_error_class = Contract_unverifiable;
                   diag_severity = Warning;
                   diag_phase = Schema;
                   diag_node_id = Some node_name;
@@ -320,7 +320,7 @@ let validate_contracts ~file (p : pipeline_result) schemas =
                 if actual_type <> expected_type then
                   Some (Diagnostics.{
                     diag_id = Diagnostics.gen_id ();
-                    diag_error_class = "contract_violation";
+                    diag_error_class = Contract_violation;
                     diag_severity = Error;
                     diag_phase = Schema;
                     diag_node_id = Some node_name;
@@ -351,7 +351,7 @@ let validate_contracts ~file (p : pipeline_result) schemas =
           List.map (fun (col, threshold) ->
             Diagnostics.{
               diag_id = Diagnostics.gen_id ();
-              diag_error_class = "contract_unverifiable";
+              diag_error_class = Contract_unverifiable;
               diag_severity = Warning;
               diag_phase = Schema;
               diag_node_id = Some node_name;
@@ -500,7 +500,7 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
                     if not (schema_has_col var validation_schema) then
                       Some (Diagnostics.{
                         diag_id = Diagnostics.gen_id ();
-                        diag_error_class = "schema_mismatch";
+                        diag_error_class = Schema_mismatch;
                         diag_severity = Error;
                         diag_phase = Schema;
                         diag_node_id = Some name;

--- a/tests/test_check.ml
+++ b/tests/test_check.ml
@@ -40,7 +40,7 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
     end
   in
   check_eq "of_verror: error_class maps to structural_error"
-    (Diagnostics.diagnostic_error_class d) "structural_error";
+    (Diagnostics.error_class_to_string (Diagnostics.diagnostic_error_class d)) "structural_error";
   check_eq "of_verror: phase maps to Wire for StructuralError"
     (Diagnostics.phase_to_string (Diagnostics.diagnostic_phase d)) "wire";
   check_eq "of_verror: severity is Error"
@@ -112,7 +112,7 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
   (* Test accessor functions work correctly *)
   let test_diag = {
     Diagnostics.diag_id = "T0001";
-    diag_error_class = "test_error";
+    diag_error_class = Unknown_error;
     diag_severity = Diagnostics.Warning;
     diag_phase = Diagnostics.Exec;
     diag_node_id = Some "my_node";
@@ -131,7 +131,7 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
   check_eq "diagnostic_severity accessor"
     (Diagnostics.severity_to_string (Diagnostics.diagnostic_severity test_diag)) "warning";
   check_eq "diagnostic_error_class accessor"
-    (Diagnostics.diagnostic_error_class test_diag) "test_error";
+    (Diagnostics.error_class_to_string (Diagnostics.diagnostic_error_class test_diag)) "unknown_error";
   check_eq "diagnostic_message accessor"
     (Diagnostics.diagnostic_message test_diag) "test message";
 
@@ -303,7 +303,7 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
     | _ -> []
   in
   let e2e_has_warn = List.exists (fun d ->
-    d.Diagnostics.diag_error_class = "invalid_expect_placement"
+    d.Diagnostics.diag_error_class = Diagnostics.Invalid_expect_placement
     && d.Diagnostics.diag_phase = Diagnostics.Wire
   ) e2e_diags in
   check "of_pipeline_result surfaces invalid_expect_placement diagnostic" e2e_has_warn;
@@ -315,7 +315,7 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
     | _ -> []
   in
   let e2e_no_spurious = not (List.exists (fun d ->
-    d.Diagnostics.diag_error_class = "invalid_expect_placement"
+    d.Diagnostics.diag_error_class = Diagnostics.Invalid_expect_placement
   ) e2e_terminal_diags) in
   check "of_pipeline_result: no spurious diagnostic for terminal expect" e2e_no_spurious;
   Ast.check_mode := false;
@@ -462,7 +462,7 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
   let nr_is_warning = match nr_diags with
     | d :: _ ->
         d.Diagnostics.diag_severity = Diagnostics.Warning
-        && d.Diagnostics.diag_error_class = "contract_unverifiable"
+        && d.Diagnostics.diag_error_class = Diagnostics.Contract_unverifiable
     | [] -> false
   in
   check "null-rate contract: warning has contract_unverifiable class" nr_is_warning;

--- a/tests/test_fix.ml
+++ b/tests/test_fix.ml
@@ -96,7 +96,7 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
   Printf.printf "\nsort_fixes_by_descending_line:\n";
   let test_sort_fixes () =
     let d1 = { Diagnostics.
-      diag_id = "T0001"; diag_error_class = "contract_violation"; diag_severity = Error;
+      diag_id = "T0001"; diag_error_class = Diagnostics.Contract_violation; diag_severity = Error;
       diag_phase = Schema; diag_node_id = None; diag_node_lang = None;
       diag_file = Some "test.t"; diag_line = Some 3; diag_column = None;
       diag_message = "first"; diag_expected = None; diag_actual = None;
@@ -140,7 +140,7 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
   Printf.printf "\ndry-run counting:\n";
   let test_dry_run_counting () =
     let d1 = { Diagnostics.
-      diag_id = "T1001"; diag_error_class = "contract_violation"; diag_severity = Error;
+      diag_id = "T1001"; diag_error_class = Diagnostics.Contract_violation; diag_severity = Error;
       diag_phase = Schema; diag_node_id = None; diag_node_lang = None;
       diag_file = Some "test.t"; diag_line = Some 5; diag_column = None;
       diag_message = "Column 'x' expected double, got int";
@@ -166,7 +166,7 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
     output_string oc "clean = raw\n  |> read_csv(\"data.csv\")\n  |> expect(x = \"double\")\n";
     close_out oc;
     let d1 = { Diagnostics.
-      diag_id = "T1003"; diag_error_class = "contract_violation"; diag_severity = Error;
+      diag_id = "T1003"; diag_error_class = Diagnostics.Contract_violation; diag_severity = Error;
       diag_phase = Schema; diag_node_id = None; diag_node_lang = None;
       diag_file = Some tmp_cast; diag_line = Some 3; diag_column = None;
       diag_message = "type mismatch"; diag_expected = None; diag_actual = None;


### PR DESCRIPTION
Replace ~22 ad-hoc error_class string literals with a proper OCaml variant type (29 constructors). The spec requires a stable enum documented alongside the OCaml error variants for agent tooling.

- diagnostics.ml: define error_class variant type with 29 constructors, add error_class_to_string (snake_case) and error_class_of_string (handles both snake_case and CamelCase from runtime, falls back to Unknown_error)
- Change diag_error_class from string to error_class in diagnostic type
- error_code_to_error_class returns error_class variant directly
- diagnostic_to_yojson serializes via error_class_to_string
- of_pipeline_result converts ne_kind/nw_kind strings via error_class_of_string
- schema_check.ml: replace 6 string literals with variant constructors
- env_check.ml: replace 5 string literals
- eval.ml: replace 2 sites, fix circular dependency at line 2179
- check_utils.ml: wrap accessor with error_class_to_string
- test_check.ml, test_fix.ml: compare against variant constructors
- docs: list all valid enum values in api-reference.md