### PR TITLE
feat(fix): implement Add_node_arg fix application and generation

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3252,7 +3252,7 @@ result = t_diff("src/pipeline.t", json = true)
 
 ### `t_fix(file, dry_run = false)`
 
-REPL-callable version of `t fix`. Runs `t check --schema` on a file, extracts diagnostics with `suggested_fix`, and applies them mechanically (e.g., inserting `|> mutate($col = as.type($col))` for type contract violations).
+REPL-callable version of `t fix`. Runs `t check --schema` on a file, extracts diagnostics with `suggested_fix`, and applies them mechanically. Supports `Cast` (inserts `|> mutate(...)` for type contract violations), `Rename_column` (replaces `$old` with `$new`), and `Add_node_arg` (inserts missing arguments into node definitions, e.g., adding a `deserializer` for cross-runtime dependencies).
 
 **Arguments:**
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,10 +17,11 @@
 
 ### `t fix` — Mechanical Suggested-Fix Application
 
-- **`t fix <file>`**: Runs `t check --schema`, extracts diagnostics with `suggested_fix`, and applies them mechanically. Supports `Cast` (inserts `|> mutate(...)`) and `Rename_column` (replaces `$old` with `$new` in column references).
+- **`t fix <file>`**: Runs `t check --schema`, extracts diagnostics with `suggested_fix`, and applies them mechanically. Supports `Cast` (inserts `|> mutate(...)`), `Rename_column` (replaces `$old` with `$new` in column references), and `Add_node_arg` (inserts missing arguments into node definitions).
 - **`t_fix(file, dry_run)` REPL function**: Invoke `t fix` from within a T session.
 - **Word-boundary-safe rename**: Column renames only affect `$col` and `` $`col` `` forms, avoiding corruption of identifiers like `valid` when renaming `id`.
 - **`target_node` on `suggested_fix`**: `Cast`, `Rename_column`, and `Add_node_arg` fixes now include a `target_node` field indicating which pipeline node the fix applies to.
+- **Cross-runtime deserializer suggestion**: When a node depends on a node from a different runtime but has no explicit `deserializer`, `t check` now suggests adding `deserializer = ^csv` via an `Add_node_arg` fix.
 
 ### `t check` Environment Validation
 

--- a/src/diagnostics.ml
+++ b/src/diagnostics.ml
@@ -343,6 +343,16 @@ let extract_cycle_nodes msg =
     [Str.matched_group 1 msg]
   with Not_found -> []
 
+(** Extract the dependency node name from a cross-runtime deserializer error message.
+    e.g. "Node `pyn` (Python) depends on `rn` (R) but has no explicit deserializer."
+    returns Some "rn" *)
+let extract_dep_name_from_cross_runtime_error msg =
+  let re = Str.regexp "depends on `\\([^`]+\\)`" in
+  try
+    ignore (Str.search_forward re msg 0);
+    Some (Str.matched_group 1 msg)
+  with Not_found -> None
+
 let extract_caused_by_from_context context =
   List.filter_map (fun (k, v) ->
     match k, v with
@@ -363,6 +373,20 @@ let of_verror ?file (err : Ast.error_info) : diagnostic =
     | [] -> extract_cycle_nodes err.message
   in
   let suggested_fix = match err.code with
+    | StructuralError when
+        let is_cross_runtime =
+          try
+            let re = Str.regexp "depends on `[^`]+` (.*) but has no explicit deserializer" in
+            ignore (Str.search_forward re err.message 0); true
+          with Not_found -> false
+        in
+        is_cross_runtime ->
+        (match extract_dep_name_from_cross_runtime_error err.message with
+         | Some _dep ->
+             let arg = "deserializer = ^csv" in
+             Add_node_arg { node = (match node_name with Some n -> n | None -> "");
+                            arg; target_node = node_name; file; line = None }
+         | None -> NoFix)
     | _ -> NoFix
   in
   {

--- a/src/diagnostics.ml
+++ b/src/diagnostics.ml
@@ -343,14 +343,19 @@ let extract_cycle_nodes msg =
     [Str.matched_group 1 msg]
   with Not_found -> []
 
-(** Extract the dependency node name from a cross-runtime deserializer error message.
+(** Extract cross-runtime deserializer info from an error message.
     e.g. "Node `pyn` (Python) depends on `rn` (R) but has no explicit deserializer."
-    returns Some "rn" *)
-let extract_dep_name_from_cross_runtime_error msg =
-  let re = Str.regexp "depends on `\\([^`]+\\)`" in
+    returns Some ("R", "^csv") — the dep's runtime and the appropriate serializer format. *)
+let extract_cross_runtime_info msg =
+  let re = Str.regexp "depends on `\\([^`]+\\)` (\\([^)]+\\))" in
   try
     ignore (Str.search_forward re msg 0);
-    Some (Str.matched_group 1 msg)
+    let dep_runtime = Str.matched_group 2 msg in
+    let serializer = match dep_runtime with
+      | "Julia" -> "^arrow"
+      | _ -> "^csv"
+    in
+    Some (dep_runtime, serializer)
   with Not_found -> None
 
 let extract_caused_by_from_context context =
@@ -373,17 +378,10 @@ let of_verror ?file (err : Ast.error_info) : diagnostic =
     | [] -> extract_cycle_nodes err.message
   in
   let suggested_fix = match err.code with
-    | StructuralError when
-        let is_cross_runtime =
-          try
-            let re = Str.regexp "depends on `[^`]+` (.*) but has no explicit deserializer" in
-            ignore (Str.search_forward re err.message 0); true
-          with Not_found -> false
-        in
-        is_cross_runtime ->
-        (match extract_dep_name_from_cross_runtime_error err.message with
-         | Some _dep ->
-             let arg = "deserializer = ^csv" in
+    | StructuralError ->
+        (match extract_cross_runtime_info err.message with
+         | Some (_dep_runtime, serializer) ->
+             let arg = "deserializer = " ^ serializer in
              Add_node_arg { node = (match node_name with Some n -> n | None -> "");
                             arg; target_node = node_name; file; line = None }
          | None -> NoFix)

--- a/src/fix.ml
+++ b/src/fix.ml
@@ -83,20 +83,20 @@ let apply_rename_column ~file ~old_name ~new_name =
 let apply_add_node_arg ~file ~node ~arg =
   let lines = ref [] in
   let ch = open_in file in
-  Fun.protect ~finally:(fun () -> close_in_noerr ch)
+  let result = Fun.protect ~finally:(fun () -> close_in_noerr ch)
     (fun () ->
-       let i = ref 1 in
        let found = ref false in
        let paren_depth = ref 0 in
-        let in_raw_code = ref false in
-        try
-           while true do
+       let in_raw_code = ref false in
+       let last_arg_indent = ref 0 in
+       let prev_line = ref "" in
+       (try
+          while true do
             let l = input_line ch in
             if not !found then begin
-              (* Look for "node_name = " followed by a node function call *)
               let trimmed = String.trim l in
               let prefix = node ^ " = " in
-              if String.length trimmed > String.length prefix
+              if String.length trimmed >= String.length prefix
                  && String.sub trimmed 0 (String.length prefix) = prefix then begin
                 let rest = String.sub trimmed (String.length prefix) (String.length trimmed - String.length prefix) in
                 let rest_stripped = String.trim rest in
@@ -105,31 +105,27 @@ let apply_add_node_arg ~file ~node ~arg =
                     && rest_stripped.[String.length fn] = '(')
                     ["node"; "pyn"; "rn"; "jln"; "qn"; "shn"] then begin
                   found := true;
-                  (* Count parens on this line *)
                   String.iter (function
                     | '(' when not !in_raw_code -> incr paren_depth
                     | ')' when not !in_raw_code -> decr paren_depth
-                    | '<' -> () (* will track <{ >} below *)
                     | _ -> ()) l;
-                  (* Track <{ >} raw code blocks *)
                   if String.length l >= 2 then
                     for k = 0 to String.length l - 2 do
                       if l.[k] = '<' && l.[k+1] = '{' then in_raw_code := true;
                       if l.[k] = '}' && l.[k+1] = '>' then in_raw_code := false
                     done;
+                  prev_line := l;
                   lines := l :: !lines
                 end else
                   lines := l :: !lines
               end else
                 lines := l :: !lines
             end else begin
-              (* Inside the node call — track parens and look for closing `)` at depth 0 *)
               if not !in_raw_code then begin
                 String.iter (function
                   | '(' -> incr paren_depth
                   | ')' -> decr paren_depth
                   | _ -> ()) l;
-                (* Track <{ >} raw code blocks *)
                 if String.length l >= 2 then
                   for k = 0 to String.length l - 2 do
                     if l.[k] = '<' && l.[k+1] = '{' then in_raw_code := true;
@@ -143,25 +139,38 @@ let apply_add_node_arg ~file ~node ~arg =
                   done;
               end;
               if !paren_depth = 0 && not !in_raw_code then begin
-                (* This line has the closing `)` — insert arg before it *)
-                let indent =
+                let trimmed_prev = String.trim !prev_line in
+                if String.length trimmed_prev > 0 then begin
+                  let last_char = trimmed_prev.[String.length trimmed_prev - 1] in
+                  if last_char <> ',' && last_char <> '(' then begin
+                    lines := (!prev_line ^ ",") :: List.tl !lines
+                  end
+                end;
+                let pad = String.make !last_arg_indent ' ' in
+                lines := l :: Printf.sprintf "%s%s" pad arg :: !lines
+              end else begin
+                let trimmed_l = String.trim l in
+                if trimmed_l <> "" && trimmed_l.[0] <> '-' then begin
                   let rec count s n =
                     if n < String.length s && s.[n] = ' ' then count s (n + 1) else n
                   in
-                  count l 0
-                in
-                let pad = String.make indent ' ' in
-                lines := l :: Printf.sprintf "%s%s" pad arg :: !lines
-              end else
+                  last_arg_indent := count l 0
+                end;
+                prev_line := l;
                 lines := l :: !lines
-            end;
-            incr i
+              end
+            end
           done
         with End_of_file -> ());
-  let oc = open_out file in
-  Fun.protect ~finally:(fun () -> close_out_noerr oc)
-    (fun () ->
-       List.iter (fun l -> output_string oc (l ^ "\n")) (List.rev !lines))
+       !found)
+  in
+  if result then begin
+    let oc = open_out file in
+    Fun.protect ~finally:(fun () -> close_out_noerr oc)
+      (fun () ->
+         List.iter (fun l -> output_string oc (l ^ "\n")) (List.rev !lines))
+  end;
+  result
 
 let apply_fix ~file (fix : Diagnostics.suggested_fix) =
   match fix with
@@ -172,7 +181,7 @@ let apply_fix ~file (fix : Diagnostics.suggested_fix) =
   | Rename_column { old_name; new_name; file = _; line = _; target_node = _ } ->
       apply_rename_column ~file ~old_name ~new_name; true
   | Add_node_arg { node; arg; file = _; line = _; target_node = _ } ->
-      apply_add_node_arg ~file ~node ~arg; true
+      apply_add_node_arg ~file ~node ~arg
   | Pin_package_version _ -> false
   | NoFix -> false
 

--- a/src/fix.ml
+++ b/src/fix.ml
@@ -80,6 +80,89 @@ let apply_rename_column ~file ~old_name ~new_name =
   Fun.protect ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc content)
 
+let apply_add_node_arg ~file ~node ~arg =
+  let lines = ref [] in
+  let ch = open_in file in
+  Fun.protect ~finally:(fun () -> close_in_noerr ch)
+    (fun () ->
+       let i = ref 1 in
+       let found = ref false in
+       let paren_depth = ref 0 in
+        let in_raw_code = ref false in
+        try
+           while true do
+            let l = input_line ch in
+            if not !found then begin
+              (* Look for "node_name = " followed by a node function call *)
+              let trimmed = String.trim l in
+              let prefix = node ^ " = " in
+              if String.length trimmed > String.length prefix
+                 && String.sub trimmed 0 (String.length prefix) = prefix then begin
+                let rest = String.sub trimmed (String.length prefix) (String.length trimmed - String.length prefix) in
+                let rest_stripped = String.trim rest in
+                if List.exists (fun fn -> String.length rest_stripped >= String.length fn + 1
+                    && String.sub rest_stripped 0 (String.length fn) = fn
+                    && rest_stripped.[String.length fn] = '(')
+                    ["node"; "pyn"; "rn"; "jln"; "qn"; "shn"] then begin
+                  found := true;
+                  (* Count parens on this line *)
+                  String.iter (function
+                    | '(' when not !in_raw_code -> incr paren_depth
+                    | ')' when not !in_raw_code -> decr paren_depth
+                    | '<' -> () (* will track <{ >} below *)
+                    | _ -> ()) l;
+                  (* Track <{ >} raw code blocks *)
+                  if String.length l >= 2 then
+                    for k = 0 to String.length l - 2 do
+                      if l.[k] = '<' && l.[k+1] = '{' then in_raw_code := true;
+                      if l.[k] = '}' && l.[k+1] = '>' then in_raw_code := false
+                    done;
+                  lines := l :: !lines
+                end else
+                  lines := l :: !lines
+              end else
+                lines := l :: !lines
+            end else begin
+              (* Inside the node call — track parens and look for closing `)` at depth 0 *)
+              if not !in_raw_code then begin
+                String.iter (function
+                  | '(' -> incr paren_depth
+                  | ')' -> decr paren_depth
+                  | _ -> ()) l;
+                (* Track <{ >} raw code blocks *)
+                if String.length l >= 2 then
+                  for k = 0 to String.length l - 2 do
+                    if l.[k] = '<' && l.[k+1] = '{' then in_raw_code := true;
+                    if l.[k] = '}' && l.[k+1] = '>' then in_raw_code := false
+                  done;
+              end else begin
+                if String.length l >= 2 then
+                  for k = 0 to String.length l - 2 do
+                    if l.[k] = '<' && l.[k+1] = '{' then in_raw_code := true;
+                    if l.[k] = '}' && l.[k+1] = '>' then in_raw_code := false
+                  done;
+              end;
+              if !paren_depth = 0 && not !in_raw_code then begin
+                (* This line has the closing `)` — insert arg before it *)
+                let indent =
+                  let rec count s n =
+                    if n < String.length s && s.[n] = ' ' then count s (n + 1) else n
+                  in
+                  count l 0
+                in
+                let pad = String.make indent ' ' in
+                lines := l :: Printf.sprintf "%s%s" pad arg :: !lines
+              end else
+                lines := l :: !lines
+            end;
+            incr i
+          done
+        with End_of_file -> ());
+  let oc = open_out file in
+  Fun.protect ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+       List.iter (fun l -> output_string oc (l ^ "\n")) (List.rev !lines))
+
 let apply_fix ~file (fix : Diagnostics.suggested_fix) =
   match fix with
   | Cast { column; cast_to; file = _; line; target_node = _ } ->
@@ -88,7 +171,8 @@ let apply_fix ~file (fix : Diagnostics.suggested_fix) =
        | None -> false)
   | Rename_column { old_name; new_name; file = _; line = _; target_node = _ } ->
       apply_rename_column ~file ~old_name ~new_name; true
-  | Add_node_arg _ -> false
+  | Add_node_arg { node; arg; file = _; line = _; target_node = _ } ->
+      apply_add_node_arg ~file ~node ~arg; true
   | Pin_package_version _ -> false
   | NoFix -> false
 
@@ -117,6 +201,7 @@ let apply_fixes ~dry_run ~default_file (fixes : Diagnostics.diagnostic list) =
       let would_work = match d.diag_suggested_fix with
         | Diagnostics.Cast { line = Some _; _ } -> true
         | Diagnostics.Rename_column _ -> true
+        | Diagnostics.Add_node_arg _ -> true
         | _ -> false
       in
       if would_work then incr would_apply else incr skipped

--- a/tests/test_check.ml
+++ b/tests/test_check.ml
@@ -201,11 +201,41 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
   let cross_diag = Diagnostics.of_verror cross_runtime_err in
   (match cross_diag.Diagnostics.diag_suggested_fix with
    | Diagnostics.Add_node_arg { node; arg; target_node = _; _ } ->
-       check_eq "cross-runtime: node name extracted" node "pyn";
-       check_eq "cross-runtime: arg is deserializer" arg "deserializer = ^csv"
-   | _ -> check "cross-runtime: generates Add_node_arg" false);
+       check_eq "cross-runtime (R dep): node name extracted" node "pyn";
+       check_eq "cross-runtime (R dep): arg uses ^csv" arg "deserializer = ^csv"
+   | _ -> check "cross-runtime (R dep): generates Add_node_arg" false);
   check_eq "cross-runtime: error class is structural_error"
     (Diagnostics.error_class_to_string cross_diag.Diagnostics.diag_error_class) "structural_error";
+
+  let julia_msg = "Node `rn` (R) depends on `jln` (Julia) but has no explicit deserializer." in
+  let julia_err = { Ast.
+    code = StructuralError;
+    message = julia_msg;
+    context = [];
+    location = None;
+    na_count = 0;
+  } in
+  let julia_diag = Diagnostics.of_verror julia_err in
+  (match julia_diag.Diagnostics.diag_suggested_fix with
+   | Diagnostics.Add_node_arg { node; arg; _ } ->
+       check_eq "cross-runtime (Julia dep): node name" node "rn";
+       check_eq "cross-runtime (Julia dep): arg uses ^arrow" arg "deserializer = ^arrow"
+   | _ -> check "cross-runtime (Julia dep): generates Add_node_arg" false);
+
+  let py_msg = "Node `jln` (Julia) depends on `pyn` (Python) but has no explicit deserializer." in
+  let py_err = { Ast.
+    code = StructuralError;
+    message = py_msg;
+    context = [];
+    location = None;
+    na_count = 0;
+  } in
+  let py_diag = Diagnostics.of_verror py_err in
+  (match py_diag.Diagnostics.diag_suggested_fix with
+   | Diagnostics.Add_node_arg { arg; _ } ->
+       check_eq "cross-runtime (Python dep): arg uses ^csv" arg "deserializer = ^csv"
+   | _ -> check "cross-runtime (Python dep): generates Add_node_arg" false);
+
   let non_cross_msg = "Some other structural error" in
   let non_cross_err = { Ast.
     code = StructuralError;

--- a/tests/test_check.ml
+++ b/tests/test_check.ml
@@ -189,6 +189,36 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
   check_eq "error_class_of_string: snake_case structural_error maps to Structural_error"
     (Diagnostics.error_class_to_string (Diagnostics.error_class_of_string "structural_error")) "structural_error";
 
+  Printf.printf "\nAdd_node_arg generation:\n";
+  let cross_runtime_msg = "Node `pyn` (Python) depends on `rn` (R) but has no explicit deserializer." in
+  let cross_runtime_err = { Ast.
+    code = StructuralError;
+    message = cross_runtime_msg;
+    context = [];
+    location = None;
+    na_count = 0;
+  } in
+  let cross_diag = Diagnostics.of_verror cross_runtime_err in
+  (match cross_diag.Diagnostics.diag_suggested_fix with
+   | Diagnostics.Add_node_arg { node; arg; target_node = _; _ } ->
+       check_eq "cross-runtime: node name extracted" node "pyn";
+       check_eq "cross-runtime: arg is deserializer" arg "deserializer = ^csv"
+   | _ -> check "cross-runtime: generates Add_node_arg" false);
+  check_eq "cross-runtime: error class is structural_error"
+    (Diagnostics.error_class_to_string cross_diag.Diagnostics.diag_error_class) "structural_error";
+  let non_cross_msg = "Some other structural error" in
+  let non_cross_err = { Ast.
+    code = StructuralError;
+    message = non_cross_msg;
+    context = [];
+    location = None;
+    na_count = 0;
+  } in
+  let non_cross_diag = Diagnostics.of_verror non_cross_err in
+  (match non_cross_diag.Diagnostics.diag_suggested_fix with
+   | Diagnostics.NoFix -> check "non-cross-runtime: no fix suggested" true
+   | _ -> check "non-cross-runtime: should be NoFix" false);
+
   Printf.printf "\nSchema check module:\n";
 
   (* Set up temp fixture for read_csv_header test *)

--- a/tests/test_fix.ml
+++ b/tests/test_fix.ml
@@ -80,6 +80,42 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
   in
   test_roundtrip ();
 
+  Printf.printf "\napply_add_node_arg:\n";
+  let test_apply_add_node_arg () =
+    let tmp = Filename.temp_file "test_fix_add_arg" ".t" in
+    let oc = open_out tmp in
+    output_string oc "raw = node(\n  command = read_csv(\"data.csv\"),\n  runtime = T\n)\n";
+    close_out oc;
+    Fix.apply_add_node_arg ~file:tmp ~node:"raw" ~arg:"serializer = ^csv";
+    let ch = open_in tmp in
+    let content = really_input_string ch (in_channel_length ch) in
+    close_in ch;
+    Sys.remove tmp;
+    let has_serializer = (try let _ = Str.search_forward (Str.regexp_string "serializer = ^csv") content 0 in true with Not_found -> false) in
+    check "add_node_arg inserts serializer before closing )" has_serializer;
+    let has_runtime = (try let _ = Str.search_forward (Str.regexp_string "runtime = T") content 0 in true with Not_found -> false) in
+    check "add_node_arg preserves existing arguments" has_runtime
+  in
+  test_apply_add_node_arg ();
+
+  Printf.printf "\napply_add_node_arg (pyn):\n";
+  let test_apply_add_node_arg_pyn () =
+    let tmp = Filename.temp_file "test_fix_add_arg_pyn" ".t" in
+    let oc = open_out tmp in
+    output_string oc "calc = pyn(\n  command = <{\ndf = raw.copy()\ndf\n  }>,\n  runtime = Python\n)\n";
+    close_out oc;
+    Fix.apply_add_node_arg ~file:tmp ~node:"calc" ~arg:"deserializer = ^csv";
+    let ch = open_in tmp in
+    let content = really_input_string ch (in_channel_length ch) in
+    close_in ch;
+    Sys.remove tmp;
+    let has_deser = (try let _ = Str.search_forward (Str.regexp_string "deserializer = ^csv") content 0 in true with Not_found -> false) in
+    check "add_node_arg works for pyn with raw code block" has_deser;
+    let has_raw_code = (try let _ = Str.search_forward (Str.regexp_string "df = raw.copy()") content 0 in true with Not_found -> false) in
+    check "add_node_arg preserves raw code block" has_raw_code
+  in
+  test_apply_add_node_arg_pyn ();
+
   Printf.printf "\napply_fix dispatch:\n";
   let test_apply_fix_noop () =
     let r = Fix.apply_fix ~file:"/dev/null" Diagnostics.NoFix in
@@ -88,8 +124,18 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
   test_apply_fix_noop ();
 
   let test_apply_fix_node_arg () =
-    let r = Fix.apply_fix ~file:"/dev/null" (Diagnostics.Add_node_arg { node = "x"; arg = "y"; target_node = None; file = None; line = None }) in
-    check "apply_fix returns false for Add_node_arg (unimplemented)" (r = false)
+    let tmp = Filename.temp_file "test_fix_dispatch_arg" ".t" in
+    let oc = open_out tmp in
+    output_string oc "raw = node(\n  command = read_csv(\"data.csv\"),\n  runtime = T\n)\n";
+    close_out oc;
+    let r = Fix.apply_fix ~file:tmp (Diagnostics.Add_node_arg { node = "raw"; arg = "serializer = ^csv"; target_node = Some "raw"; file = Some tmp; line = None }) in
+    let ch = open_in tmp in
+    let content = really_input_string ch (in_channel_length ch) in
+    close_in ch;
+    Sys.remove tmp;
+    check "apply_fix returns true for Add_node_arg" (r = true);
+    let has_serializer = (try let _ = Str.search_forward (Str.regexp_string "serializer = ^csv") content 0 in true with Not_found -> false) in
+    check "apply_fix patches file for Add_node_arg" has_serializer
   in
   test_apply_fix_node_arg ();
 
@@ -153,10 +199,14 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
       diag_message = "Column 'y' expected string, got int";
       diag_suggested_fix = Cast { column = "y"; cast_to = "string"; target_node = None; file = Some "test.t"; line = Some 8 };
     } in
-    let fixes = [d1; d2] in
+    let d3 = { d1 with diag_id = "T1003"; diag_line = Some 12;
+      diag_message = "Node `pyn` depends on `rn` but has no explicit deserializer";
+      diag_suggested_fix = Add_node_arg { node = "pyn"; arg = "deserializer = ^csv"; target_node = Some "pyn"; file = Some "test.t"; line = None };
+    } in
+    let fixes = [d1; d2; d3] in
     let result = Fix.apply_fixes ~dry_run:true ~default_file:"test.t" fixes in
     check "dry_run: applied = 0" (result.Fix.applied = 0);
-    check "dry_run: would_apply = 2" (result.Fix.would_apply = 2);
+    check "dry_run: would_apply = 3" (result.Fix.would_apply = 3);
     check "dry_run: skipped = 0" (result.Fix.skipped = 0)
   in
   test_dry_run_counting ();

--- a/tests/test_fix.ml
+++ b/tests/test_fix.ml
@@ -86,15 +86,19 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
     let oc = open_out tmp in
     output_string oc "raw = node(\n  command = read_csv(\"data.csv\"),\n  runtime = T\n)\n";
     close_out oc;
-    Fix.apply_add_node_arg ~file:tmp ~node:"raw" ~arg:"serializer = ^csv";
+    let r = Fix.apply_add_node_arg ~file:tmp ~node:"raw" ~arg:"serializer = ^csv" in
+    check "add_node_arg returns true when node found" r;
     let ch = open_in tmp in
     let content = really_input_string ch (in_channel_length ch) in
     close_in ch;
-    Sys.remove tmp;
     let has_serializer = (try let _ = Str.search_forward (Str.regexp_string "serializer = ^csv") content 0 in true with Not_found -> false) in
-    check "add_node_arg inserts serializer before closing )" has_serializer;
-    let has_runtime = (try let _ = Str.search_forward (Str.regexp_string "runtime = T") content 0 in true with Not_found -> false) in
-    check "add_node_arg preserves existing arguments" has_runtime
+    check "add_node_arg inserts serializer" has_serializer;
+    let has_comma_before = (try let _ = Str.search_forward (Str.regexp "runtime = T,") content 0 in true with Not_found -> false) in
+    check "add_node_arg adds comma to previous arg" has_comma_before;
+    let indent_re = Str.regexp "\\( +\\)serializer" in
+    let indent = (try ignore (Str.search_forward indent_re content 0); Str.matched_group 1 content with Not_found -> "") in
+    check "add_node_arg matches sibling indentation" (indent = "  ");
+    Sys.remove tmp
   in
   test_apply_add_node_arg ();
 
@@ -104,17 +108,41 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
     let oc = open_out tmp in
     output_string oc "calc = pyn(\n  command = <{\ndf = raw.copy()\ndf\n  }>,\n  runtime = Python\n)\n";
     close_out oc;
-    Fix.apply_add_node_arg ~file:tmp ~node:"calc" ~arg:"deserializer = ^csv";
+    let r = Fix.apply_add_node_arg ~file:tmp ~node:"calc" ~arg:"deserializer = ^csv" in
+    check "add_node_arg returns true for pyn" r;
     let ch = open_in tmp in
     let content = really_input_string ch (in_channel_length ch) in
     close_in ch;
-    Sys.remove tmp;
     let has_deser = (try let _ = Str.search_forward (Str.regexp_string "deserializer = ^csv") content 0 in true with Not_found -> false) in
     check "add_node_arg works for pyn with raw code block" has_deser;
     let has_raw_code = (try let _ = Str.search_forward (Str.regexp_string "df = raw.copy()") content 0 in true with Not_found -> false) in
-    check "add_node_arg preserves raw code block" has_raw_code
+    check "add_node_arg preserves raw code block" has_raw_code;
+    let has_comma_before = (try let _ = Str.search_forward (Str.regexp "runtime = Python,") content 0 in true with Not_found -> false) in
+    check "add_node_arg adds comma before deserializer (pyn)" has_comma_before;
+    Sys.remove tmp
   in
   test_apply_add_node_arg_pyn ();
+
+  Printf.printf "\napply_add_node_arg not found:\n";
+  let test_apply_add_node_arg_not_found () =
+    let tmp = Filename.temp_file "test_fix_add_arg_miss" ".t" in
+    let oc = open_out tmp in
+    output_string oc "other = node(\n  command = read_csv(\"data.csv\")\n)\n";
+    close_out oc;
+    let original_content =
+      let ch = open_in tmp in
+      let c = really_input_string ch (in_channel_length ch) in
+      close_in ch; c
+    in
+    let r = Fix.apply_add_node_arg ~file:tmp ~node:"nonexistent" ~arg:"serializer = ^csv" in
+    check "add_node_arg returns false when node not found" (r = false);
+    let ch = open_in tmp in
+    let content = really_input_string ch (in_channel_length ch) in
+    close_in ch;
+    check "add_node_arg does not modify file when node not found" (content = original_content);
+    Sys.remove tmp
+  in
+  test_apply_add_node_arg_not_found ();
 
   Printf.printf "\napply_fix dispatch:\n";
   let test_apply_fix_noop () =
@@ -133,11 +161,24 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
     let content = really_input_string ch (in_channel_length ch) in
     close_in ch;
     Sys.remove tmp;
-    check "apply_fix returns true for Add_node_arg" (r = true);
+    check "apply_fix returns true for Add_node_arg" r;
     let has_serializer = (try let _ = Str.search_forward (Str.regexp_string "serializer = ^csv") content 0 in true with Not_found -> false) in
-    check "apply_fix patches file for Add_node_arg" has_serializer
+    check "apply_fix patches file for Add_node_arg" has_serializer;
+    let has_comma = (try let _ = Str.search_forward (Str.regexp "runtime = T,") content 0 in true with Not_found -> false) in
+    check "apply_fix produces valid comma separation" has_comma
   in
   test_apply_fix_node_arg ();
+
+  let test_apply_fix_node_arg_not_found () =
+    let tmp = Filename.temp_file "test_fix_dispatch_miss" ".t" in
+    let oc = open_out tmp in
+    output_string oc "other = node(\n  command = read_csv(\"data.csv\")\n)\n";
+    close_out oc;
+    let r = Fix.apply_fix ~file:tmp (Diagnostics.Add_node_arg { node = "nonexistent"; arg = "serializer = ^csv"; target_node = None; file = Some tmp; line = None }) in
+    Sys.remove tmp;
+    check "apply_fix returns false for non-existent node" (r = false)
+  in
+  test_apply_fix_node_arg_not_found ();
 
   Printf.printf "\nsort_fixes_by_descending_line:\n";
   let test_sort_fixes () =


### PR DESCRIPTION
Implement the mechanical application of Add_node_arg suggested fixes:
- apply_add_node_arg finds a node definition by name in a .t file, locates the closing paren of the node call (handling multi-line <{ ... }> raw code blocks), and inserts the argument before it.
- apply_fix dispatch now calls apply_add_node_arg instead of returning false. Dry-run counting recognizes Add_node_arg as applicable.

Wire up Add_node_arg diagnostic generation:
- of_verror now detects cross-runtime deserializer errors (e.g., 'Node pyn depends on rn but has no explicit deserializer') and generates an Add_node_arg fix suggesting 'deserializer = ^csv'.
- Added extract_dep_name_from_cross_runtime_error helper in diagnostics.ml.

Tests:
- test_apply_add_node_arg: multi-line node() with closing paren on its own line
- test_apply_add_node_arg_pyn: node with <{ ... }> raw code block
- test_apply_fix_node_arg: apply_fix dispatch returns true and patches file
- test_cross_runtime_generation: of_verror generates Add_node_arg for cross-runtime errors, NoFix for other StructuralErrors
- Updated dry-run counting test to include Add_node_arg

Docs: updated changelog and api-reference.md.