### PR TITLE
perf(tests): cache shared Packages.init_env() across test runs

### DIFF
--- a/tests/test_runner.ml
+++ b/tests/test_runner.ml
@@ -9,11 +9,12 @@ let failures = ref []
 let () =
   Eval.show_warnings := false
 
+let shared_env = Packages.init_env ()
+
 let eval_string input =
-  let env = Packages.init_env () in
   let lexbuf = Lexing.from_string input in
   let program = Parser.program Lexer.token lexbuf in
-  let (result, _env) = Eval.eval_program ~resilient:false program env in
+  let (result, _env) = Eval.eval_program ~resilient:false program shared_env in
   result
 
 let eval_string_env input env =


### PR DESCRIPTION
Env.t is Map.Make(String) — immutable. eval_program returns a new map without mutating the input. Caching the base env avoids calling Packages.init_env() ~1500 times during the test suite.