### PR TITLE
feat(cli): add t explain --node command supporting JSON and plain-tex…

### DIFF
--- a/agents/agents-project.md
+++ b/agents/agents-project.md
@@ -88,7 +88,7 @@ p = pipeline {
 | **Sync Environment** | `t update` |
 | **Run Analysis** | `t run src/pipeline.t` |
 | **Run Tests** | `t test` |
-| **Debug a Node** | `t explain --node name` |
+| **Debug a Node** | `t explain --node p.name` (add `--json` for machine-readable JSON) |
 | **Check Health** | `t doctor` |
 | **Schema Check** | `t check --schema src/pipeline.t` |
 | **Inspect Node** | `t run --unsafe src/view.t` (with `t_make()` + `glimpse(read_node(p.name))`) |

--- a/agents/skill-t-project.md
+++ b/agents/skill-t-project.md
@@ -143,8 +143,9 @@ warning_msg(p.clean_data)
 # Structural check (milliseconds, no Nix builds)
 t check --schema src/pipeline.t
 
-# Explain a specific node's diagnostics
-t explain --node clean_data
+# Explain a specific node's diagnostics (use --json for agent-readable output)
+t explain --node p.clean_data
+t explain --json --node p.clean_data
 
 # Catch environment drift
 t doctor

--- a/agents/skill-t-project.md
+++ b/agents/skill-t-project.md
@@ -154,6 +154,7 @@ t doctor
 ### Gotchas
 
 - **`read_node` requires dot access:** Use `read_node(p.node_name)` — the string form `read_node("name")` throws a TypeError.
+- **`t explain --node` requires explicit prefix:** You must specify `t explain --node <pipeline_var>.<node_name>` (e.g. `p.clean_data`). Omitting the prefix or using a non-existent variable name will result in an error.
 - **`read_node` before build:** If the pipeline hasn't been built, `read_node` errors. Use `build_pipeline(p)` first, or `read_past_node(p.node_name, which_log = "...")` for historical builds.
 - **Non-pipeline scripts:** Scripts without a `pipeline { }` block need `t run --unsafe` (e.g., `t run --unsafe src/view.t`).
 - **Resilient errors:** T nodes return `Error` values rather than raising exceptions. A run can complete while carrying an error downstream. Check `is_error()` on outputs.

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -857,15 +857,117 @@ let cmd_init_project args =
 
 let cmd_explain ?failfast mode rest env =
   Packages.ensure_docs_loaded ();
-  let expr_str = String.concat " " (List.filter (fun s -> s <> "--json") rest) in
-  if expr_str = "" then (Printf.eprintf "Usage: t explain <expr>\n"; exit 1)
-  else begin
-    let (result, env') = parse_and_eval ?failfast mode env expr_str in
-    let explain_expr = "explain(__explain_target__)" in
-    let env'' = Ast.Env.add "__explain_target__" result env' in
-    let (explain_result, _) = parse_and_eval ?failfast mode env'' explain_expr in
-    print_string (Pretty_print.pretty_print_value explain_result)
-  end
+  let json = List.mem "--json" rest in
+  let rec get_node_arg = function
+    | [] -> None
+    | "--node" :: v :: _ -> Some v
+    | _ :: xs -> get_node_arg xs
+  in
+  match get_node_arg rest with
+  | Some node_arg ->
+      let pipeline_var, node_name =
+        match String.split_on_char '.' node_arg with
+        | [n] -> ("p", n)
+        | [v; n] -> (v, n)
+        | _ -> Printf.eprintf "Error: Invalid --node format. Expected <pipeline_var>.<node_name> or <node_name>.\n"; exit 1
+      in
+      let remaining = List.filter (fun s -> s <> "--json" && s <> "--node" && s <> node_arg) rest in
+      let filename =
+        match remaining with
+        | [] -> "src/pipeline.t"
+        | [f] -> f
+        | _ -> Printf.eprintf "Usage: t explain --node <pipeline_var>.<node_name> [pipeline.t]\n"; exit 1
+      in
+      if not (Sys.file_exists filename) then begin
+        Printf.eprintf "Error: File '%s' not found.\n" filename;
+        exit 1
+      end;
+      let old_check_mode = !Ast.check_mode in
+      Ast.check_mode := true;
+      (try
+         let (_, env_val) = Check_utils.run_file ?failfast mode filename env in
+         Ast.check_mode := old_check_mode;
+         let pipeline_opt =
+           match Ast.Env.find_opt pipeline_var env_val with
+           | Some (Ast.VPipeline p) -> Some p
+           | _ ->
+               (* Fallback: search for any pipeline in the environment *)
+               let found = ref None in
+               Ast.Env.iter (fun _name value ->
+                 match value with
+                 | Ast.VPipeline p -> found := Some p
+                 | _ -> ()
+               ) env_val;
+               !found
+         in
+         match pipeline_opt with
+         | None ->
+             Printf.eprintf "Error: Pipeline variable '%s' not found or is not a Pipeline.\n" pipeline_var;
+             exit 1
+         | Some p ->
+             let diagnostics_map = Builder_read_node.merge_pipeline_node_diagnostics_with_latest_log p in
+             match List.assoc_opt node_name diagnostics_map with
+             | None ->
+                 Printf.eprintf "Error: Node '%s' not found in the pipeline.\n" node_name;
+                 exit 1
+             | Some d ->
+                 if json then begin
+                   let error_block =
+                     match d.nd_error with
+                     | Some err ->
+                         let fn_str =
+                           if err.ne_fn <> "" then Printf.sprintf ", \"function\": \"%s\"" (Serialization.json_escape err.ne_fn)
+                           else ""
+                         in
+                         Printf.sprintf "\"status\": \"failed\", \"error_code\": \"%s\", \"message\": \"%s\"%s"
+                           (Serialization.json_escape err.ne_kind)
+                           (Serialization.json_escape err.ne_message)
+                           fn_str
+                     | None -> "\"status\": \"success\""
+                   in
+                   let warnings_list =
+                     List.map (fun w ->
+                       Printf.sprintf "{\"code\": \"%s\", \"message\": \"%s\"}"
+                         (Serialization.json_escape w.Ast.nw_kind)
+                         (Serialization.json_escape w.Ast.nw_message)
+                     ) d.nd_warnings
+                   in
+                   let warnings_str = "[" ^ String.concat ", " warnings_list ^ "]" in
+                   Printf.printf "{\n  %s,\n  \"warnings\": %s\n}\n" error_block warnings_str
+                 end else begin
+                   let has_output = ref false in
+                   (match d.nd_error with
+                    | Some err ->
+                        has_output := true;
+                        Printf.printf "Node '%s' failed:\n" node_name;
+                        Printf.printf "  Error Code: %s\n" err.ne_kind;
+                        Printf.printf "  Message: %s\n" err.ne_message;
+                        if err.ne_fn <> "" then Printf.printf "  Function: %s\n" err.ne_fn
+                    | None -> ());
+                   if d.nd_warnings <> [] then begin
+                     has_output := true;
+                     Printf.printf "Node '%s' has warning(s):\n" node_name;
+                     List.iter (fun w ->
+                       Printf.printf "  - [%s] %s\n" w.Ast.nw_kind w.Ast.nw_message
+                     ) d.nd_warnings
+                   end;
+                   if not !has_output then
+                     Printf.printf "Node '%s' compiled/built successfully with no errors or warnings.\n" node_name
+                 end
+       with e ->
+         Ast.check_mode := old_check_mode;
+         Printf.eprintf "Error loading '%s': %s\n" filename (Printexc.to_string e);
+         exit 1)
+  | None ->
+      let expr_str = String.concat " " (List.filter (fun s -> s <> "--json") rest) in
+      if expr_str = "" then (Printf.eprintf "Usage: t explain <expr> | t explain --node <pipeline_var>.<node_name> [pipeline.t]\n"; exit 1)
+      else begin
+        let (result, env') = parse_and_eval ?failfast mode env expr_str in
+        let explain_expr = "explain(__explain_target__)" in
+        let env'' = Ast.Env.add "__explain_target__" result env' in
+        let (explain_result, _) = parse_and_eval ?failfast mode env'' explain_expr in
+        print_string (Pretty_print.pretty_print_value explain_result)
+      end
 
 let cmd_test args =
   let cwd = Sys.getcwd () in

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -858,18 +858,23 @@ let cmd_init_project args =
 let cmd_explain ?failfast mode rest env =
   Packages.ensure_docs_loaded ();
   let json = List.mem "--json" rest in
+  let has_node = List.mem "--node" rest in
   let rec get_node_arg = function
     | [] -> None
     | "--node" :: v :: _ -> Some v
     | _ :: xs -> get_node_arg xs
   in
-  match get_node_arg rest with
+  let node_arg_opt = get_node_arg rest in
+  if has_node && node_arg_opt = None then begin
+    Printf.eprintf "Usage: t explain --node <pipeline_var>.<node_name> [pipeline.t]\n";
+    exit 1
+  end;
+  match node_arg_opt with
   | Some node_arg ->
       let pipeline_var, node_name =
         match String.split_on_char '.' node_arg with
-        | [n] -> ("p", n)
-        | [v; n] -> (v, n)
-        | _ -> Printf.eprintf "Error: Invalid --node format. Expected <pipeline_var>.<node_name> or <node_name>.\n"; exit 1
+        | [v; n] when v <> "" && n <> "" -> (v, n)
+        | _ -> Printf.eprintf "Error: Invalid --node format. Expected <pipeline_var>.<node_name>.\n"; exit 1
       in
       let remaining = List.filter (fun s -> s <> "--json" && s <> "--node" && s <> node_arg) rest in
       let filename =
@@ -890,15 +895,7 @@ let cmd_explain ?failfast mode rest env =
          let pipeline_opt =
            match Ast.Env.find_opt pipeline_var env_val with
            | Some (Ast.VPipeline p) -> Some p
-           | _ ->
-               (* Fallback: search for any pipeline in the environment *)
-               let found = ref None in
-               Ast.Env.iter (fun _name value ->
-                 match value with
-                 | Ast.VPipeline p -> found := Some p
-                 | _ -> ()
-               ) env_val;
-               !found
+           | _ -> None
          in
          match pipeline_opt with
          | None ->
@@ -912,28 +909,32 @@ let cmd_explain ?failfast mode rest env =
                  exit 1
              | Some d ->
                  if json then begin
-                   let error_block =
-                     match d.nd_error with
-                     | Some err ->
-                         let fn_str =
-                           if err.ne_fn <> "" then Printf.sprintf ", \"function\": \"%s\"" (Serialization.json_escape err.ne_fn)
-                           else ""
-                         in
-                         Printf.sprintf "\"status\": \"failed\", \"error_code\": \"%s\", \"message\": \"%s\"%s"
-                           (Serialization.json_escape err.ne_kind)
-                           (Serialization.json_escape err.ne_message)
-                           fn_str
-                     | None -> "\"status\": \"success\""
-                   in
-                   let warnings_list =
+                   let fields = ref [
+                     ("pipeline", `String pipeline_var);
+                     ("node", `String node_name);
+                   ] in
+                   (match d.nd_error with
+                    | Some err ->
+                        fields := !fields @ [
+                          ("status", `String "failed");
+                          ("error_code", `String err.ne_kind);
+                          ("message", `String err.ne_message);
+                        ];
+                        if err.ne_fn <> "" then
+                          fields := !fields @ [("function", `String err.ne_fn)]
+                    | None ->
+                        fields := !fields @ [("status", `String "success")]);
+                   let warnings_json =
                      List.map (fun w ->
-                       Printf.sprintf "{\"code\": \"%s\", \"message\": \"%s\"}"
-                         (Serialization.json_escape w.Ast.nw_kind)
-                         (Serialization.json_escape w.Ast.nw_message)
+                       `Assoc [
+                         ("code", `String w.Ast.nw_kind);
+                         ("message", `String w.Ast.nw_message);
+                       ]
                      ) d.nd_warnings
                    in
-                   let warnings_str = "[" ^ String.concat ", " warnings_list ^ "]" in
-                   Printf.printf "{\n  %s,\n  \"warnings\": %s\n}\n" error_block warnings_str
+                   fields := !fields @ [("warnings", `List warnings_json)];
+                   let json_obj = `Assoc !fields in
+                   print_endline (Yojson.Safe.pretty_to_string json_obj)
                  end else begin
                    let has_output = ref false in
                    (match d.nd_error with

--- a/tests/cli/test_cli.ml
+++ b/tests/cli/test_cli.ml
@@ -516,4 +516,82 @@ let run_tests pass_count fail_count _failures _eval_string _eval_string_env test
   test "help: apropos with invalid type returns error"
     "apropos(42)"
     {|Error(TypeError: "apropos expects a query string.")|};
+
+  Printf.printf "CLI — t explain --node functionality:\n";
+  let run_t_explain args =
+    let repl_path =
+      if Sys.file_exists "../src/repl.exe" then "../src/repl.exe"
+      else if Sys.file_exists "_build/default/src/repl.exe" then "_build/default/src/repl.exe"
+      else if Sys.file_exists "src/repl.exe" then "src/repl.exe"
+      else "./repl.exe"
+    in
+    let cmd = String.concat " " (List.map Filename.quote (repl_path :: "explain" :: args)) ^ " 2>&1" in
+    let ic = Unix.open_process_in cmd in
+    let lines = ref [] in
+    (try
+       while true do
+         lines := input_line ic :: !lines
+       done
+     with End_of_file -> ());
+    let status = Unix.close_process_in ic in
+    let output = String.concat "\n" (List.rev !lines) in
+    let exit_code =
+      match status with
+      | Unix.WEXITED code -> code
+      | _ -> -1
+    in
+    (exit_code, output)
+  in
+
+  (* 1. Missing node value (trailing flag) *)
+  let (code1, out1) = run_t_explain ["--node"] in
+  test_message "explain --node with no value prints usage"
+    (code1 = 1 && contains out1 "Usage: t explain --node");
+
+  (* 2. Missing prefix format *)
+  let (code2, out2) = run_t_explain ["--node"; "clean_data"] in
+  test_message "explain --node with missing pipeline prefix errors out"
+    (code2 = 1 && contains out2 "Error: Invalid --node format");
+
+  (* 3. Non-existent file *)
+  let (code3, out3) = run_t_explain ["--node"; "p.clean_data"; "non_existent.t"] in
+  test_message "explain --node with non-existent file errors out"
+    (code3 = 1 && contains out3 "Error: File 'non_existent.t' not found");
+
+  (* Set up a temporary pipeline file *)
+  let temp_pipeline_path = "/tmp/explain_test_pipeline.t" in
+  (try
+     let oc = open_out temp_pipeline_path in
+     output_string oc "p = pipeline { clean_data = node(command = 1, serializer = ^csv) }\n";
+     close_out oc;
+
+     (* 4. Non-existent pipeline variable *)
+     let (code4, out4) = run_t_explain ["--node"; "q.clean_data"; temp_pipeline_path] in
+     test_message "explain --node with non-existent pipeline variable errors out"
+       (code4 = 1 && contains out4 "Error: Pipeline variable 'q' not found");
+
+     (* 5. Non-existent node *)
+     let (code5, out5) = run_t_explain ["--node"; "p.other_node"; temp_pipeline_path] in
+     test_message "explain --node with non-existent node errors out"
+       (code5 = 1 && contains out5 "Error: Node 'other_node' not found in the pipeline");
+
+     (* 6. Successful plain-text explain *)
+     let (code6, out6) = run_t_explain ["--node"; "p.clean_data"; temp_pipeline_path] in
+     test_message "explain --node successful plain-text output"
+       (code6 = 0 && contains out6 "Node 'clean_data' compiled/built successfully");
+
+     (* 7. Successful JSON explain *)
+     let (code7, out7) = run_t_explain ["--json"; "--node"; "p.clean_data"; temp_pipeline_path] in
+     test_message "explain --json --node successful JSON fields"
+       (code7 = 0 &&
+        contains out7 "\"pipeline\": \"p\"" &&
+        contains out7 "\"node\": \"clean_data\"" &&
+        contains out7 "\"status\": \"success\"" &&
+        contains out7 "\"warnings\": []");
+
+     Sys.remove temp_pipeline_path
+   with e ->
+     if Sys.file_exists temp_pipeline_path then Sys.remove temp_pipeline_path;
+     raise e);
+
   print_newline ()

--- a/tests/dune
+++ b/tests/dune
@@ -72,6 +72,6 @@
 
 (rule
  (alias runtest)
- (deps docs.json)
+ (deps docs.json ../src/repl.exe)
  (action (run ./test_runner.exe))
 )


### PR DESCRIPTION
…t output

- Added support for t explain --node <pipeline_var>.<node_name> [pipeline.t]
- Resolves the pipeline variable dynamically from the environment
- Outputs clean structured JSON if --json is passed, or plain-text description otherwise