### PR TITLE
feat: expanded suggested_fix with cast fixes, expect() contracts, and…

### DIFF
--- a/src/ast.ml
+++ b/src/ast.ml
@@ -119,6 +119,12 @@ and node_diagnostics = {
   nd_upstream_errors : string list;
 }
 
+(** Contracts extracted from expect() calls for static schema validation *)
+and expect_contract =
+  | Contract_columns of string list
+  | Contract_type of string * string
+  | Contract_null_rate of string * float
+
 
 (** Phase 3: Pipeline result with cached values and dependency info *)
 and pipeline_result = {

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -346,7 +346,6 @@ and expr_node =
   | IfElse of { cond : expr; then_ : expr; else_ : expr }
   | Match of { scrutinee : expr; cases : (match_pattern * expr) list }
   | ListLit of (string option * expr) list
-  | ListComp of { expr : expr; clauses : comp_clause list }
   | DictLit of (string * expr) list
   | BinOp of { op : binop; left : expr; right : expr }
   | UnOp of { op : unop; operand : expr }
@@ -381,7 +380,6 @@ and import_spec = {
 and binop = Plus | Minus | Mul | Div | Mod | Eq | NEq | Gt | Lt | GtEq | LtEq | And | Or | BitAnd | BitOr
   | In (* New: membership check *) | Pipe | MaybePipe | Formula | FatArrow
 and unop = Not | Neg
-and comp_clause = CFor of { var : symbol; iter : expr } | CFilter of expr
 
 and typ =
   | TInt
@@ -912,7 +910,6 @@ module Utils = struct
     | Unquote e -> "!!" ^ unparse_expr e
     | UnquoteSplice e -> "!!!" ^ unparse_expr e
     | Block stmts -> "{ " ^ (List.map unparse_stmt stmts |> String.concat "; ") ^ " }"
-    | ListComp _ -> "[...]"
     | ShellExpr cmd -> "?<{ " ^ cmd ^ " }>"
     | IntentDef _ -> "intent { ... }"
 

--- a/src/diagnostics.ml
+++ b/src/diagnostics.ml
@@ -33,6 +33,9 @@ type error_class =
   | Na_warning
   | Nix_error
   | Unknown_error
+  | Contract_violation
+  | Contract_unverifiable
+  | Invalid_expect_placement
 
 let error_class_to_string = function
   | Structural_error -> "structural_error"
@@ -62,6 +65,9 @@ let error_class_to_string = function
   | Na_warning -> "na_warning"
   | Nix_error -> "nix_error"
   | Unknown_error -> "unknown_error"
+  | Contract_violation -> "contract_violation"
+  | Contract_unverifiable -> "contract_unverifiable"
+  | Invalid_expect_placement -> "invalid_expect_placement"
 
 let error_class_of_string = function
   | "structural_error" | "StructuralError" -> Structural_error
@@ -90,12 +96,17 @@ let error_class_of_string = function
   | "nix_eval_error" -> Nix_eval_error
   | "na_warning" | "NAExcluded" -> Na_warning
   | "nix_error" | "NixError" -> Nix_error
+  | "contract_violation" -> Contract_violation
+  | "contract_unverifiable" -> Contract_unverifiable
+  | "invalid_expect_placement" -> Invalid_expect_placement
   | _ -> Unknown_error
 
 type suggested_fix =
   | Cast of { column: string; cast_to: string; target_node: string option; file: string option; line: int option }
   | Rename_column of { old_name: string; new_name: string; target_node: string option; file: string option; line: int option }
   | Add_node_arg of { node: string; arg: string; target_node: string option; file: string option; line: int option }
+  | Suggest_identifier of { name: string; suggestion: string; target_node: string option; file: string option; line: int option }
+  | Run_command of { command: string; description: string; target_node: string option; file: string option; line: int option }
   | NoFix
 
 type diagnostic = {
@@ -182,6 +193,24 @@ let suggested_fix_to_yojson = function
         ("file", opt_string_to_yojson file);
         ("line", opt_int_to_yojson line);
       ]
+  | Suggest_identifier { name; suggestion; target_node; file; line } ->
+      `Assoc [
+        ("kind", `String "suggest_identifier");
+        ("name", `String name);
+        ("suggestion", `String suggestion);
+        ("target_node", opt_string_to_yojson target_node);
+        ("file", opt_string_to_yojson file);
+        ("line", opt_int_to_yojson line);
+      ]
+  | Run_command { command; description; target_node; file; line } ->
+      `Assoc [
+        ("kind", `String "run_command");
+        ("command", `String command);
+        ("description", `String description);
+        ("target_node", opt_string_to_yojson target_node);
+        ("file", opt_string_to_yojson file);
+        ("line", opt_int_to_yojson line);
+      ]
   | NoFix -> `Null
 
 let opt_string_of_yojson json =
@@ -224,6 +253,20 @@ let suggested_fix_of_yojson json =
           Add_node_arg {
             node = json |> member "node" |> to_string;
             arg = json |> member "arg" |> to_string;
+            target_node;
+            file; line;
+          }
+      | "suggest_identifier" ->
+          Suggest_identifier {
+            name = json |> member "name" |> to_string;
+            suggestion = json |> member "suggestion" |> to_string;
+            target_node;
+            file; line;
+          }
+      | "run_command" ->
+          Run_command {
+            command = json |> member "command" |> to_string;
+            description = json |> member "description" |> to_string;
             target_node;
             file; line;
           }
@@ -350,6 +393,72 @@ let extract_caused_by_from_context context =
     | _ -> None
   ) context
 
+let known_identifiers = [
+  "summary"; "mean"; "sd"; "var"; "median"; "sum"; "min"; "max"; "length";
+  "nrow"; "ncol"; "read_csv"; "write_csv"; "print"; "paste"; "paste0";
+  "toupper"; "tolower"; "nchar"; "substr"; "grep"; "gsub"; "strsplit";
+  "is.na"; "is.numeric"; "is.character"; "is.logical"; "as.numeric";
+  "as.character"; "as.logical"; "seq"; "rep"; "c"; "list"; "data.frame";
+  "filter"; "mutate"; "select"; "arrange"; "group_by"; "ungroup";
+  "summarise"; "summarize"; "pivot_longer"; "pivot_wider"; "rename";
+  "slice"; "head"; "tail"; "distinct"; "count"; "tally"; "pull";
+  "left_join"; "right_join"; "inner_join"; "full_join"; "anti_join";
+  "bind_rows"; "bind_cols"; "do.call"; "apply"; "lapply"; "sapply";
+  "vapply"; "tapply"; "mapply"; "Reduce"; "Map";
+  "which"; "ifelse"; "case_when"; "between"; "near";
+  "row_number"; "rank"; "dense_rank"; "lag"; "lead";
+  "cumsum"; "cumprod"; "cummax"; "cummin";
+  "table"; "prop.table"; "addmargins"; "margin.table";
+  "class"; "typeof"; "str"; "names"; "colnames"; "rownames";
+  "dim"; "nlevels"; "levels"; "attributes"; "attr";
+  "list.files"; "dir.exists"; "file.exists"; "readLines";
+  "writeLines"; "cat"; "message"; "warning"; "stop";
+  "tryCatch"; "withCallingHandlers"; "suppressWarnings";
+  "suppressMessages"; "system"; "system.time"; "proc.time";
+  "Sys.time"; "Sys.sleep"; "date"; "Sys.Date";
+  "library"; "require"; "install.packages"; "available.packages";
+  "optim"; "nlm"; "uniroot"; "integrate"; "deriv";
+  "solve"; "qr"; "svd"; "eigen"; "chol"; "det"; "norm";
+  "crossprod"; "tcrossprod"; "outer"; "inner"; "%*%";
+  "which.min"; "which.max"; "pmax"; "pmin"; "pmax.int"; "pmin.int";
+  "xor"; "all"; "any"; "identical"; "equal"; "setdiff";
+  "union"; "intersect"; "match"; "%in%";
+  "Rev"; "sort"; "order"; "duplicated"; "unique";
+  "tabulate"; "findInterval"; "cut"; "find";
+  "grepl"; "regexpr"; "gregexpr"; "regmatches";
+  "sprintf"; "format"; "formatC"; "prettyNum"; "pretty";
+  "hcl.colors"; "rainbow"; "heat.colors"; "terrain.colors";
+  "topo.colors"; "cm.colors"; "colorRampPalette";
+  "par"; "plot"; "points"; "lines"; "abline"; "curve";
+  "hist"; "barplot"; "boxplot"; "pie"; "stripchart";
+  "text"; "legend"; "title"; "axis"; "mtext"; "grid";
+  "polygon"; "rect"; "segments"; "arrows";
+  "locator"; "identify"; "dev.new"; "dev.off"; "pdf"; "png"; "jpeg"
+]
+
+let known_identifiers_lower_table =
+  let tbl = Hashtbl.create (List.length known_identifiers) in
+  List.iter (fun k ->
+    Hashtbl.replace tbl (String.lowercase_ascii k) k
+  ) known_identifiers;
+  tbl
+
+(** Extract the variable name and an optional correction from an error message.
+    Returns (name, suggestion option). *)
+let extract_name_and_suggestion msg =
+  let re = Str.regexp "Variable '\\([^']+\\)' is not defined" in
+  try
+    ignore (Str.search_forward re msg 0);
+    let name = Str.matched_group 1 msg in
+    let lower_name = String.lowercase_ascii name in
+    let candidates = Hashtbl.fold (fun lk _ acc -> lk :: acc) known_identifiers_lower_table [] in
+    let suggestion = match Ast.suggest_name lower_name candidates with
+      | Some lower_match -> Some (Hashtbl.find known_identifiers_lower_table lower_match)
+      | None -> None
+    in
+    (name, suggestion)
+  with Not_found -> ("", None)
+
 let of_verror ?file (err : Ast.error_info) : diagnostic =
   let diag_phase = error_code_to_phase err.code in
   let node_name = extract_node_name_from_message err.message in
@@ -364,6 +473,12 @@ let of_verror ?file (err : Ast.error_info) : diagnostic =
              let arg = "deserializer = " ^ serializer in
              Add_node_arg { node = (match node_name with Some n -> n | None -> "");
                             arg; target_node = node_name; file; line = None }
+         | None -> NoFix)
+    | NameError ->
+        let (name, suggestion) = extract_name_and_suggestion err.message in
+        (match suggestion with
+         | Some s ->
+             Suggest_identifier { name; suggestion = s; target_node = node_name; file; line = None }
          | None -> NoFix)
     | _ -> NoFix
   in

--- a/src/dune
+++ b/src/dune
@@ -66,8 +66,8 @@
    t_read_csv t_read_parquet t_write_csv t_read_arrow t_write_arrow t_write_parquet t_dataframe colnames nrow ncol clean_colnames glimpse
       ; packages/pipeline
        pipeline_utils pipeline_args pipeline_nodes pipeline_deps pipeline_node pipeline_run build_pipeline populate_pipeline inspect_pipeline trace_nodes read_node read_past_node pipeline_copy
-      pipeline_to_frame filter_node which_nodes mutate_node rename_node select_node arrange_node pipeline_to_drv
-       pipeline_set_ops pipeline_dag_ops pipeline_composition pipeline_expand pipeline_inspect2 pipeline_to_ga t_make_mod build_log pipeline_diff diff_summary pipeline_report t_check t_diff t_fix
+       pipeline_to_frame filter_node which_nodes mutate_node rename_node select_node arrange_node pipeline_to_drv
+        pipeline_set_ops pipeline_dag_ops pipeline_composition pipeline_expand pipeline_inspect2 pipeline_to_ga t_make_mod build_log pipeline_diff diff_summary pipeline_report t_check t_diff t_fix expect
       pipeline_to_store set_nix_defaults pipeline_cache_status pipeline_gc export_artifacts import_artifacts inspect_artifacts
     ; packages/colcraft
     t_select t_filter mutate arrange group_by ungroup summarize n n_distinct

--- a/src/env_check.ml
+++ b/src/env_check.ml
@@ -28,6 +28,11 @@ let check_declared_requirements ~file ~tproject_path ~project_root ~tproject_cfg
       || not (Pipeline_dependency_requirements.String_set.is_empty required.latex_pkgs)
     in
     if has_any_requirements then
+      let tools = ref [] in
+      if not (Pipeline_dependency_requirements.String_set.is_empty required.r_deps) then tools := "R" :: !tools;
+      if not (Pipeline_dependency_requirements.String_set.is_empty required.py_deps) then tools := "Python" :: !tools;
+      if not (Pipeline_dependency_requirements.String_set.is_empty required.julia_deps) then tools := "Julia" :: !tools;
+      let tool_list = String.concat ", " (List.rev !tools) in
       [Diagnostics.{
         diag_id = Diagnostics.gen_id ();
         diag_error_class = Missing_tproject;
@@ -40,11 +45,17 @@ let check_declared_requirements ~file ~tproject_path ~project_root ~tproject_cfg
         diag_column = None;
         diag_end_line = None;
         diag_end_column = None;
-        diag_message = Printf.sprintf "Pipeline requires R/Python/Julia packages but tproject.toml not found at %s" tproject_path;
-        diag_expected = None;
+        diag_message = Printf.sprintf "Pipeline requires %s packages but tproject.toml not found at %s" tool_list tproject_path;
+        diag_expected = Some "tproject.toml";
         diag_actual = None;
         diag_caused_by = [];
-        diag_suggested_fix = NoFix;
+        diag_suggested_fix = Run_command {
+          command = Printf.sprintf "t init %s" project_root;
+          description = "Initialize tproject.toml in project root";
+          target_node = None;
+          file = Some file;
+          line = None;
+        };
       }]
     else []
   | Some cfg ->
@@ -65,6 +76,14 @@ let check_declared_requirements ~file ~tproject_path ~project_root ~tproject_cfg
       let missing_diags = ref [] in
       let add_missing section pkgs =
         List.iter (fun pkg ->
+          let section_cmd = match section with
+            | "[r-dependencies]" -> "R"
+            | "[py-dependencies]" -> "Python"
+            | "[jl-dependencies]" -> "Julia"
+            | "[additional-tools]" -> "tool"
+            | "[latex]" -> "latex"
+            | _ -> "package"
+          in
           missing_diags := Diagnostics.{
             diag_id = Diagnostics.gen_id ();
             diag_error_class = Missing_package;
@@ -78,10 +97,16 @@ let check_declared_requirements ~file ~tproject_path ~project_root ~tproject_cfg
             diag_end_line = None;
             diag_end_column = None;
             diag_message = Printf.sprintf "Package '%s' required by pipeline not declared in %s %s" pkg tproject_path section;
-            diag_expected = None;
+            diag_expected = Some (Printf.sprintf "%s %s" section pkg);
             diag_actual = None;
             diag_caused_by = [];
-            diag_suggested_fix = NoFix;
+            diag_suggested_fix = Run_command {
+              command = Printf.sprintf "t add %s %s" section_cmd pkg;
+              description = Printf.sprintf "Add %s to %s" pkg section;
+              target_node = None;
+              file = Some file;
+              line = None;
+            };
           } :: !missing_diags
         ) pkgs
       in

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -88,7 +88,7 @@ let rec expr_uses_named_scope_fields fields (expr : Ast.expr) : bool =
       ) stmts
   | Lambda _ | Value _ | RawCode _ | ShellExpr _ -> false
   | Unquote e | UnquoteSplice e -> expr_uses_named_scope_fields fields e
-  | PipelineDef _ | PipelineOfDef _ | IntentDef _ | ListComp _ -> false
+  | PipelineDef _ | PipelineOfDef _ | IntentDef _ -> false
 
 (** Rewrite bare field names from a scoped predicate to [root.field], while
     leaving all other variables unchanged.
@@ -191,7 +191,7 @@ let rec desugar_named_scope_expr ~root ~fields (expr : Ast.expr) : Ast.expr =
       Ast.mk_expr ?loc (Unquote (desugar_named_scope_expr ~root ~fields e))
   | UnquoteSplice e ->
       Ast.mk_expr ?loc (UnquoteSplice (desugar_named_scope_expr ~root ~fields e))
-  | Lambda _ | Value _ | RawCode _ | ShellExpr _ | ColumnRef _ | PipelineDef _ | PipelineOfDef _ | IntentDef _ | ListComp _ ->
+  | Lambda _ | Value _ | RawCode _ | ShellExpr _ | ColumnRef _ | PipelineDef _ | PipelineOfDef _ | IntentDef _ ->
       expr
 
 (** Field names exposed on read-pipeline node records and available for
@@ -1572,7 +1572,6 @@ and eval_expr (env_ref : environment ref) (expr : Ast.expr) : value =
     | DictLit pairs -> eval_dict_lit env_ref pairs
     | DotAccess { target; field } -> eval_dot_access env_ref target field
     | RawCode { raw_text; _ } -> VRawCode raw_text
-    | ListComp _ -> Error.internal_error "List comprehensions are not yet implemented"
     | Block stmts -> eval_block env_ref stmts
     | PipelineDef nodes -> eval_pipeline env_ref nodes
     | PipelineOfDef nodes -> eval_pipeline_of env_ref nodes
@@ -1649,7 +1648,6 @@ and free_vars (expr : Ast.expr) : string list =
         in
         collect false scrutinee @ List.concat_map collect_case cases
     | { node = ListLit items; _ } -> List.concat_map (fun (_, e) -> collect false e) items
-    | { node = ListComp _; _ } -> []
     | { node = DictLit pairs; _ } -> List.concat_map (fun (_, e) -> collect false e) pairs
     | { node = BinOp { left; right; _ }; _ } -> collect false left @ collect false right
     | { node = UnOp { operand; _ }; _ } -> collect false operand
@@ -1778,12 +1776,6 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
           IfElse { cond = sub cond; then_ = sub then_; else_ = sub else_ }
       | Match { scrutinee; cases } ->
           Match { scrutinee = sub scrutinee; cases = List.map (fun (pat, body) -> (pat, sub body)) cases }
-      | ListComp { expr = c_expr; clauses } ->
-          let clauses' = List.map (function
-            | CFor { var; iter } -> CFor { var; iter = sub iter }
-            | CFilter e -> CFilter (sub e)
-          ) clauses in
-          ListComp { expr = sub c_expr; clauses = clauses' }
       | Lambda l ->
           let inner_node_names = l.params @ node_names in
           Lambda { l with body = substitute_env_vars env inner_node_names l.body }
@@ -2381,14 +2373,6 @@ and quote_expr (env_ref : environment ref) (expr : Ast.expr) : Ast.expr =
   | PipelineDef nodes  -> Ast.mk_expr ?loc (PipelineDef (List.map qpair nodes))
   | PipelineOfDef nodes -> Ast.mk_expr ?loc (PipelineOfDef (List.map qpair nodes))
   | IntentDef fields   -> Ast.mk_expr ?loc (IntentDef (List.map qpair fields))
-
-  (* ── List comprehension ────────────────────────────────────── *)
-  | ListComp { expr = e; clauses } ->
-      let qclause = function
-        | CFor { var; iter }  -> CFor { var; iter = q iter }
-        | CFilter filter_expr -> CFilter (q filter_expr)
-      in
-      Ast.mk_expr ?loc (ListComp { expr = q e; clauses = List.map qclause clauses })
 
   (* ── Leaves (Value, Var, ColumnRef, RawCode) pass through ── *)
   | _ -> expr
@@ -3049,14 +3033,6 @@ and expand_autoquoted_unquotes (env_ref : environment ref) (expr : Ast.expr) : A
       Ast.mk_expr ?loc (Match { scrutinee = expand scrutinee; cases = List.map (fun (pattern, body) -> (pattern, expand body)) cases })
   | ListLit items ->
       Ast.mk_expr ?loc (ListLit (List.map (fun (name, e) -> (name, expand e)) items))
-  | ListComp { expr = inner; clauses } ->
-      let clauses =
-        List.map (function
-          | CFor { var; iter } -> CFor { var; iter = expand iter }
-          | CFilter filter_expr -> CFilter (expand filter_expr)
-        ) clauses
-      in
-      Ast.mk_expr ?loc (ListComp { expr = expand inner; clauses })
   | DictLit pairs ->
       Ast.mk_expr ?loc (DictLit (List.map (fun (name, e) -> (name, expand e)) pairs))
   | DotAccess { target; field } ->

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -2794,6 +2794,15 @@ and eval_dot_access_val env_ref target_val field =
                           String.sub c 0 pfx_len = pfx)
       (Arrow_table.column_names arrow_table)
   in
+  let suggest_closest_column arrow_table field =
+    let cols = Arrow_table.column_names arrow_table in
+    let lower_cols = List.map (fun c -> (String.lowercase_ascii c, c)) cols in
+    let candidates = List.map fst lower_cols in
+    let lower_field = String.lowercase_ascii field in
+    match Ast.suggest_name lower_field candidates with
+    | Some lower_match -> Some (List.assoc lower_match lower_cols)
+    | None -> None
+  in
   let has_node_prefix p prefix =
     let pfx = prefix ^ "." in
     List.exists (fun (n, _) -> String.starts_with ~prefix:pfx n) p.p_nodes ||
@@ -2873,7 +2882,12 @@ and eval_dot_access_val env_ref target_val field =
          if has_column_prefix arrow_table field
          then VDict [("__partial_dot_df__", VDataFrame df);
                      ("__partial_dot_prefix__", VString field)]
-         else Error.make_error KeyError (Printf.sprintf "Column `%s` not found in DataFrame." field))
+         else
+           let hint = match suggest_closest_column arrow_table field with
+             | Some suggestion -> Printf.sprintf " Did you mean `%s`?" suggestion
+             | None -> ""
+           in
+           Error.make_error KeyError (Printf.sprintf "Column `%s` not found in DataFrame.%s" field hint))
   | VPipeline p ->
        (match get_pipeline_member p field with
         | Some v -> v

--- a/src/fix.ml
+++ b/src/fix.ml
@@ -257,6 +257,8 @@ let apply_fix ~file (fix : Diagnostics.suggested_fix) =
       apply_rename_column ~file ~old_name ~new_name; true
   | Add_node_arg { node; arg; file = _; line = _; target_node = _ } ->
       apply_add_node_arg ~file ~node ~arg
+  | Suggest_identifier _ -> false
+  | Run_command _ -> false
   | NoFix -> false
 
 (* Sort fixes by descending line within each file, so bottom-up application

--- a/src/package_manager/package_doctor.ml
+++ b/src/package_manager/package_doctor.ml
@@ -397,14 +397,6 @@ let rec pipeline_defs_in_expr expr =
   | Ast.UnquoteSplice operand
   | Ast.Lambda { body = operand; _ } ->
       pipeline_defs_in_expr operand
-  | Ast.ListComp { expr; clauses } ->
-      pipeline_defs_in_expr expr
-      @ List.concat
-          (List.map
-             (function
-               | Ast.CFor { iter; _ }
-               | Ast.CFilter iter -> pipeline_defs_in_expr iter)
-             clauses)
   | Ast.Block stmts ->
       pipeline_defs_in_program stmts
   | Ast.Value _

--- a/src/packages/core/packages.ml
+++ b/src/packages/core/packages.ml
@@ -204,7 +204,7 @@ let pipeline_package = {
                  "pipeline_cycles"; "pipeline_validate"; "pipeline_assert";
                   "pipeline_print"; "pipeline_to_dot"; "pipeline_to_mermaid";
                   "pipeline_to_ga";
-                  "t_check"; "t_diff"; "t_fix"];
+                   "t_check"; "t_diff"; "t_fix"; "expect"];
 }
 
 let explain_package = {
@@ -857,6 +857,7 @@ let init_env () =
   let env = T_check.register env in
   let env = T_diff.register env in
   let env = T_fix.register env in
+  let env = Expect.register env in
   (* Colcraft package *)
   let env = T_select.register env in
   let env = T_filter.register ~eval_call:Eval.eval_call_immutable ~eval_expr:Eval.eval_expr_immutable ~uses_nse:Eval.uses_nse ~desugar_nse_expr:Eval.desugar_nse_expr env in

--- a/src/packages/pipeline/expect.ml
+++ b/src/packages/pipeline/expect.ml
@@ -1,0 +1,27 @@
+open Ast
+
+(*
+--# Schema Contract Annotation
+--#
+--# Declares static schema contracts for a pipeline node. Contracts are validated
+--# during `t check --schema` and have no runtime effect.
+--#
+--# Supported contracts:
+--#   expect(columns = ["id", "name"])       — column presence
+--#   expect(amount ~ double())              — type contract
+--#   expect(null_rate("amount") < 0.05)     — null-rate (unverifiable statically)
+--#
+--# @name expect
+--# @param data :: DataFrame The piped data (passed through unchanged).
+--# @param ... :: Any Contract expressions.
+--# @return :: DataFrame The same data, unchanged.
+--# @family pipeline
+--# @export
+*)
+let register env =
+  Env.add "expect"
+    (make_builtin ~name:"expect" ~unwrap:false 1 (fun args _env ->
+      match args with
+      | data :: _ -> data
+      | [] -> Error.arity_error_named "expect" 1 0
+    )) env

--- a/src/packages/pipeline/pipeline_composition.ml
+++ b/src/packages/pipeline/pipeline_composition.ml
@@ -91,19 +91,6 @@ let rec rewrite_expr sub_name local_names (expr : Ast.expr) : Ast.expr =
         Unquote (rewrite_expr sub_name local_names e)
     | UnquoteSplice e ->
         UnquoteSplice (rewrite_expr sub_name local_names e)
-    | ListComp { expr; clauses } ->
-        let rec filter_clauses local_acc = function
-          | [] -> (local_acc, [])
-          | CFor { var; iter } :: rest ->
-              let next_local = List.filter (fun n -> n <> var) local_acc in
-              let (final_local, rest_clauses) = filter_clauses next_local rest in
-              (final_local, CFor { var; iter = rewrite_expr sub_name local_acc iter } :: rest_clauses)
-          | CFilter filter_expr :: rest ->
-              let (final_local, rest_clauses) = filter_clauses local_acc rest in
-              (final_local, CFilter (rewrite_expr sub_name local_acc filter_expr) :: rest_clauses)
-        in
-        let (filtered_local, rewritten_clauses) = filter_clauses local_names clauses in
-        ListComp { expr = rewrite_expr sub_name filtered_local expr; clauses = rewritten_clauses }
   in
   Ast.mk_expr ?loc node
 
@@ -174,11 +161,6 @@ let rec find_dot_access_targets (expr : Ast.expr) : string list =
   | PipelineDef nodes | PipelineOfDef nodes | IntentDef nodes ->
       List.concat_map (fun (_, e) -> find_dot_access_targets e) nodes
   | Unquote e | UnquoteSplice e -> find_dot_access_targets e
-  | ListComp { expr; clauses } ->
-      find_dot_access_targets expr @ List.concat_map (function
-        | CFor { iter; _ } -> find_dot_access_targets iter
-        | CFilter f -> find_dot_access_targets f
-      ) clauses
 
 and find_dot_access_targets_stmt (stmt : Ast.stmt) : string list =
   match stmt.node with

--- a/src/packages/pipeline/pipeline_expand.ml
+++ b/src/packages/pipeline/pipeline_expand.ml
@@ -92,8 +92,6 @@ let rec substitute_vars_in_expr
       Ast.mk_expr (Ast.ListLit (List.map (fun (n, e) -> (n, subst e)) items))
   | DictLit items ->
       Ast.mk_expr (Ast.DictLit (List.map (fun (k, e) -> (k, subst e)) items))
-  | ListComp { expr; clauses } ->
-      Ast.mk_expr (Ast.ListComp { expr = subst expr; clauses })
   | Lambda l ->
       Ast.mk_expr (Ast.Lambda { l with body = subst l.body })
   | BroadcastOp { op; left; right } ->

--- a/src/packages/pipeline/t_fix.ml
+++ b/src/packages/pipeline/t_fix.ml
@@ -35,6 +35,10 @@ let format_fix_result (result : Fix.fix_result) =
         | Diagnostics.Rename_column { old_name; new_name; _ } ->
             Printf.sprintf "  Rename column '%s' to '%s'" old_name new_name
         | Diagnostics.Add_node_arg _ -> "  Add node argument"
+        | Diagnostics.Suggest_identifier { name; suggestion; _ } ->
+            Printf.sprintf "  Did you mean '%s' instead of '%s'?" suggestion name
+        | Diagnostics.Run_command { command; _ } ->
+            Printf.sprintf "  Run: %s" command
         | Diagnostics.NoFix -> "  No fix"
       in
       Buffer.add_string buf (Printf.sprintf "%s:%d: %s\n"

--- a/src/pipeline/nix_unparse.ml
+++ b/src/pipeline/nix_unparse.ml
@@ -127,7 +127,6 @@ and unparse_expr expr =
   | PipelineOfDef nodes ->
       "pipeline_of { " ^ String.concat "; " (List.map (fun (n, e) -> n ^ " = " ^ unparse_expr e) nodes) ^ " }"
   | Block stmts -> "{ " ^ (List.map unparse_stmt stmts |> String.concat "; ") ^ " }"
-  | ListComp _ -> "[...]"
   | IntentDef _ -> "intent { ... }"
 
 and unparse_stmt stmt =

--- a/src/pipeline_script.ml
+++ b/src/pipeline_script.ml
@@ -134,20 +134,6 @@ let rec analyze_expr_for_pipeline_call expr =
         (fun acc (_, item) -> combine_t_make_pipeline_contract acc (analyze_expr_for_pipeline_call item))
         MissingPipelineBuildCall
         nodes
-  | ListComp { expr; clauses } ->
-      let clause_contract =
-        List.fold_left
-          (fun acc clause ->
-            let clause_expr =
-              match clause with
-              | CFor { iter; _ } -> analyze_expr_for_pipeline_call iter
-              | CFilter filter_expr -> analyze_expr_for_pipeline_call filter_expr
-            in
-            combine_t_make_pipeline_contract acc clause_expr)
-          MissingPipelineBuildCall
-          clauses
-      in
-      combine_t_make_pipeline_contract clause_contract (analyze_expr_for_pipeline_call expr)
   | Block stmts ->
       List.fold_left
         (fun acc stmt -> combine_t_make_pipeline_contract acc (analyze_stmt_for_pipeline_call stmt))

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -51,7 +51,6 @@ let rec expr_has_build_pipeline = function
   | { Ast.node = Ast.Block stmts; _ } -> List.exists stmt_has_build_pipeline stmts
   | { Ast.node = Ast.PipelineDef _; _ }
   | { Ast.node = Ast.PipelineOfDef _; _ } -> true
-  | { Ast.node = Ast.ListComp { expr; _ }; _ } -> expr_has_build_pipeline expr
   | { Ast.node = Ast.IntentDef pairs; _ } -> List.exists (fun (_, e) -> expr_has_build_pipeline e) pairs
   | _ -> false
 

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -459,6 +459,7 @@ let print_help () =
   Printf.printf "  test              Run tests in the current directory\n";
   Printf.printf "  update            Update dependencies and nixpkgs date from tproject.toml\n";
   Printf.printf "  upgrade           Upgrade T version and nixpkgs date to today's date\n";
+  Printf.printf "  add <runtime> <pkg>  Add a package to tproject.toml (R, Python, or Julia)\n";
   Printf.printf "  doctor            Check package health\n";
   Printf.printf "  docs              Open documentation\n";
   Printf.printf "  --help, -h        Show this help message\n";
@@ -1060,6 +1061,76 @@ let cmd_update () =
   match Update_manager.update_flake_lock () with
   | Ok () -> Printf.printf "Updated.\n"
   | Error msg -> Printf.eprintf "Error: %s\n" msg; exit 1
+
+let cmd_add args =
+  let usage () =
+    Printf.eprintf "Usage: t add <runtime> <package>\n";
+    Printf.eprintf "  <runtime>  R, Python, or Julia\n";
+    Printf.eprintf "  <package>  Package name to add to tproject.toml\n";
+    exit 1
+  in
+  let has_flag s = String.length s > 2 && s.[0] = '-' && s.[1] = '-' in
+  let positional = List.filter (fun s -> not (has_flag s)) args in
+  (match positional with
+   | [runtime; pkg] ->
+       let dir = Sys.getcwd () in
+       let tproject_path = Filename.concat dir "tproject.toml" in
+       if not (Sys.file_exists tproject_path) then begin
+         Printf.eprintf "Error: tproject.toml not found. Run 't init --project <name>' first.\n";
+         exit 1
+       end;
+       let read_file path =
+         try
+           let ch = open_in path in
+           Fun.protect ~finally:(fun () -> close_in_noerr ch)
+             (fun () -> Ok (really_input_string ch (in_channel_length ch)))
+         with Sys_error msg -> Error msg
+       in
+       let write_file path content =
+         try
+           let oc = open_out path in
+           Fun.protect ~finally:(fun () -> close_out_noerr oc)
+             (fun () -> output_string oc content; Ok ())
+         with Sys_error msg -> Error msg
+       in
+       let cfg_result =
+         match read_file tproject_path with
+         | Error msg -> Error (Printf.sprintf "Cannot read tproject.toml: %s" msg)
+         | Ok content ->
+             (match Toml_parser.parse_tproject_toml ~root_dir:dir content with
+             | Error msg -> Error (Printf.sprintf "Cannot parse tproject.toml: %s" msg)
+             | Ok cfg -> Ok cfg)
+       in
+       (match cfg_result with
+        | Error msg -> Printf.eprintf "Error: %s\n" msg; exit 1
+        | Ok cfg ->
+            let (runtime_key, list_getter, list_setter) =
+              match String.lowercase_ascii runtime with
+              | "r" -> ("[r-dependencies]",
+                        (fun c -> c.Package_types.proj_r_dependencies),
+                        (fun pkg c -> { c with Package_types.proj_r_dependencies = c.Package_types.proj_r_dependencies @ [pkg] }))
+              | "python" | "py" -> ("[py-dependencies]",
+                                    (fun c -> c.Package_types.proj_py_dependencies),
+                                    (fun pkg c -> { c with Package_types.proj_py_dependencies = c.Package_types.proj_py_dependencies @ [pkg] }))
+              | "julia" | "jl" -> ("[jl-dependencies]",
+                                   (fun c -> c.Package_types.proj_julia_dependencies),
+                                   (fun pkg c -> { c with Package_types.proj_julia_dependencies = c.Package_types.proj_julia_dependencies @ [pkg] }))
+              | _ ->
+                  Printf.eprintf "Error: Unknown runtime '%s'. Use R, Python, or Julia.\n" runtime;
+                  exit 1
+            in
+            let existing = list_getter cfg in
+            if List.mem pkg existing then
+              Printf.printf "'%s' is already declared in %s.\n" pkg runtime_key
+            else begin
+              let new_cfg = list_setter pkg cfg in
+              let new_content = Toml_parser.serialize_tproject_toml new_cfg in
+              match write_file tproject_path new_content with
+              | Error msg -> Printf.eprintf "Error writing tproject.toml: %s\n" msg; exit 1
+              | Ok () ->
+                  Printf.printf "'%s' added to %s in tproject.toml.\nRun 't update' to sync flake.nix.\n" pkg runtime_key
+            end)
+   | _ -> usage ())
 
 let cmd_upgrade () =
   match Update_manager.cmd_upgrade () with
@@ -1682,6 +1753,7 @@ let () =
   | _ :: "init" :: "--package" :: rest -> cmd_init_package rest
   | _ :: "init" :: "--project" :: rest -> cmd_init_project rest
   | _ :: "test" :: rest -> cmd_test rest
+  | _ :: "add" :: rest -> cmd_add rest
   | _ :: "doctor" :: _ -> cmd_doctor ()
   | _ :: "docs" :: _ -> cmd_docs ()
   | _ :: "doc" :: rest -> cmd_doc rest

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -1115,8 +1115,14 @@ let cmd_add args =
               | "julia" | "jl" -> ("[jl-dependencies]",
                                    (fun c -> c.Package_types.proj_julia_dependencies),
                                    (fun pkg c -> { c with Package_types.proj_julia_dependencies = c.Package_types.proj_julia_dependencies @ [pkg] }))
+              | "tool" -> ("[additional-tools]",
+                           (fun c -> c.Package_types.proj_additional_tools),
+                           (fun pkg c -> { c with Package_types.proj_additional_tools = c.Package_types.proj_additional_tools @ [pkg] }))
+              | "latex" -> ("[latex]",
+                            (fun c -> c.Package_types.proj_latex_packages),
+                            (fun pkg c -> { c with Package_types.proj_latex_packages = c.Package_types.proj_latex_packages @ [pkg] }))
               | _ ->
-                  Printf.eprintf "Error: Unknown runtime '%s'. Use R, Python, or Julia.\n" runtime;
+                  Printf.eprintf "Error: Unknown runtime '%s'. Use R, Python, Julia, tool, or latex.\n" runtime;
                   exit 1
             in
             let existing = list_getter cfg in

--- a/src/schema_check.ml
+++ b/src/schema_check.ml
@@ -675,11 +675,10 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
       let ops = unwrap_pipe expr in
       let ops_len = List.length ops in
       let contract_diags = ref [] in
-      let is_first = ref true in
-      List.iter (fun op ->
+      List.iteri (fun idx op ->
         if classify_verb op = Expect then begin
-          if not !is_first || ops_len > 1 then begin
-            (* Mid-chain or chained expect(): warn placement *)
+          if idx <> ops_len - 1 then begin
+            (* Mid-chain expect(): warn placement *)
             contract_diags := (Diagnostics.{
               diag_id = gen_id ();
               diag_error_class = Invalid_expect_placement;
@@ -699,15 +698,14 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
               diag_suggested_fix = NoFix;
             } : Diagnostics.diagnostic) :: !contract_diags
           end else
-            (* Sole expect() at the end: validate contracts *)
+            (* Last position: validate contracts against final schema *)
             let contracts = match op.node with
               | Call { args; _ } -> extract_contracts args
               | _ -> []
             in
             let diags = validate_contracts ~node_name:name ~file:(Some file) contracts !current_validation_schema in
             contract_diags := diags @ !contract_diags
-        end;
-        is_first := false
+        end
       ) ops;
       diagnostics := !contract_diags @ !diagnostics;
 

--- a/src/schema_check.ml
+++ b/src/schema_check.ml
@@ -182,6 +182,7 @@ type verb =
   | Distinct
   | Slice
   | Count
+  | Expect
   | Other of string
 
 let classify_verb expr =
@@ -199,6 +200,7 @@ let classify_verb expr =
        | "distinct" -> Distinct
        | "slice" | "slice_min" | "slice_max" | "slice_sample" -> Slice
        | "count" -> Count
+       | "expect" -> Expect
        | _ -> Other name)
   | _ -> Other "unknown"
 
@@ -312,6 +314,9 @@ let infer_output_schema input_schema expr =
       if named <> [] then
         List.map (fun (name, t) -> { sc_name = name; sc_type = t }) named
       else input_schema @ [{ sc_name = "n"; sc_type = Some "int" }]
+  | Expect ->
+      (* expect() is a schema annotation — pass through unchanged *)
+      input_schema
   | Other _ ->
       (* Unknown function — schema is unknown *)
       []
@@ -352,6 +357,128 @@ let extract_rename_mapping expr =
        ) args
      | _ -> [])
   | _ -> []
+
+(* ---------- expect() contract extraction and validation ---------- *)
+
+let extract_contracts args =
+  List.filter_map (fun (name, e) ->
+    match name, e.node with
+    | Some "columns", ListLit items ->
+        let cols = List.filter_map (fun (_, item) ->
+          match item.node with
+          | Value (VString s) -> Some s
+          | _ -> None
+        ) items in
+        if cols <> [] then Some (Ast.Contract_columns cols) else None
+    | _, BinOp { op = Formula; left = { node = Var col; _ }; right = { node = Call { fn = { node = Var t; _ }; _ }; _ } } ->
+        Some (Ast.Contract_type (col, t))
+    | _, BinOp { op = Lt;
+              left = { node = Call { fn = { node = Var "null_rate"; _ };
+                           args = [(_, { node = Value (VString col); _ })] }; _ };
+              right = { node = Value (VFloat threshold); _ } } ->
+        Some (Ast.Contract_null_rate (col, threshold))
+    | _ -> None
+  ) args
+
+let validate_contracts ~node_name ~file contracts output_schema =
+  let diags = ref [] in
+  List.iter (fun contract ->
+    match contract with
+    | Ast.Contract_columns cols ->
+        List.iter (fun col ->
+          if not (schema_has_col col output_schema) then
+            diags := (Diagnostics.{
+              diag_id = Diagnostics.gen_id ();
+              diag_error_class = Contract_violation;
+              diag_severity = Error;
+              diag_phase = Schema;
+              diag_node_id = Some node_name;
+              diag_node_lang = None;
+              diag_file = file;
+              diag_line = None;
+              diag_column = None;
+              diag_end_line = None;
+              diag_end_column = None;
+              diag_message = Printf.sprintf "Expected column '%s' not found in output schema" col;
+              diag_expected = Some col;
+              diag_actual = None;
+              diag_caused_by = [];
+              diag_suggested_fix = NoFix;
+            } : Diagnostics.diagnostic) :: !diags
+        ) cols
+    | Ast.Contract_type (col, expected_type) ->
+        (match schema_find_type col output_schema with
+         | Some actual_type when actual_type <> expected_type ->
+             diags := (Diagnostics.{
+               diag_id = Diagnostics.gen_id ();
+               diag_error_class = Contract_violation;
+               diag_severity = Warning;
+               diag_phase = Schema;
+               diag_node_id = Some node_name;
+               diag_node_lang = None;
+               diag_file = file;
+               diag_line = None;
+               diag_column = None;
+               diag_end_line = None;
+               diag_end_column = None;
+               diag_message = Printf.sprintf "Column '%s' type contract: expected '%s', got '%s'"
+                 col expected_type actual_type;
+               diag_expected = Some expected_type;
+               diag_actual = Some actual_type;
+               diag_caused_by = [];
+               diag_suggested_fix =
+                 if List.mem expected_type ["int"; "double"; "string"; "bool"]
+                 then Diagnostics.Cast {
+                   column = col;
+                   cast_to = expected_type;
+                   target_node = Some node_name;
+                   file;
+                   line = None;
+                 }
+                 else NoFix;
+             } : Diagnostics.diagnostic) :: !diags
+         | _ -> ())
+    | Ast.Contract_null_rate (col, _threshold) ->
+        if not (schema_has_col col output_schema) then
+          diags := (Diagnostics.{
+            diag_id = Diagnostics.gen_id ();
+            diag_error_class = Contract_violation;
+            diag_severity = Error;
+            diag_phase = Schema;
+            diag_node_id = Some node_name;
+            diag_node_lang = None;
+            diag_file = file;
+            diag_line = None;
+            diag_column = None;
+            diag_end_line = None;
+            diag_end_column = None;
+            diag_message = Printf.sprintf "null_rate contract: column '%s' not found in output schema" col;
+            diag_expected = Some col;
+            diag_actual = None;
+            diag_caused_by = [];
+            diag_suggested_fix = NoFix;
+          } : Diagnostics.diagnostic) :: !diags
+        else
+          diags := (Diagnostics.{
+            diag_id = Diagnostics.gen_id ();
+            diag_error_class = Contract_unverifiable;
+            diag_severity = Warning;
+            diag_phase = Schema;
+            diag_node_id = Some node_name;
+            diag_node_lang = None;
+            diag_file = file;
+            diag_line = None;
+            diag_column = None;
+            diag_end_line = None;
+            diag_end_column = None;
+            diag_message = Printf.sprintf "null_rate contract for '%s' cannot be verified statically; requires runtime data" col;
+            diag_expected = None;
+            diag_actual = None;
+            diag_caused_by = [];
+            diag_suggested_fix = NoFix;
+          } : Diagnostics.diagnostic) :: !diags
+  ) contracts;
+  !diags
 
 (* Validate that all column references in an expression exist in the schema *)
 let validate_col_refs ~node_name ~(file : string option) ~schema ?(rename_mapping = []) expr =
@@ -505,7 +632,16 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
             diag_expected = Some expected_type;
             diag_actual = Some actual_type;
             diag_caused_by = [];
-            diag_suggested_fix = NoFix;
+            diag_suggested_fix =
+              if List.mem expected_type ["int"; "double"; "string"; "bool"]
+              then Diagnostics.Cast {
+                column = col_name;
+                cast_to = expected_type;
+                target_node = Some name;
+                file = Some file;
+                line = (match expr.loc with Some l -> Some l.line | None -> None);
+              }
+              else NoFix;
           } : Diagnostics.diagnostic) :: !diagnostics
         ) mismatches
       end;
@@ -534,6 +670,46 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
         last_rename_mapping := extract_rename_mapping op;
         current_validation_schema := apply_pipe_op !current_validation_schema op
       ) all_refs;
+
+      (* Validate expect() contracts: last position validates, mid-chain warns *)
+      let ops = unwrap_pipe expr in
+      let ops_len = List.length ops in
+      let contract_diags = ref [] in
+      let is_first = ref true in
+      List.iter (fun op ->
+        if classify_verb op = Expect then begin
+          if not !is_first || ops_len > 1 then begin
+            (* Mid-chain or chained expect(): warn placement *)
+            contract_diags := (Diagnostics.{
+              diag_id = gen_id ();
+              diag_error_class = Invalid_expect_placement;
+              diag_severity = Warning;
+              diag_phase = Schema;
+              diag_node_id = Some name;
+              diag_node_lang = None;
+              diag_file = Some file;
+              diag_line = (match op.loc with Some l -> Some l.line | None -> None);
+              diag_column = None;
+              diag_end_line = None;
+              diag_end_column = None;
+              diag_message = "expect() must be the last step in a pipeline. Contracts from this position will not be validated.";
+              diag_expected = None;
+              diag_actual = None;
+              diag_caused_by = [];
+              diag_suggested_fix = NoFix;
+            } : Diagnostics.diagnostic) :: !contract_diags
+          end else
+            (* Sole expect() at the end: validate contracts *)
+            let contracts = match op.node with
+              | Call { args; _ } -> extract_contracts args
+              | _ -> []
+            in
+            let diags = validate_contracts ~node_name:name ~file:(Some file) contracts !current_validation_schema in
+            contract_diags := diags @ !contract_diags
+        end;
+        is_first := false
+      ) ops;
+      diagnostics := !contract_diags @ !diagnostics;
 
       (* Also validate formula variables if this is a lm() or similar call *)
       match expr.node with

--- a/tests/test_check.ml
+++ b/tests/test_check.ml
@@ -397,4 +397,57 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
   check "t_fix dry_run returns String"
     (match result with Ast.VString _ -> true | _ -> false);
 
+  Printf.printf "\nName_error suggestions:\n";
+  let test_name_suggestion () =
+    let (name, suggestion) = Diagnostics.extract_name_and_suggestion "Variable 'prnt' is not defined" in
+    check "prnt extracts name" (name = "prnt");
+    check "prnt suggests print" (suggestion = Some "print");
+    let (_name2, suggestion2) = Diagnostics.extract_name_and_suggestion "Variable 'flter' is not defined" in
+    check "flter suggests filter" (suggestion2 = Some "filter");
+    let (_name3, suggestion3) = Diagnostics.extract_name_and_suggestion "Variable 'mutat' is not defined" in
+    check "mutat suggests mutate" (suggestion3 = Some "mutate");
+    let (_name4, suggestion4) = Diagnostics.extract_name_and_suggestion "Variable 'xyzzy_unknown' is not defined" in
+    check "unknown name has no suggestion" (suggestion4 = None)
+  in
+  test_name_suggestion ();
+
+  Printf.printf "\nSuggest_identifier fix:\n";
+  let test_suggest_identifier () =
+    let d = { Diagnostics.
+      diag_id = "T9001"; diag_error_class = Diagnostics.Name_error; diag_severity = Error;
+      diag_phase = Wire; diag_node_id = None; diag_node_lang = None;
+      diag_file = Some "test.t"; diag_line = Some 1; diag_column = None;
+      diag_end_line = None; diag_end_column = None;
+      diag_message = "Variable 'prnt' is not defined"; diag_expected = None; diag_actual = None;
+      diag_caused_by = [];
+      diag_suggested_fix = Diagnostics.Suggest_identifier { name = "prnt"; suggestion = "print"; target_node = None; file = Some "test.t"; line = Some 1 };
+    } in
+    let json = Diagnostics.diagnostic_to_yojson d in
+    let fix_json = Yojson.Safe.Util.member "suggested_fix" json in
+    let kind = Yojson.Safe.Util.member "kind" fix_json |> Yojson.Safe.Util.to_string in
+    check "Suggest_identifier serializes kind=suggest_identifier" (kind = "suggest_identifier");
+    let suggestion = Yojson.Safe.Util.member "suggestion" fix_json |> Yojson.Safe.Util.to_string in
+    check "Suggest_identifier serializes suggestion=print" (suggestion = "print");
+    let roundtrip = Diagnostics.suggested_fix_of_yojson fix_json in
+    (match roundtrip with
+     | Diagnostics.Suggest_identifier { name; suggestion = s; _ } ->
+         check "Suggest_identifier roundtrip name" (name = "prnt");
+         check "Suggest_identifier roundtrip suggestion" (s = "print")
+     | _ -> check "Suggest_identifier roundtrip fails" false)
+  in
+  test_suggest_identifier ();
+
+  Printf.printf "\nRun_command fix:\n";
+  let test_run_command () =
+    let fix = Diagnostics.Run_command { command = "t init ."; description = "Initialize tproject.toml"; target_node = None; file = Some "test.t"; line = None } in
+    let json = Diagnostics.suggested_fix_to_yojson fix in
+    let roundtrip = Diagnostics.suggested_fix_of_yojson json in
+    (match roundtrip with
+     | Diagnostics.Run_command { command; description; _ } ->
+         check "Run_command roundtrip command" (command = "t init .");
+         check "Run_command roundtrip description" (description = "Initialize tproject.toml")
+     | _ -> check "Run_command roundtrip fails" false)
+  in
+  test_run_command ();
+
   Printf.printf "\n";

--- a/tests/test_fix.ml
+++ b/tests/test_fix.ml
@@ -153,6 +153,8 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
       Cast { column = "y"; cast_to = "string"; target_node = None; file = Some "test.t"; line = Some 6 };
       Rename_column { old_name = "a"; new_name = "b"; target_node = Some "step2"; file = Some "test.t"; line = None };
       Add_node_arg { node = "filter"; arg = "na_rm=true"; target_node = None; file = Some "test.t"; line = None };
+      Suggest_identifier { name = "prnt"; suggestion = "print"; target_node = None; file = Some "test.t"; line = None };
+      Run_command { command = "t init ."; description = "Initialize tproject.toml"; target_node = None; file = Some "test.t"; line = None };
       NoFix;
     ] in
     let all_ok = List.for_all (fun fix ->
@@ -166,6 +168,10 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
           o1 = o2 && n1 = n2 && tn1 = tn2
       | Add_node_arg { node = n1; arg = a1; target_node = tn1; _ }, Add_node_arg { node = n2; arg = a2; target_node = tn2; _ } ->
           n1 = n2 && a1 = a2 && tn1 = tn2
+      | Suggest_identifier { name = nm1; suggestion = s1; _ }, Suggest_identifier { name = nm2; suggestion = s2; _ } ->
+          nm1 = nm2 && s1 = s2
+      | Run_command { command = cmd1; description = desc1; _ }, Run_command { command = cmd2; description = desc2; _ } ->
+          cmd1 = cmd2 && desc1 = desc2
       | _ -> false
     ) fixes in
     check "suggested_fix roundtrips through JSON" all_ok


### PR DESCRIPTION
… agentic suggestions

Phase 1: Cast fix generation in schema_check.ml — generates Cast fix instead of NoFix for type mismatches when expected type is int/double/string/bool.

Phase 2: expect() contract system — AST contract types, Contract_violation and Contract_unverifiable error classes, extract_contracts/validate_contracts in schema_check.ml, expect() no-op builtin.

Phase 3: Expanded suggested_fix — Suggest_identifier and Run_command variants, Levenshtein-based name suggestions (edit_distance, known_identifiers list), DataFrame column suggestions (Did you mean?), Missing_tproject/Missing_package Run_command fixes, pattern-match handling in fix.ml and t_fix.ml.

Tests: JSON roundtrip for new fix variants, extract_name_suggestion tests, Suggest_identifier/Run_command serialization tests.