### PR TITLE
feat(diagnostics): add suggested_fix confidence level and agent workf…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,10 @@ clean = raw
 ### Agent Check-Fix Loop Rules (Critical for LLMs)
 
 - **`t fix` is Not Idempotent:** `t fix` does not check if a suggestion was already applied. If you run `t check` -> `t fix` in a loop, you must count the number of diagnostics/errors returned. If the count does not decrease after a fix, **stop immediately** and do not run `t fix` again; otherwise, you will insert duplicate code blocks (e.g. repeated cast mutations).
+- **Suggested Fix Confidence Levels:** Every suggested fix contains a `"confidence"` string field in JSON (`"high"`, `"medium"`, or `"low"`) indicating its determinism:
+  - `Cast` & `Rename_column`: `"high"` (highly deterministic, safe to apply automatically)
+  - `Add_node_arg` & `Suggest_identifier`: `"medium"` (heuristic, verify before applying)
+  - `Run_command`: `"low"` (actionable commands, check manual commands before execution)
 - **Avoid Watch Mode:** Do NOT use `--watch` (e.g., `t check --watch`). It runs a blocking loop that waits for file changes and requires a manual `Ctrl+C` interrupt, which hangs agent execution.
 - **Schema Silencing on Custom Verbs:** If you use a custom or unrecognized function in a pipe chain, the schema compiler drops the schema to empty (`[]`). This silences subsequent column-reference checks downstream. Always manually verify column references if custom verbs are introduced.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -523,12 +523,12 @@ Safe changes (no approval needed):
 
 T uses a single source of truth for its version. To release a new version:
 
-1.  **Bump the Version**: Update the version string in the root [VERSION](file:///home/brodrigues/Documents/repos/tlang/VERSION) file (e.g., `0.51.1`).
+1.  **Bump the Version**: Update the version string in the root [VERSION](./VERSION) file (e.g., `0.51.1`).
 2.  **Sync Documentation**: Run the synchronization script to propagate the version to READMEs and documentation:
     ```bash
     ./scripts/sync_version.sh
     ```
-3.  **Update Changelog**: Add the release notes and date to [docs/changelog.md](file:///home/brodrigues/Documents/repos/tlang/docs/changelog.md).
+3.  **Update Changelog**: Add the release notes and date to [docs/changelog.md](./docs/changelog.md).
 4.  **Commit and Push**:
     ```bash
     git add .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,12 @@ clean = raw
 5. Run `dune runtest` — full test suite
 6. Run `build_pipeline(p)` — Nix build (only when structural checks pass)
 
+### Agent Check-Fix Loop Rules (Critical for LLMs)
+
+- **`t fix` is Not Idempotent:** `t fix` does not check if a suggestion was already applied. If you run `t check` -> `t fix` in a loop, you must count the number of diagnostics/errors returned. If the count does not decrease after a fix, **stop immediately** and do not run `t fix` again; otherwise, you will insert duplicate code blocks (e.g. repeated cast mutations).
+- **Avoid Watch Mode:** Do NOT use `--watch` (e.g., `t check --watch`). It runs a blocking loop that waits for file changes and requires a manual `Ctrl+C` interrupt, which hangs agent execution.
+- **Schema Silencing on Custom Verbs:** If you use a custom or unrecognized function in a pipe chain, the schema compiler drops the schema to empty (`[]`). This silences subsequent column-reference checks downstream. Always manually verify column references if custom verbs are introduced.
+
 ---
 
 ## Project Overview

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,10 +117,13 @@ clean = raw
 ### Agent Check-Fix Loop Rules (Critical for LLMs)
 
 - **`t fix` is Not Idempotent:** `t fix` does not check if a suggestion was already applied. If you run `t check` -> `t fix` in a loop, you must count the number of diagnostics/errors returned. If the count does not decrease after a fix, **stop immediately** and do not run `t fix` again; otherwise, you will insert duplicate code blocks (e.g. repeated cast mutations).
-- **Suggested Fix Confidence Levels:** Every suggested fix contains a `"confidence"` string field in JSON (`"high"`, `"medium"`, or `"low"`) indicating its determinism:
-  - `Cast` & `Rename_column`: `"high"` (highly deterministic, safe to apply automatically)
-  - `Add_node_arg` & `Suggest_identifier`: `"medium"` (heuristic, verify before applying)
-  - `Run_command`: `"low"` (actionable commands, check manual commands before execution)
+- **Suggested Fix Confidence Levels:** Every suggested fix contains a `"confidence"` string field in JSON (`"high"`, `"medium"`, or `"low"`) indicating whether the fix is deterministic or heuristic. Confidence is computed dynamically from diagnostic context, not static per fix kind:
+  - `Cast`: `"high"` when schema chain is intact, `"medium"` when broken (missing upstream column)
+  - `Rename_column`: `"high"` at edit distance 1 and unique, `"medium"` at distance 2, `"low"` at 3+
+  - `Add_node_arg`: always `"medium"` (heuristic, verify before applying)
+  - `Suggest_identifier`: `"high"` at distance 1 and unique, scales down with distance/uniqueness
+  - `Run_command`: always `"low"` (actionable commands, check manual commands before execution)
+  - **Note:** `t fix` applies all non-`NoFix` suggestions regardless of confidence. Confidence is informational for agents/tools to decide whether to auto-apply or review first.
 - **Avoid Watch Mode:** Do NOT use `--watch` (e.g., `t check --watch`). It runs a blocking loop that waits for file changes and requires a manual `Ctrl+C` interrupt, which hangs agent execution.
 - **Schema Silencing on Custom Verbs:** If you use a custom or unrecognized function in a pipe chain, the schema compiler drops the schema to empty (`[]`). This silences subsequent column-reference checks downstream. Always manually verify column references if custom verbs are introduced.
 

--- a/agents/skill-t-project.md
+++ b/agents/skill-t-project.md
@@ -189,7 +189,7 @@ then apply with `t fix`. Supported fix types carry a `confidence` field (`"high"
 
 ### ⚠️ Critical Rules for Agentic Check-Fix Loops
 
-1. **`t fix` is Not Idempotent:** `t fix` will mechanically insert code even if a identical correction was already applied in a previous step. You must re-run `t check` after every `t fix` and monitor the error count. If the error count does not decrease, **stop immediately** and do not run `t fix` again, otherwise you will corrupt the file.
+1. **`t fix` is Not Idempotent:** `t fix` will mechanically insert code even if an identical correction was already applied in a previous step. You must re-run `t check` after every `t fix` and monitor the error count. If the error count does not decrease, **stop immediately** and do not run `t fix` again, otherwise you will corrupt the file.
 2. **Never Use `--watch`:** Running `t check --watch` will start an infinite loop monitoring file changes, which blocks execution and hangs the agent.
 3. **Schema Silencing on Unrecognized Verbs:** If the pipe chain uses a custom/unrecognized function (i.e. not standard `select`, `filter`, `mutate`, `arrange`, etc.), the schema compiler drops the schema to empty (`[]`). This disables subsequent column-reference checks downstream. Always verify column references manually when custom functions are introduced.
 

--- a/agents/skill-t-project.md
+++ b/agents/skill-t-project.md
@@ -189,9 +189,12 @@ then apply with `t fix`. Supported fix types carry a `confidence` field (`"high"
 
 ### ⚠️ Critical Rules for Agentic Check-Fix Loops
 
-1. **`t fix` is Not Idempotent:** `t fix` will mechanically insert code even if an identical correction was already applied in a previous step. You must re-run `t check` after every `t fix` and monitor the error count. If the error count does not decrease, **stop immediately** and do not run `t fix` again, otherwise you will corrupt the file.
-2. **Never Use `--watch`:** Running `t check --watch` will start an infinite loop monitoring file changes, which blocks execution and hangs the agent.
-3. **Schema Silencing on Unrecognized Verbs:** If the pipe chain uses a custom/unrecognized function (i.e. not standard `select`, `filter`, `mutate`, `arrange`, etc.), the schema compiler drops the schema to empty (`[]`). This disables subsequent column-reference checks downstream. Always verify column references manually when custom functions are introduced.
+Before running check-fix loops or applying mechanical fixes, you MUST read and follow the **Agent Check-Fix Loop Rules** defined in the project's root [AGENTS.md](file:///home/brodrigues/Documents/repos/tlang/AGENTS.md#agent-check-fix-loop-rules). 
+
+These rules contain critical constraints regarding:
+- The non-idempotency of `t fix` and how to prevent code corruption.
+- Avoiding `--watch` mode which hangs agent execution.
+- Schema silencing limitations on custom/unrecognized verbs.
 
 **After `t run`:** Run `t diff` (or `t diff --json` for structured agent output) to see what changed. This is free (uses Nix content hashes) and tells you whether your edit had the intended effect or cascaded downstream.
 

--- a/agents/skill-t-project.md
+++ b/agents/skill-t-project.md
@@ -180,13 +180,20 @@ builds Python/R/Julia environments per node). Never trigger `t run` until `t che
 passes clean — you're wasting minutes on errors that could be caught in seconds.
 
 **When `t check --json` emits a `suggested_fix`:** Preview it with `t fix --dry-run`,
-then apply with `t fix`. Supported fix types:
-- `Cast` — inserts a type coercion (`mutate($col = as.double($col))`)
-- `Rename_column` — renames `$old` to `$new` in column references
-- `Add_node_arg` — adds a missing argument to a node definition
+then apply with `t fix`. Supported fix types carry a `confidence` field (`"high"`, `"medium"`, or `"low"`) indicating whether the fix is highly deterministic or heuristic:
+- `Cast` (High confidence) — inserts a type coercion (`mutate($col = as.double($col))`)
+- `Rename_column` (High confidence) — renames `$old` to `$new` in column references
+- `Add_node_arg` (Medium confidence) — adds a missing argument (e.g. deserializer) to a node definition
+- `Suggest_identifier` (Medium confidence) — suggests spelling corrections for names
+- `Run_command` (Low confidence) — suggests shell commands
 
-**After `t run`:** Run `t diff` to see what changed. This is free (uses Nix content
-hashes) and tells you whether your edit had the intended effect or cascaded downstream.
+### ⚠️ Critical Rules for Agentic Check-Fix Loops
+
+1. **`t fix` is Not Idempotent:** `t fix` will mechanically insert code even if a identical correction was already applied in a previous step. You must re-run `t check` after every `t fix` and monitor the error count. If the error count does not decrease, **stop immediately** and do not run `t fix` again, otherwise you will corrupt the file.
+2. **Never Use `--watch`:** Running `t check --watch` will start an infinite loop monitoring file changes, which blocks execution and hangs the agent.
+3. **Schema Silencing on Unrecognized Verbs:** If the pipe chain uses a custom/unrecognized function (i.e. not standard `select`, `filter`, `mutate`, `arrange`, etc.), the schema compiler drops the schema to empty (`[]`). This disables subsequent column-reference checks downstream. Always verify column references manually when custom functions are introduced.
+
+**After `t run`:** Run `t diff` (or `t diff --json` for structured agent output) to see what changed. This is free (uses Nix content hashes) and tells you whether your edit had the intended effect or cascaded downstream.
 
 **`t check --schema` limitation:** This validates structure and type contracts in milliseconds, but does NOT build the pipeline. Calls to `read_node()` in post-build sections will error during `t check` — these are expected. Verify with `t run` instead.
 

--- a/agents/skill-t-project.md
+++ b/agents/skill-t-project.md
@@ -189,7 +189,7 @@ then apply with `t fix`. Supported fix types carry a `confidence` field (`"high"
 
 ### ⚠️ Critical Rules for Agentic Check-Fix Loops
 
-Before running check-fix loops or applying mechanical fixes, you MUST read and follow the **Agent Check-Fix Loop Rules** defined in the project's root [AGENTS.md](file:///home/brodrigues/Documents/repos/tlang/AGENTS.md#agent-check-fix-loop-rules). 
+Before running check-fix loops or applying mechanical fixes, you MUST read and follow the **Agent Check-Fix Loop Rules** defined in the project's root [AGENTS.md](../AGENTS.md#agent-check-fix-loop-rules). 
 
 These rules contain critical constraints regarding:
 - The non-idempotency of `t fix` and how to prevent code corruption.

--- a/agents/skill-t-project.md
+++ b/agents/skill-t-project.md
@@ -180,12 +180,14 @@ builds Python/R/Julia environments per node). Never trigger `t run` until `t che
 passes clean — you're wasting minutes on errors that could be caught in seconds.
 
 **When `t check --json` emits a `suggested_fix`:** Preview it with `t fix --dry-run`,
-then apply with `t fix`. Supported fix types carry a `confidence` field (`"high"`, `"medium"`, or `"low"`) indicating whether the fix is highly deterministic or heuristic:
-- `Cast` (High confidence) — inserts a type coercion (`mutate($col = as.double($col))`)
-- `Rename_column` (High confidence) — renames `$old` to `$new` in column references
-- `Add_node_arg` (Medium confidence) — adds a missing argument (e.g. deserializer) to a node definition
-- `Suggest_identifier` (Medium confidence) — suggests spelling corrections for names
-- `Run_command` (Low confidence) — suggests shell commands
+then apply with `t fix`. Supported fix types carry a `confidence` field (`"high"`, `"medium"`, or `"low"`) computed dynamically from diagnostic context:
+- `Cast` — `"high"` when schema chain is intact, `"medium"` when broken (missing upstream column). Inserts a type coercion (`mutate($col = as.double($col))`)
+- `Rename_column` — `"high"` at edit distance 1 and unique, `"medium"` at distance 2, `"low"` at 3+. Renames `$old` to `$new` in column references
+- `Add_node_arg` — always `"medium"`. Adds a missing argument (e.g. deserializer) to a node definition
+- `Suggest_identifier` — scales with edit distance and uniqueness. Suggests spelling corrections for names
+- `Run_command` — always `"low"`. Suggests shell commands
+
+**Note:** `t fix` applies all non-`NoFix` suggestions regardless of confidence. Confidence is informational for you to decide whether to auto-apply or review first.
 
 ### ⚠️ Critical Rules for Agentic Check-Fix Loops
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3311,6 +3311,16 @@ The `tier` field is derived from the deepest phase that produced diagnostics: pa
 
 Each diagnostic entry contains: `id`, `error_class`, `severity`, `phase`, `node` (with nested `id`, `lang`, `file`, and `span` containing `start` and `end`), `message`, `expected`, `actual`, `caused_by`, and `suggested_fix`.
 
+**`suggested_fix` structure:** When non-null, a `suggested_fix` is a JSON object with a `kind` field and fix-specific fields. Every fix also carries a `confidence` field (`"high"`, `"medium"`, or `"low"`) indicating whether the fix is deterministic or heuristic. Confidence is computed dynamically from diagnostic context (e.g., schema chain integrity, edit distance) rather than being a static label per fix kind:
+
+| `kind` | Typical confidence | When it drops | Key fields |
+|--------|-------------------|---------------|------------|
+| `cast` | `"high"` | `"medium"` when schema chain is broken (missing upstream column) | `column`, `cast_to`, `target_node`, `line` |
+| `rename_column` | `"high"` | `"medium"` at edit distance 2; `"low"` at distance 3+ | `old_name`, `new_name`, `target_node` |
+| `add_node_arg` | `"medium"` | Always `"medium"` | `node`, `arg`, `target_node` |
+| `suggest_identifier` | varies | Scales with edit distance and uniqueness | `name`, `suggestion`, `target_node` |
+| `run_command` | `"low"` | Always `"low"` | `command`, `description`, `target_node` |
+
 **`error_class` enum values:** `structural_error`, `name_error`, `arity_error`, `type_error`, `parse_error`, `file_error`, `key_error`, `index_error`, `value_error`, `runtime_error`, `division_by_zero`, `assertion_error`, `match_error`, `shell_error`, `aggregation_error`, `na_predicate_error`, `missing_artifact`, `generic_error`, `schema_mismatch`, `contract_violation`, `contract_unverifiable`, `missing_tproject`, `missing_package`, `missing_from_lockfile`, `nix_generation_error`, `nix_eval_error`, `invalid_expect_placement`, `na_warning`, `unknown_error`.
 
 **Examples:**
@@ -3820,7 +3830,8 @@ $ t check --json pipeline.t | jq '.diagnostics[].suggested_fix'
   "cast_to": "double",
   "target_node": "clean",
   "file": "pipeline.t",
-  "line": 5
+  "line": 5,
+  "confidence": "high"
 }
 
 $ t fix pipeline.t

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,7 @@
 - **Tier 1 CLI (`t check <file>`)**: Structural pipeline validation without triggering Nix builds. Catches parse errors, DAG cycles, dangling node references, arity errors, and built-in name resolution. Exit codes: 0=clean, 1=wire error, 2=schema error, 3=env error.
 - **Tier 2 Schema Validation (`t check --schema`)**: Static column-name and type propagation through the pipeline DAG. Validates column references against inferred upstream schemas, checks `expect()` type contracts, and reports contract violations with `Cast` suggested fixes.
 - **Structured JSON Diagnostics (`--json`)**: Machine-readable output for all tiers, with `schema_version`, `status`, `phase`, `tier`, and per-diagnostic `error_class` (stable enum), `severity`, `expected`, `actual`, `caused_by`, and `suggested_fix` fields. **Breaking change:** `file` and `span` (with `start` and `end`) are now nested inside the `node` sub-object. Designed for agent tooling.
+- **Dynamic confidence levels**: Every `suggested_fix` now carries a `confidence` field (`"high"`, `"medium"`, `"low"`) computed from diagnostic context. `Cast` is `"high"` when the schema chain is intact, drops to `"medium"` when broken. `Rename_column` and `Suggest_identifier` scale with edit distance and uniqueness. `Add_node_arg` is always `"medium"`, `Run_command` always `"low"`.
 - **`t_check(file, json, schema, env)` REPL function**: Invoke `t check` from within a T session.
 
 ### `t diff` — Content-Addressed Output Diffing

--- a/spec_files/confidence_design_study.md
+++ b/spec_files/confidence_design_study.md
@@ -1,0 +1,100 @@
+# Architectural Study: Calculated Suggested-Fix Confidence Levels
+
+This document explores how to transition the `confidence` annotation on diagnostics from a static per-constructor label into a dynamic, context-aware signal computed at the point of inference.
+
+---
+
+## 1. Concrete Signals & Rules
+
+For each suggested fix type, we can compute confidence by analyzing the evidence backing the inference:
+
+```mermaid
+graph TD
+    A[Error Incurred] --> B{Fix Type}
+    
+    B -->|Cast| C{Unbroken Schema Chain?}
+    C -->|Yes| C1[High Confidence]
+    C -->|No/Silenced| C2[Medium/Low Confidence]
+    
+    B -->|Rename| D{ typo edit distance }
+    D -->|Distance = 1 & Unique| D1[High Confidence]
+    D -->|Distance >= 2 / Ambiguous| D2[Medium/Low Confidence]
+    
+    B -->|Suggest_identifier| E{Levenshtein score}
+    E -->|score = 1| E1[High Confidence]
+    E -->|score = 2| E2[Medium Confidence]
+    E -->|score >= 3| E3[Low Confidence]
+    
+    B -->|Add_node_arg| F{Upstream serializer known?}
+    F -->|Yes| F1[High Confidence]
+    F -->|No / Guessing| F2[Medium/Low Confidence]
+```
+
+### `Cast` Fixes (Type Mismatches)
+*   **Dynamic Rule:** If a type mismatch is detected on a schema derived from a fully typed, unbroken pipeline chain, confidence is **High**. If the schema chain passed through an unrecognized or custom function (which dropped schema propagation to `[]` downstream), the mismatch is likely a false positive or unreliable—confidence drops to **Medium** or the fix is suppressed.
+*   **Implementation Signal:** Trace the schema chain's integrity (e.g. track a boolean flag `schema_is_complete` alongside the schema list through the DAG walk).
+
+### `Rename_column` Fixes (Missing Column References)
+*   **Dynamic Rule:** If the renamer is matching a typo (e.g. suggesting `$mpg` for `$mpg2` or `$cyl` for `$cly`), confidence should reflect Levenshtein distance and candidate uniqueness:
+    *   **High:** Distance = 1, and only one candidate exists in the schema within threshold.
+    *   **Medium:** Distance = 2, or multiple similar candidates exist (e.g. schema has both `$cyl` and `$cycle` when matching `$cly`).
+    *   **Low:** Distance $\ge$ 3, or high candidate ambiguity.
+*   **Implementation Signal:** Leverage a revised `suggest_name` function that exposes edit distance and candidate-set cardinality.
+
+### `Suggest_identifier` Fixes (Spelling Suggestions)
+*   **Dynamic Rule:** Similar to renames, scale confidence directly with Levenshtein distance:
+    *   **High:** Distance = 1 (e.g. `mutat` $\to$ `mutate`).
+    *   **Medium:** Distance = 2 (e.g. `prnt` $\to$ `print`).
+    *   **Low:** Distance $\ge$ 3.
+
+### `Add_node_arg` Fixes (Missing Deserializers)
+*   **Dynamic Rule:** If the compiler has access to the upstream dependency node's serialization target, it can resolve the missing deserializer with **High** confidence. If the compiler is guessing solely based on the dependency's runtime parsed from the error message (as it currently does), it is a heuristic—confidence is **Medium**.
+
+---
+
+## 2. Implementation Paths
+
+To represent this in the compiler, we have two available architectural paths:
+
+### Path A: Typed AST Representation (Recommended)
+Add `confidence` directly to the variant payload fields in `diagnostics.ml`.
+
+```ocaml
+type confidence = High | Medium | Low
+
+type suggested_fix =
+  | Cast of {
+      column: string;
+      cast_to: string;
+      target_node: string option;
+      file: string option;
+      line: int option;
+      confidence: confidence; (* Added *)
+    }
+  | Rename_column of { ...; confidence: confidence }
+  (* ... *)
+```
+
+*   **Pros:**
+    *   Type safety: The compiler enforces that every piece of code generating a fix must explicitly calculate and supply a confidence score.
+    *   Easily auditable: All inference sites are forced to declare their logic.
+*   **Cons:**
+    *   Requires updating all pattern matches (`fix.ml`, `t_fix.ml`, tests) to handle the new record field.
+
+### Path B: Contextual Serialization Helper
+Keep the OCaml type constructors unchanged, but store the underlying signals (e.g. `distance: int option`, `chain_broken: bool option`) inside the variant payloads, then resolve confidence inside `suggested_fix_to_yojson`.
+
+*   **Pros:**
+    *   Separates semantic compiler structures from client-facing diagnostic metrics.
+    *   Slightly less pattern-matching code churn.
+*   **Cons:**
+    *   Splits the confidence logic across two layers (computational signals stored in AST, resolved to label at serialization).
+
+---
+
+## 3. Recommended Next Steps
+
+If we proceed with Path A, the immediate tasks are:
+1.  Refactor `Ast.suggest_name` to return the score: `val suggest_name : string -> string list -> (string * int) option`.
+2.  Extend `Diagnostics.suggested_fix` variants with `confidence: confidence`.
+3.  Thread the Levenshtein score from name suggestions and the schema-integrity flag from `schema_check.ml` into the construction sites.

--- a/spec_files/confidence_design_study.md
+++ b/spec_files/confidence_design_study.md
@@ -6,7 +6,7 @@ This document explores how to transition the `confidence` annotation on diagnost
 
 ## 1. Concrete Signals & Rules
 
-For each suggested fix type, we can compute confidence by analyzing the evidence backing the inference:
+For each suggested fix type, we compute confidence by analyzing the evidence backing the inference:
 
 ```mermaid
 graph TD
@@ -20,44 +20,51 @@ graph TD
     D -->|Distance = 1 & Unique| D1[High Confidence]
     D -->|Distance >= 2 / Ambiguous| D2[Medium/Low Confidence]
     
-    B -->|Suggest_identifier| E{Levenshtein score}
-    E -->|score = 1| E1[High Confidence]
-    E -->|score = 2| E2[Medium Confidence]
-    E -->|score >= 3| E3[Low Confidence]
+    B -->|Suggest_identifier| E{Levenshtein candidates list}
+    E -->|Unique best with dist = 1| E1[High Confidence]
+    E -->|Unique best with dist = 2| E2[Medium Confidence]
+    E -->|Multiple close candidates / dist >= 3| E3[Low Confidence]
     
-    B -->|Add_node_arg| F{Upstream serializer known?}
+    B -->|Add_node_arg| F{Upstream serializer resolved?}
     F -->|Yes| F1[High Confidence]
-    F -->|No / Guessing| F2[Medium/Low Confidence]
+    F -->|Parsed from error message only| F2[Medium Confidence]
 ```
 
 ### `Cast` Fixes (Type Mismatches)
 *   **Dynamic Rule:** If a type mismatch is detected on a schema derived from a fully typed, unbroken pipeline chain, confidence is **High**. If the schema chain passed through an unrecognized or custom function (which dropped schema propagation to `[]` downstream), the mismatch is likely a false positive or unreliable—confidence drops to **Medium** or the fix is suppressed.
 *   **Implementation Signal:** Trace the schema chain's integrity (e.g. track a boolean flag `schema_is_complete` alongside the schema list through the DAG walk).
 
-### `Rename_column` Fixes (Missing Column References)
-*   **Dynamic Rule:** If the renamer is matching a typo (e.g. suggesting `$mpg` for `$mpg2` or `$cyl` for `$cly`), confidence should reflect Levenshtein distance and candidate uniqueness:
-    *   **High:** Distance = 1, and only one candidate exists in the schema within threshold.
-    *   **Medium:** Distance = 2, or multiple similar candidates exist (e.g. schema has both `$cyl` and `$cycle` when matching `$cly`).
-    *   **Low:** Distance $\ge$ 3, or high candidate ambiguity.
-*   **Implementation Signal:** Leverage a revised `suggest_name` function that exposes edit distance and candidate-set cardinality.
-
-### `Suggest_identifier` Fixes (Spelling Suggestions)
-*   **Dynamic Rule:** Similar to renames, scale confidence directly with Levenshtein distance:
-    *   **High:** Distance = 1 (e.g. `mutat` $\to$ `mutate`).
-    *   **Medium:** Distance = 2 (e.g. `prnt` $\to$ `print`).
-    *   **Low:** Distance $\ge$ 3.
+### `Rename_column` & `Suggest_identifier` Fixes (Typo/Spelling Suggestions)
+To prevent two implementers from building inconsistent behavior, candidate uniqueness and thresholds are defined as follows:
+*   **Candidate Search Range:** The search candidate list is retrieved via `levenshtein` distance comparison. A candidate `c` is valid if `levenshtein name c <= max(2, String.length name / 3)`.
+*   **Defining Candidate Uniqueness:**
+    *   **High Confidence:** Exactly one candidate is found within the search range with a distance of $1$, OR a best candidate has a distance of $1$ and the runner-up candidate has a distance difference of $\ge 2$ (e.g., best is distance 1, runner-up is distance 3 or more).
+    *   **Medium Confidence:** The best candidate has a distance of $2$ and is unique, OR multiple candidates exist but the gap between the best and runner-up candidate is at least $1$ (e.g., best distance 1, runner-up distance 2).
+    *   **Low Confidence:** Multiple candidates have the same edit distance (a tie), OR the best candidate distance is $\ge 3$.
+*   **Implementation Signal:** The candidate picker returns the sorted list of candidates with their scores: `(string * int) list`.
 
 ### `Add_node_arg` Fixes (Missing Deserializers)
-*   **Dynamic Rule:** If the compiler has access to the upstream dependency node's serialization target, it can resolve the missing deserializer with **High** confidence. If the compiler is guessing solely based on the dependency's runtime parsed from the error message (as it currently does), it is a heuristic—confidence is **Medium**.
+*   **Spike/Caveat:** The upstream node's serialization targets may not always be clean or exposed as a simple boolean flag to `t_check`. 
+*   **Dynamic Rule:** If the upstream serializer is explicitly resolved by inspecting the pipeline DAG, confidence is **High**. If the compiler is parsing the error message text and guessing the default runtime serializer (e.g., default `^csv` for R/Python, `^arrow` for Julia), the signal is weaker—confidence remains **Medium**. If no runtime can be parsed, the fix remains **NoFix**.
 
 ---
 
 ## 2. Implementation Paths
 
-To represent this in the compiler, we have two available architectural paths:
+To represent this in the compiler, we evaluate three available architectural paths:
 
-### Path A: Typed AST Representation (Recommended)
+### Path A: Typed AST Representation
 Add `confidence` directly to the variant payload fields in `diagnostics.ml`.
+*   **Pros:** Strongly typed, compiles-time verified.
+*   **Cons:** Higher code churn across `fix.ml`, `t_fix.ml`, and tests.
+
+### Path B: Contextual Serialization Helper
+Keep the OCaml type constructors unchanged, but store the underlying signals (e.g., `distance`, `candidate_count`, `chain_broken`) inside the variant payloads, then resolve confidence inside `suggested_fix_to_yojson`.
+*   **Pros:** Separates semantic compiler structures from client-facing diagnostic metrics; allows changing the mapping thresholds without changing all constructor sites.
+*   **Cons:** Splits the confidence logic across two layers.
+
+### Path C: Hybrid Approach (Recommended)
+Store the raw signals (`distance`, `candidate_count`, `chain_broken`) directly in the variant constructor payloads, *and* include a required `confidence` field on the variant, computed once via a centralized pure function (`confidence_of_signals`) called at constructor instantiation time.
 
 ```ocaml
 type confidence = High | Medium | Low
@@ -69,32 +76,33 @@ type suggested_fix =
       target_node: string option;
       file: string option;
       line: int option;
-      confidence: confidence; (* Added *)
+      chain_broken: bool;
+      confidence: confidence; (* Computed at instantiation *)
     }
-  | Rename_column of { ...; confidence: confidence }
-  (* ... *)
+  | Rename_column of {
+      old_name: string;
+      new_name: string;
+      target_node: string option;
+      file: string option;
+      line: int option;
+      edit_distance: int;
+      is_unique: bool;
+      confidence: confidence;
+    }
 ```
 
-*   **Pros:**
-    *   Type safety: The compiler enforces that every piece of code generating a fix must explicitly calculate and supply a confidence score.
-    *   Easily auditable: All inference sites are forced to declare their logic.
-*   **Cons:**
-    *   Requires updating all pattern matches (`fix.ml`, `t_fix.ml`, tests) to handle the new record field.
-
-### Path B: Contextual Serialization Helper
-Keep the OCaml type constructors unchanged, but store the underlying signals (e.g. `distance: int option`, `chain_broken: bool option`) inside the variant payloads, then resolve confidence inside `suggested_fix_to_yojson`.
-
-*   **Pros:**
-    *   Separates semantic compiler structures from client-facing diagnostic metrics.
-    *   Slightly less pattern-matching code churn.
-*   **Cons:**
-    *   Splits the confidence logic across two layers (computational signals stored in AST, resolved to label at serialization).
+*   **Why this is best:**
+    *   **Testability:** The centralized `confidence_of_signals` function can be unit-tested independently against different edge cases (e.g., "does distance 2 and chain-broken output medium?").
+    *   **Centralized Thresholding:** If we want to tune the thresholds (e.g., deciding distance-2 with a unique candidate deserves "high"), we only modify one place in the code, rather than auditing every construction site.
+    *   **Compiler Enforcement:** Every constructor instantiation is still forced to compute and supply the confidence value, preventing silent omissions.
 
 ---
 
 ## 3. Recommended Next Steps
 
-If we proceed with Path A, the immediate tasks are:
-1.  Refactor `Ast.suggest_name` to return the score: `val suggest_name : string -> string list -> (string * int) option`.
-2.  Extend `Diagnostics.suggested_fix` variants with `confidence: confidence`.
-3.  Thread the Levenshtein score from name suggestions and the schema-integrity flag from `schema_check.ml` into the construction sites.
+1.  **Refactor `Ast.suggest_name`** to return the sorted list of candidates with scores: 
+    ```ocaml
+    val suggest_name : string -> string list -> (string * int) list
+    ```
+2.  **Implement `confidence_of_signals`** in `diagnostics.ml` as a pure, centralized resolver.
+3.  **Audit test assertions:** Update test suites (like `test_check.ml`) to use deliberate test fixtures (e.g., constructing a `Cast` fix with `chain_broken = true` to assert it degrades the serialized confidence correctly), rather than asserting static literals.

--- a/spec_files/confidence_design_study.md
+++ b/spec_files/confidence_design_study.md
@@ -6,7 +6,7 @@ This document explores how to transition the `confidence` annotation on diagnost
 
 ## 1. Concrete Signals & Rules
 
-For each suggested fix type, we compute confidence by analyzing the evidence backing the inference:
+For each suggested fix type, we can compute confidence by analyzing the evidence backing the inference:
 
 ```mermaid
 graph TD
@@ -20,51 +20,44 @@ graph TD
     D -->|Distance = 1 & Unique| D1[High Confidence]
     D -->|Distance >= 2 / Ambiguous| D2[Medium/Low Confidence]
     
-    B -->|Suggest_identifier| E{Levenshtein candidates list}
-    E -->|Unique best with dist = 1| E1[High Confidence]
-    E -->|Unique best with dist = 2| E2[Medium Confidence]
-    E -->|Multiple close candidates / dist >= 3| E3[Low Confidence]
+    B -->|Suggest_identifier| E{Levenshtein score}
+    E -->|score = 1| E1[High Confidence]
+    E -->|score = 2| E2[Medium Confidence]
+    E -->|score >= 3| E3[Low Confidence]
     
-    B -->|Add_node_arg| F{Upstream serializer resolved?}
+    B -->|Add_node_arg| F{Upstream serializer known?}
     F -->|Yes| F1[High Confidence]
-    F -->|Parsed from error message only| F2[Medium Confidence]
+    F -->|No / Guessing| F2[Medium/Low Confidence]
 ```
 
 ### `Cast` Fixes (Type Mismatches)
 *   **Dynamic Rule:** If a type mismatch is detected on a schema derived from a fully typed, unbroken pipeline chain, confidence is **High**. If the schema chain passed through an unrecognized or custom function (which dropped schema propagation to `[]` downstream), the mismatch is likely a false positive or unreliable—confidence drops to **Medium** or the fix is suppressed.
 *   **Implementation Signal:** Trace the schema chain's integrity (e.g. track a boolean flag `schema_is_complete` alongside the schema list through the DAG walk).
 
-### `Rename_column` & `Suggest_identifier` Fixes (Typo/Spelling Suggestions)
-To prevent two implementers from building inconsistent behavior, candidate uniqueness and thresholds are defined as follows:
-*   **Candidate Search Range:** The search candidate list is retrieved via `levenshtein` distance comparison. A candidate `c` is valid if `levenshtein name c <= max(2, String.length name / 3)`.
-*   **Defining Candidate Uniqueness:**
-    *   **High Confidence:** Exactly one candidate is found within the search range with a distance of $1$, OR a best candidate has a distance of $1$ and the runner-up candidate has a distance difference of $\ge 2$ (e.g., best is distance 1, runner-up is distance 3 or more).
-    *   **Medium Confidence:** The best candidate has a distance of $2$ and is unique, OR multiple candidates exist but the gap between the best and runner-up candidate is at least $1$ (e.g., best distance 1, runner-up distance 2).
-    *   **Low Confidence:** Multiple candidates have the same edit distance (a tie), OR the best candidate distance is $\ge 3$.
-*   **Implementation Signal:** The candidate picker returns the sorted list of candidates with their scores: `(string * int) list`.
+### `Rename_column` Fixes (Missing Column References)
+*   **Dynamic Rule:** If the renamer is matching a typo (e.g. suggesting `$mpg` for `$mpg2` or `$cyl` for `$cly`), confidence should reflect Levenshtein distance and candidate uniqueness:
+    *   **High:** Distance = 1, and only one candidate exists in the schema within threshold.
+    *   **Medium:** Distance = 2, or multiple similar candidates exist (e.g. schema has both `$cyl` and `$cycle` when matching `$cly`).
+    *   **Low:** Distance $\ge$ 3, or high candidate ambiguity.
+*   **Implementation Signal:** Leverage a revised `suggest_name` function that exposes edit distance and candidate-set cardinality.
+
+### `Suggest_identifier` Fixes (Spelling Suggestions)
+*   **Dynamic Rule:** Similar to renames, scale confidence directly with Levenshtein distance:
+    *   **High:** Distance = 1 (e.g. `mutat` $\to$ `mutate`).
+    *   **Medium:** Distance = 2 (e.g. `prnt` $\to$ `print`).
+    *   **Low:** Distance $\ge$ 3.
 
 ### `Add_node_arg` Fixes (Missing Deserializers)
-*   **Spike/Caveat:** The upstream node's serialization targets may not always be clean or exposed as a simple boolean flag to `t_check`. 
-*   **Dynamic Rule:** If the upstream serializer is explicitly resolved by inspecting the pipeline DAG, confidence is **High**. If the compiler is parsing the error message text and guessing the default runtime serializer (e.g., default `^csv` for R/Python, `^arrow` for Julia), the signal is weaker—confidence remains **Medium**. If no runtime can be parsed, the fix remains **NoFix**.
+*   **Dynamic Rule:** If the compiler has access to the upstream dependency node's serialization target, it can resolve the missing deserializer with **High** confidence. If the compiler is guessing solely based on the dependency's runtime parsed from the error message (as it currently does), it is a heuristic—confidence is **Medium**.
 
 ---
 
 ## 2. Implementation Paths
 
-To represent this in the compiler, we evaluate three available architectural paths:
+To represent this in the compiler, we have two available architectural paths:
 
-### Path A: Typed AST Representation
+### Path A: Typed AST Representation (Recommended)
 Add `confidence` directly to the variant payload fields in `diagnostics.ml`.
-*   **Pros:** Strongly typed, compiles-time verified.
-*   **Cons:** Higher code churn across `fix.ml`, `t_fix.ml`, and tests.
-
-### Path B: Contextual Serialization Helper
-Keep the OCaml type constructors unchanged, but store the underlying signals (e.g., `distance`, `candidate_count`, `chain_broken`) inside the variant payloads, then resolve confidence inside `suggested_fix_to_yojson`.
-*   **Pros:** Separates semantic compiler structures from client-facing diagnostic metrics; allows changing the mapping thresholds without changing all constructor sites.
-*   **Cons:** Splits the confidence logic across two layers.
-
-### Path C: Hybrid Approach (Recommended)
-Store the raw signals (`distance`, `candidate_count`, `chain_broken`) directly in the variant constructor payloads, *and* include a required `confidence` field on the variant, computed once via a centralized pure function (`confidence_of_signals`) called at constructor instantiation time.
 
 ```ocaml
 type confidence = High | Medium | Low
@@ -76,33 +69,32 @@ type suggested_fix =
       target_node: string option;
       file: string option;
       line: int option;
-      chain_broken: bool;
-      confidence: confidence; (* Computed at instantiation *)
+      confidence: confidence; (* Added *)
     }
-  | Rename_column of {
-      old_name: string;
-      new_name: string;
-      target_node: string option;
-      file: string option;
-      line: int option;
-      edit_distance: int;
-      is_unique: bool;
-      confidence: confidence;
-    }
+  | Rename_column of { ...; confidence: confidence }
+  (* ... *)
 ```
 
-*   **Why this is best:**
-    *   **Testability:** The centralized `confidence_of_signals` function can be unit-tested independently against different edge cases (e.g., "does distance 2 and chain-broken output medium?").
-    *   **Centralized Thresholding:** If we want to tune the thresholds (e.g., deciding distance-2 with a unique candidate deserves "high"), we only modify one place in the code, rather than auditing every construction site.
-    *   **Compiler Enforcement:** Every constructor instantiation is still forced to compute and supply the confidence value, preventing silent omissions.
+*   **Pros:**
+    *   Type safety: The compiler enforces that every piece of code generating a fix must explicitly calculate and supply a confidence score.
+    *   Easily auditable: All inference sites are forced to declare their logic.
+*   **Cons:**
+    *   Requires updating all pattern matches (`fix.ml`, `t_fix.ml`, tests) to handle the new record field.
+
+### Path B: Contextual Serialization Helper
+Keep the OCaml type constructors unchanged, but store the underlying signals (e.g. `distance: int option`, `chain_broken: bool option`) inside the variant payloads, then resolve confidence inside `suggested_fix_to_yojson`.
+
+*   **Pros:**
+    *   Separates semantic compiler structures from client-facing diagnostic metrics.
+    *   Slightly less pattern-matching code churn.
+*   **Cons:**
+    *   Splits the confidence logic across two layers (computational signals stored in AST, resolved to label at serialization).
 
 ---
 
 ## 3. Recommended Next Steps
 
-1.  **Refactor `Ast.suggest_name`** to return the sorted list of candidates with scores: 
-    ```ocaml
-    val suggest_name : string -> string list -> (string * int) list
-    ```
-2.  **Implement `confidence_of_signals`** in `diagnostics.ml` as a pure, centralized resolver.
-3.  **Audit test assertions:** Update test suites (like `test_check.ml`) to use deliberate test fixtures (e.g., constructing a `Cast` fix with `chain_broken = true` to assert it degrades the serialized confidence correctly), rather than asserting static literals.
+If we proceed with Path A, the immediate tasks are:
+1.  Refactor `Ast.suggest_name` to return the score: `val suggest_name : string -> string list -> (string * int) option`.
+2.  Extend `Diagnostics.suggested_fix` variants with `confidence: confidence`.
+3.  Thread the Levenshtein score from name suggestions and the schema-integrity flag from `schema_check.ml` into the construction sites.

--- a/spec_files/implementation_plan.md
+++ b/spec_files/implementation_plan.md
@@ -45,13 +45,13 @@ The centralized helper functions in `diagnostics.ml` will map compiler signals t
 
 ### AST Layer
 
-#### [MODIFY] [ast.ml](file:///home/brodrigues/Documents/repos/tlang/src/ast.ml)
+#### [MODIFY] [ast.ml](./src/ast.ml)
 - Add `suggest_names_with_scores : string -> string list -> (string * int) list` returning all matches within Levenshtein range, sorted by distance.
 - Re-implement `suggest_name` in terms of `suggest_names_with_scores` to ensure 100% backward compatibility with `eval.ml`.
 
 ### Diagnostics Layer
 
-#### [MODIFY] [diagnostics.ml](file:///home/brodrigues/Documents/repos/tlang/src/diagnostics.ml)
+#### [MODIFY] [diagnostics.ml](./src/diagnostics.ml)
 - Define `type confidence = High | Medium | Low`.
 - Update `type suggested_fix` constructor payloads to include `confidence` and their respective signal fields:
   ```ocaml
@@ -74,25 +74,25 @@ The centralized helper functions in `diagnostics.ml` will map compiler signals t
 
 ### Schema Checking Layer
 
-#### [MODIFY] [schema_check.ml](file:///home/brodrigues/Documents/repos/tlang/src/schema_check.ml)
+#### [MODIFY] [schema_check.ml](./src/schema_check.ml)
 - Track schema chain integrity: `chain_broken` is set to `true` if a schema was derived downstream of any unrecognized or custom function (which drops schema propagation to `[]`).
 - Update `Cast` and `Rename_column` fix instantiation to use the new smart constructors, passing calculated signal metrics.
 
 ### Mechanical Fix Application Layer
 
-#### [MODIFY] [fix.ml](file:///home/brodrigues/Documents/repos/tlang/src/fix.ml)
+#### [MODIFY] [fix.ml](./src/fix.ml)
 - Update `suggested_fix` pattern matching in `apply_fix` and `apply_fixes` to match the new constructor payloads.
 
-#### [MODIFY] [t_fix.ml](file:///home/brodrigues/Documents/repos/tlang/src/packages/pipeline/t_fix.ml)
+#### [MODIFY] [t_fix.ml](./src/packages/pipeline/t_fix.ml)
 - Update `suggested_fix` pattern matching in `format_fix_result` to match the new constructor payloads.
 
 ### Unit Tests
 
-#### [MODIFY] [test_check.ml](file:///home/brodrigues/Documents/repos/tlang/tests/test_check.ml)
+#### [MODIFY] [test_check.ml](./tests/test_check.ml)
 - Update test cases constructing `suggested_fix` records.
 - Add test cases explicitly checking that confidence degrades correctly under chain-broken or ambiguous typo scenarios.
 
-#### [MODIFY] [test_fix.ml](file:///home/brodrigues/Documents/repos/tlang/tests/test_fix.ml)
+#### [MODIFY] [test_fix.ml](./tests/test_fix.ml)
 - Update test cases constructing `suggested_fix` records.
 
 ---

--- a/spec_files/implementation_plan.md
+++ b/spec_files/implementation_plan.md
@@ -10,10 +10,34 @@ This plan details the implementation of **Path C (Hybrid Approach)** to transiti
 > - **Smart Constructors:** To prevent representation drift between raw signals and precomputed `confidence` values, variants of `suggested_fix` will be created *only* via centralized smart constructors (e.g. `Diagnostics.make_cast_fix`, `Diagnostics.make_rename_column_fix`). Exposing raw record construction of fixes is disallowed.
 > - **Centralized Resolution:** The signal-to-label threshold mapping is isolated inside `Diagnostics.confidence_of_signals` (or helper functions) in `diagnostics.ml`, allowing easy threshold tuning and unit testing.
 > - **JSON Serialization Contract:** The JSON diagnostics schema remains clean and backward-compatible: it will serialize the precomputed `"confidence"` string, but will *not* expose the internal OCaml signal fields (`chain_broken`, `edit_distance`, `is_unique`) to keep the public API minimal.
+> - **of_yojson Defaults:** When deserializing a suggested fix from JSON, internal signal fields that are absent in the JSON representation will be assigned safe defaults (`chain_broken = false`, `edit_distance = 0`, `is_unique = true`). Round-trip unit tests will assert the equality of serialized fields (like `confidence` and syntactic parameters) rather than full record equality.
 > - **Add_node_arg Status:** `Add_node_arg` will stay a hardcoded `Medium` confidence for this iteration (due to parsing error strings without full DAG context).
 > - **Sequenced Delivery:** The implementation is divided into two sequential, low-risk phases:
 >   - **Phase 1:** AST definitions, `diagnostics.ml` smart constructors, unit tests with mock signals.
 >   - **Phase 2:** `schema_check.ml` wiring to supply real compiler signals.
+
+---
+
+## Signal-to-Label Mapping Logic (Truth Table)
+
+The centralized helper functions in `diagnostics.ml` will map compiler signals to `confidence` labels according to the following specification:
+
+| Fix Type | Signals | Resulting Confidence |
+|---|---|---|
+| **`Cast`** | `chain_broken = false` | `High` |
+| | `chain_broken = true` | `Medium` |
+| **`Rename_column`** | `edit_distance = 1` and `is_unique = true` | `High` |
+| | `edit_distance = 2` and `is_unique = true` | `Medium` |
+| | `edit_distance = 1` and `is_unique = false` | `Medium` (best candidate score is high but ambiguous) |
+| | `edit_distance = 2` and `is_unique = false` | `Low` |
+| | `edit_distance >= 3` | `Low` |
+| **`Suggest_identifier`** | `edit_distance = 1` and `is_unique = true` | `High` |
+| | `edit_distance = 2` and `is_unique = true` | `Medium` |
+| | `edit_distance = 1` and `is_unique = false` | `Medium` |
+| | `edit_distance = 2` and `is_unique = false` | `Low` |
+| | `edit_distance >= 3` | `Low` |
+| **`Add_node_arg`** | *N/A (Heuristic fallback)* | `Medium` |
+| **`Run_command`** | *N/A (Heuristic fallback)* | `Low` |
 
 ---
 

--- a/spec_files/implementation_plan.md
+++ b/spec_files/implementation_plan.md
@@ -1,0 +1,62 @@
+# Implementation Plan - Calculated Suggested-Fix Confidence Levels
+
+This plan details the implementation of **Path C (Hybrid Approach)** to transition suggested fixes from static serialization constants to dynamically calculated values based on compiler signals (edit distance, candidate uniqueness, schema chain integrity).
+
+---
+
+## User Review Required
+
+> [!IMPORTANT]
+> - All variants of `suggested_fix` (except `NoFix`) will be modified to include their underlying calculation metrics (e.g. `chain_broken: bool`, `edit_distance: int`, `is_unique: bool`) along with the pre-computed `confidence` value.
+> - `Ast.suggest_name` remains unchanged for backward compatibility to avoid touching the tree-walking evaluator (`eval.ml`), but a new `Ast.suggest_names_with_scores` function will be added.
+
+---
+
+## Proposed Changes
+
+### AST Layer
+
+#### [MODIFY] [ast.ml](file:///home/brodrigues/Documents/repos/tlang/src/ast.ml)
+- Add `suggest_names_with_scores : string -> string list -> (string * int) list` returning all matches within Levenshtein range, sorted.
+- Re-implement `suggest_name` in terms of `suggest_names_with_scores` to ensure backward compatibility.
+
+### Diagnostics Layer
+
+#### [MODIFY] [diagnostics.ml](file:///home/brodrigues/Documents/repos/tlang/src/diagnostics.ml)
+- Define `type confidence = High | Medium | Low`.
+- Update `type suggested_fix` constructor payloads to include `confidence` and their respective signal fields (`chain_broken`, `edit_distance`, `is_unique`).
+- Add helper functions `confidence_for_cast` and `confidence_for_typo` to centralize signal-to-label threshold mapping.
+- Update `suggested_fix_to_yojson` and `suggested_fix_of_yojson` to serialize and parse these new fields.
+- Update `of_verror` to construct `Suggest_identifier` and `Add_node_arg` using dynamic signals.
+
+### Schema Checking Layer
+
+#### [MODIFY] [schema_check.ml](file:///home/brodrigues/Documents/repos/tlang/src/schema_check.ml)
+- Add tracking for schema chain integrity (e.g., track whether the current schema was derived from a chain containing an unknown/custom function).
+- Update construction of `Cast` fixes (lines 431, 637) to determine `chain_broken` and compute `confidence`.
+- Update construction of `Rename_column` fixes (line 494) to calculate Levenshtein distance and uniqueness against candidates.
+
+### Mechanical Fix Application Layer
+
+#### [MODIFY] [fix.ml](file:///home/brodrigues/Documents/repos/tlang/src/fix.ml)
+- Update `suggested_fix` pattern matching in `apply_fix` and `apply_fixes` to match the new constructor payloads.
+
+#### [MODIFY] [t_fix.ml](file:///home/brodrigues/Documents/repos/tlang/src/packages/pipeline/t_fix.ml)
+- Update `suggested_fix` pattern matching in `format_fix_result` to match the new constructor payloads.
+
+### Unit Tests
+
+#### [MODIFY] [test_check.ml](file:///home/brodrigues/Documents/repos/tlang/tests/test_check.ml)
+- Update test cases constructing `suggested_fix` records.
+- Add test cases explicitly checking that confidence degrades correctly under chain-broken or ambiguous typo scenarios.
+
+#### [MODIFY] [test_fix.ml](file:///home/brodrigues/Documents/repos/tlang/tests/test_fix.ml)
+- Update test cases constructing `suggested_fix` records.
+
+---
+
+## Verification Plan
+
+### Automated Tests
+- Run `dune build` and `dune runtest` to ensure the compilation is successful and all unit tests pass.
+- Run the new test blocks in `test_check.ml` to verify dynamic confidence scoring under various scenarios.

--- a/spec_files/implementation_plan.md
+++ b/spec_files/implementation_plan.md
@@ -7,8 +7,13 @@ This plan details the implementation of **Path C (Hybrid Approach)** to transiti
 ## User Review Required
 
 > [!IMPORTANT]
-> - All variants of `suggested_fix` (except `NoFix`) will be modified to include their underlying calculation metrics (e.g. `chain_broken: bool`, `edit_distance: int`, `is_unique: bool`) along with the pre-computed `confidence` value.
-> - `Ast.suggest_name` remains unchanged for backward compatibility to avoid touching the tree-walking evaluator (`eval.ml`), but a new `Ast.suggest_names_with_scores` function will be added.
+> - **Smart Constructors:** To prevent representation drift between raw signals and precomputed `confidence` values, variants of `suggested_fix` will be created *only* via centralized smart constructors (e.g. `Diagnostics.make_cast_fix`, `Diagnostics.make_rename_column_fix`). Exposing raw record construction of fixes is disallowed.
+> - **Centralized Resolution:** The signal-to-label threshold mapping is isolated inside `Diagnostics.confidence_of_signals` (or helper functions) in `diagnostics.ml`, allowing easy threshold tuning and unit testing.
+> - **JSON Serialization Contract:** The JSON diagnostics schema remains clean and backward-compatible: it will serialize the precomputed `"confidence"` string, but will *not* expose the internal OCaml signal fields (`chain_broken`, `edit_distance`, `is_unique`) to keep the public API minimal.
+> - **Add_node_arg Status:** `Add_node_arg` will stay a hardcoded `Medium` confidence for this iteration (due to parsing error strings without full DAG context).
+> - **Sequenced Delivery:** The implementation is divided into two sequential, low-risk phases:
+>   - **Phase 1:** AST definitions, `diagnostics.ml` smart constructors, unit tests with mock signals.
+>   - **Phase 2:** `schema_check.ml` wiring to supply real compiler signals.
 
 ---
 
@@ -17,24 +22,37 @@ This plan details the implementation of **Path C (Hybrid Approach)** to transiti
 ### AST Layer
 
 #### [MODIFY] [ast.ml](file:///home/brodrigues/Documents/repos/tlang/src/ast.ml)
-- Add `suggest_names_with_scores : string -> string list -> (string * int) list` returning all matches within Levenshtein range, sorted.
-- Re-implement `suggest_name` in terms of `suggest_names_with_scores` to ensure backward compatibility.
+- Add `suggest_names_with_scores : string -> string list -> (string * int) list` returning all matches within Levenshtein range, sorted by distance.
+- Re-implement `suggest_name` in terms of `suggest_names_with_scores` to ensure 100% backward compatibility with `eval.ml`.
 
 ### Diagnostics Layer
 
 #### [MODIFY] [diagnostics.ml](file:///home/brodrigues/Documents/repos/tlang/src/diagnostics.ml)
 - Define `type confidence = High | Medium | Low`.
-- Update `type suggested_fix` constructor payloads to include `confidence` and their respective signal fields (`chain_broken`, `edit_distance`, `is_unique`).
-- Add helper functions `confidence_for_cast` and `confidence_for_typo` to centralize signal-to-label threshold mapping.
-- Update `suggested_fix_to_yojson` and `suggested_fix_of_yojson` to serialize and parse these new fields.
-- Update `of_verror` to construct `Suggest_identifier` and `Add_node_arg` using dynamic signals.
+- Update `type suggested_fix` constructor payloads to include `confidence` and their respective signal fields:
+  ```ocaml
+  type suggested_fix =
+    | Cast of { column: string; cast_to: string; target_node: string option; file: string option; line: int option; chain_broken: bool; confidence: confidence }
+    | Rename_column of { old_name: string; new_name: string; target_node: string option; file: string option; line: int option; edit_distance: int; is_unique: bool; confidence: confidence }
+    | Add_node_arg of { node: string; arg: string; target_node: string option; file: string option; line: int option; confidence: confidence }
+    | Suggest_identifier of { name: string; suggestion: string; target_node: string option; file: string option; line: int option; edit_distance: int; is_unique: bool; confidence: confidence }
+    | Run_command of { command: string; description: string; target_node: string option; file: string option; line: int option; confidence: confidence }
+    | NoFix
+  ```
+- Expose **smart constructors** to instantiate fixes and calculate confidence:
+  - `make_cast_fix ~column ~cast_to ~chain_broken ?target_node ?file ?line ()`
+  - `make_rename_column_fix ~old_name ~new_name ~edit_distance ~is_unique ?target_node ?file ?line ()`
+  - `make_suggest_identifier_fix ~name ~suggestion ~edit_distance ~is_unique ?target_node ?file ?line ()`
+  - `make_add_node_arg_fix ~node ~arg ?target_node ?file ?line ()`
+  - `make_run_command_fix ~command ~description ?target_node ?file ?line ()`
+- Update `suggested_fix_to_yojson` and `suggested_fix_of_yojson` to serialize and parse the `"confidence"` field while keeping signal fields internal-only.
+- Update `of_verror` to construct fixes using the smart constructors.
 
 ### Schema Checking Layer
 
 #### [MODIFY] [schema_check.ml](file:///home/brodrigues/Documents/repos/tlang/src/schema_check.ml)
-- Add tracking for schema chain integrity (e.g., track whether the current schema was derived from a chain containing an unknown/custom function).
-- Update construction of `Cast` fixes (lines 431, 637) to determine `chain_broken` and compute `confidence`.
-- Update construction of `Rename_column` fixes (line 494) to calculate Levenshtein distance and uniqueness against candidates.
+- Track schema chain integrity: `chain_broken` is set to `true` if a schema was derived downstream of any unrecognized or custom function (which drops schema propagation to `[]`).
+- Update `Cast` and `Rename_column` fix instantiation to use the new smart constructors, passing calculated signal metrics.
 
 ### Mechanical Fix Application Layer
 
@@ -58,5 +76,8 @@ This plan details the implementation of **Path C (Hybrid Approach)** to transiti
 ## Verification Plan
 
 ### Automated Tests
-- Run `dune build` and `dune runtest` to ensure the compilation is successful and all unit tests pass.
-- Run the new test blocks in `test_check.ml` to verify dynamic confidence scoring under various scenarios.
+- Run `dune build` and `dune runtest` to ensure successful compilation and test execution.
+- Add and run specific test scenarios in `test_check.ml` that exercise:
+  - `Cast` confidence degradation (`chain_broken = true` $\to$ `Medium` confidence).
+  - Typo confidence degradation (`edit_distance = 2` or `is_unique = false` $\to$ `Medium`/`Low` confidence).
+  - Round-trip serialization testing: `suggested_fix` parsed back from JSON retains matching semantic fields.

--- a/spec_files/walkthrough.md
+++ b/spec_files/walkthrough.md
@@ -40,7 +40,7 @@ We have successfully implemented dynamic, evidence-based confidence scores for a
 All tests were run and passed successfully using `dune runtest`.
 
 ### 1. Verification of Truth Tables & Confidence Degradation
-We added a comprehensive suite of unit tests in [test_check.ml](file:///home/brodrigues/Documents/repos/tlang/tests/test_check.ml) which asserts:
+We added a comprehensive suite of unit tests in [test_check.ml](./tests/test_check.ml) which asserts:
 - **`Cast` confidence mapping:** Unbroken chain $\rightarrow$ `high`; broken chain $\rightarrow$ `medium`.
 - **`Rename_column` confidence matrix:** All combinations of `edit_distance` and `is_unique` map precisely to their expected confidence value (`high`, `medium`, or `low`).
 

--- a/spec_files/walkthrough.md
+++ b/spec_files/walkthrough.md
@@ -1,0 +1,48 @@
+# Walkthrough: Dynamic Confidence for Suggested Fixes
+
+We have successfully implemented dynamic, evidence-based confidence scores for all suggested fixes within the `t check` pipeline diagnostics. This ensures that confidence rankings (`high`, `medium`, or `low`) reflect the actual strength of inference rather than hardcoded heuristics.
+
+---
+
+## Changes Implemented
+
+### 1. AST & Core Suggestions (`src/ast.ml`)
+- Updated `suggest_name` to use `suggest_names_with_scores`, returning a list of `(candidate, edit_distance)` tuples.
+- Exposed `suggest_names_with_scores` so downstream diagnostics can access raw edit distance and uniqueness signals.
+
+### 2. Smart Constructors & Diagnostics plumbing (`src/diagnostics.ml`)
+- Expose a clean `confidence` type with `High`, `Medium`, and `Low` cases.
+- Modified the internal constructors of `suggested_fix` to carry the raw signals (e.g. `chain_broken` for `Cast`; `edit_distance` and `is_unique` for `Rename_column`).
+- Expose the smart constructors (`make_cast_fix`, `make_rename_column_fix`, etc.) as the only sanctioned way to build suggested fixes. These resolve confidence dynamically according to the truth tables:
+  - **`Cast`**: `High` confidence if the schema chain is unbroken; `Medium` if `chain_broken` is true.
+  - **`Rename_column`**:
+    - `edit_distance = 1`, `is_unique = true` $\rightarrow$ `High`
+    - `edit_distance = 2`, `is_unique = true` $\rightarrow$ `Medium`
+    - `edit_distance = 1`, `is_unique = false` $\rightarrow$ `Medium`
+    - `edit_distance = 2`, `is_unique = false` $\rightarrow$ `Low`
+    - `edit_distance >= 3` $\rightarrow$ `Low`
+- Ensured JSON serialization outputs `confidence: string` dynamically resolved from the signals.
+- Configured JSON deserialization (`suggested_fix_of_yojson`) to use sensible defaults for signal fields (e.g. `is_unique = true`) to enable round-trip reconstruction without leaking internal signals to public JSON.
+
+### 3. Dynamic Inference in Schema Checking (`src/schema_check.ml`)
+- Tracked `chain_broken` status within `check_pipeline_schemas` by checking if any custom/unrecognized verb has caused the schema to drop/clear to `[]`.
+- Constructed `Cast` fixes using the smart constructor passing `~chain_broken`.
+- Extracted suggestions from naming errors, calculating the edit distance and uniqueness of matches against current dataframe column names, and passing these to `make_rename_column_fix`.
+
+### 4. Code Refactoring & Compilation (`src/fix.ml`, `src/env_check.ml`)
+- Refactored all pattern matches on `suggested_fix` to handle the new field layouts.
+- Updated REPL helper `t_fix.ml` to properly format the updated suggested fix variants.
+
+---
+
+## Verification & Automated Tests
+
+All tests were run and passed successfully using `dune runtest`.
+
+### 1. Verification of Truth Tables & Confidence Degradation
+We added a comprehensive suite of unit tests in [test_check.ml](file:///home/brodrigues/Documents/repos/tlang/tests/test_check.ml) which asserts:
+- **`Cast` confidence mapping:** Unbroken chain $\rightarrow$ `high`; broken chain $\rightarrow$ `medium`.
+- **`Rename_column` confidence matrix:** All combinations of `edit_distance` and `is_unique` map precisely to their expected confidence value (`high`, `medium`, or `low`).
+
+### 2. JSON Round-tripping
+- Verified that all suggested fixes (`Cast`, `Rename_column`, `Suggest_identifier`, `Run_command`) round-trip cleanly from OCaml to JSON and back, reconstructing their semantic types and setting safe defaults for hidden signal fields.

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -1181,13 +1181,16 @@ let levenshtein s t =
 (** Find the closest matching name from a list of candidates.
     Returns Some name if there is a match within a reasonable edit distance.
     The threshold is max(2, len/3) — allowing up to ~33% character changes. *)
-let suggest_name name candidates =
+let suggest_names_with_scores name candidates =
   let max_dist = max 2 (String.length name / 3) in
   let scored = List.filter_map (fun c ->
     let d = levenshtein name c in
     if d > 0 && d <= max_dist then Some (c, d) else None
   ) candidates in
-  match List.sort (fun (_, d1) (_, d2) -> compare d1 d2) scored with
+  List.sort (fun (_, d1) (_, d2) -> compare d1 d2) scored
+
+let suggest_name name candidates =
+  match suggest_names_with_scores name candidates with
   | (best, _) :: _ -> Some best
   | [] -> None
 

--- a/src/diagnostics.ml
+++ b/src/diagnostics.ml
@@ -174,6 +174,7 @@ let suggested_fix_to_yojson = function
         ("target_node", opt_string_to_yojson target_node);
         ("file", opt_string_to_yojson file);
         ("line", opt_int_to_yojson line);
+        ("confidence", `String "high");
       ]
   | Rename_column { old_name; new_name; target_node; file; line } ->
       `Assoc [
@@ -183,6 +184,7 @@ let suggested_fix_to_yojson = function
         ("target_node", opt_string_to_yojson target_node);
         ("file", opt_string_to_yojson file);
         ("line", opt_int_to_yojson line);
+        ("confidence", `String "high");
       ]
   | Add_node_arg { node; arg; target_node; file; line } ->
       `Assoc [
@@ -192,6 +194,7 @@ let suggested_fix_to_yojson = function
         ("target_node", opt_string_to_yojson target_node);
         ("file", opt_string_to_yojson file);
         ("line", opt_int_to_yojson line);
+        ("confidence", `String "medium");
       ]
   | Suggest_identifier { name; suggestion; target_node; file; line } ->
       `Assoc [
@@ -201,6 +204,7 @@ let suggested_fix_to_yojson = function
         ("target_node", opt_string_to_yojson target_node);
         ("file", opt_string_to_yojson file);
         ("line", opt_int_to_yojson line);
+        ("confidence", `String "medium");
       ]
   | Run_command { command; description; target_node; file; line } ->
       `Assoc [
@@ -210,6 +214,7 @@ let suggested_fix_to_yojson = function
         ("target_node", opt_string_to_yojson target_node);
         ("file", opt_string_to_yojson file);
         ("line", opt_int_to_yojson line);
+        ("confidence", `String "low");
       ]
   | NoFix -> `Null
 

--- a/src/diagnostics.ml
+++ b/src/diagnostics.ml
@@ -122,9 +122,18 @@ type suggested_fix =
   | NoFix
 let no_fix = NoFix
 
+(** Compute confidence for a Cast fix based on schema chain integrity.
+    When [chain_broken] is [true] (missing upstream column or custom verb
+    in the pipeline), the fix may not be applicable, so confidence drops
+    to [Medium]. When the chain is intact, the fix is deterministic. *)
 let confidence_for_cast ~chain_broken =
   if chain_broken then Medium else High
 
+(** Compute confidence for typo-based fixes (Rename_column, Suggest_identifier).
+    Scales with edit distance and match uniqueness:
+    - distance 1 + unique = [High]
+    - distance 2 + unique, or distance 1 + ambiguous = [Medium]
+    - everything else = [Low] *)
 let confidence_for_typo ~edit_distance ~is_unique =
   if edit_distance = 1 && is_unique then High
   else if edit_distance = 2 && is_unique then Medium

--- a/src/diagnostics.ml
+++ b/src/diagnostics.ml
@@ -101,13 +101,52 @@ let error_class_of_string = function
   | "invalid_expect_placement" -> Invalid_expect_placement
   | _ -> Unknown_error
 
+type confidence = High | Medium | Low
+
+let confidence_to_string = function
+  | High -> "high"
+  | Medium -> "medium"
+  | Low -> "low"
+
+let confidence_of_string = function
+  | "high" -> High
+  | "medium" -> Medium
+  | "low" | _ -> Low
+
 type suggested_fix =
-  | Cast of { column: string; cast_to: string; target_node: string option; file: string option; line: int option }
-  | Rename_column of { old_name: string; new_name: string; target_node: string option; file: string option; line: int option }
-  | Add_node_arg of { node: string; arg: string; target_node: string option; file: string option; line: int option }
-  | Suggest_identifier of { name: string; suggestion: string; target_node: string option; file: string option; line: int option }
-  | Run_command of { command: string; description: string; target_node: string option; file: string option; line: int option }
+  | Cast of { column: string; cast_to: string; target_node: string option; file: string option; line: int option; chain_broken: bool; confidence: confidence }
+  | Rename_column of { old_name: string; new_name: string; target_node: string option; file: string option; line: int option; edit_distance: int; is_unique: bool; confidence: confidence }
+  | Add_node_arg of { node: string; arg: string; target_node: string option; file: string option; line: int option; confidence: confidence }
+  | Suggest_identifier of { name: string; suggestion: string; target_node: string option; file: string option; line: int option; edit_distance: int; is_unique: bool; confidence: confidence }
+  | Run_command of { command: string; description: string; target_node: string option; file: string option; line: int option; confidence: confidence }
   | NoFix
+
+let confidence_for_cast ~chain_broken =
+  if chain_broken then Medium else High
+
+let confidence_for_typo ~edit_distance ~is_unique =
+  if edit_distance = 1 && is_unique then High
+  else if edit_distance = 2 && is_unique then Medium
+  else if edit_distance = 1 then Medium
+  else Low
+
+let make_cast_fix ~column ~cast_to ~chain_broken ?target_node ?file ?line () =
+  let confidence = confidence_for_cast ~chain_broken in
+  Cast { column; cast_to; target_node; file; line; chain_broken; confidence }
+
+let make_rename_column_fix ~old_name ~new_name ~edit_distance ~is_unique ?target_node ?file ?line () =
+  let confidence = confidence_for_typo ~edit_distance ~is_unique in
+  Rename_column { old_name; new_name; target_node; file; line; edit_distance; is_unique; confidence }
+
+let make_suggest_identifier_fix ~name ~suggestion ~edit_distance ~is_unique ?target_node ?file ?line () =
+  let confidence = confidence_for_typo ~edit_distance ~is_unique in
+  Suggest_identifier { name; suggestion; target_node; file; line; edit_distance; is_unique; confidence }
+
+let make_add_node_arg_fix ~node ~arg ?target_node ?file ?line () =
+  Add_node_arg { node; arg; target_node; file; line; confidence = Medium }
+
+let make_run_command_fix ~command ~description ?target_node ?file ?line () =
+  Run_command { command; description; target_node; file; line; confidence = Low }
 
 type diagnostic = {
   diag_id : string;
@@ -166,7 +205,7 @@ let opt_int_to_yojson = function
   | None -> `Null
 
 let suggested_fix_to_yojson = function
-  | Cast { column; cast_to; target_node; file; line } ->
+  | Cast { column; cast_to; target_node; file; line; chain_broken = _; confidence } ->
       `Assoc [
         ("kind", `String "cast");
         ("column", `String column);
@@ -174,9 +213,9 @@ let suggested_fix_to_yojson = function
         ("target_node", opt_string_to_yojson target_node);
         ("file", opt_string_to_yojson file);
         ("line", opt_int_to_yojson line);
-        ("confidence", `String "high");
+        ("confidence", `String (confidence_to_string confidence));
       ]
-  | Rename_column { old_name; new_name; target_node; file; line } ->
+  | Rename_column { old_name; new_name; target_node; file; line; edit_distance = _; is_unique = _; confidence } ->
       `Assoc [
         ("kind", `String "rename_column");
         ("old_name", `String old_name);
@@ -184,9 +223,9 @@ let suggested_fix_to_yojson = function
         ("target_node", opt_string_to_yojson target_node);
         ("file", opt_string_to_yojson file);
         ("line", opt_int_to_yojson line);
-        ("confidence", `String "high");
+        ("confidence", `String (confidence_to_string confidence));
       ]
-  | Add_node_arg { node; arg; target_node; file; line } ->
+  | Add_node_arg { node; arg; target_node; file; line; confidence } ->
       `Assoc [
         ("kind", `String "add_node_arg");
         ("node", `String node);
@@ -194,9 +233,9 @@ let suggested_fix_to_yojson = function
         ("target_node", opt_string_to_yojson target_node);
         ("file", opt_string_to_yojson file);
         ("line", opt_int_to_yojson line);
-        ("confidence", `String "medium");
+        ("confidence", `String (confidence_to_string confidence));
       ]
-  | Suggest_identifier { name; suggestion; target_node; file; line } ->
+  | Suggest_identifier { name; suggestion; target_node; file; line; edit_distance = _; is_unique = _; confidence } ->
       `Assoc [
         ("kind", `String "suggest_identifier");
         ("name", `String name);
@@ -204,9 +243,9 @@ let suggested_fix_to_yojson = function
         ("target_node", opt_string_to_yojson target_node);
         ("file", opt_string_to_yojson file);
         ("line", opt_int_to_yojson line);
-        ("confidence", `String "medium");
+        ("confidence", `String (confidence_to_string confidence));
       ]
-  | Run_command { command; description; target_node; file; line } ->
+  | Run_command { command; description; target_node; file; line; confidence } ->
       `Assoc [
         ("kind", `String "run_command");
         ("command", `String command);
@@ -214,7 +253,7 @@ let suggested_fix_to_yojson = function
         ("target_node", opt_string_to_yojson target_node);
         ("file", opt_string_to_yojson file);
         ("line", opt_int_to_yojson line);
-        ("confidence", `String "low");
+        ("confidence", `String (confidence_to_string confidence));
       ]
   | NoFix -> `Null
 
@@ -239,6 +278,11 @@ let suggested_fix_of_yojson json =
       let file = json |> member "file" |> opt_string_of_yojson in
       let line = json |> member "line" |> opt_int_of_yojson in
       let target_node = json |> member "target_node" |> opt_string_of_yojson in
+      let confidence =
+        match json |> member "confidence" |> opt_string_of_yojson with
+        | Some c -> confidence_of_string c
+        | None -> Low
+      in
       match kind with
       | "cast" ->
           Cast {
@@ -246,6 +290,9 @@ let suggested_fix_of_yojson json =
             cast_to = json |> member "cast_to" |> to_string;
             target_node;
             file; line;
+            (* Signal fields are not recoverable from JSON; safe defaults are assigned *)
+            chain_broken = false;
+            confidence;
           }
       | "rename_column" ->
           Rename_column {
@@ -253,6 +300,10 @@ let suggested_fix_of_yojson json =
             new_name = json |> member "new_name" |> to_string;
             target_node;
             file; line;
+            (* Signal fields are not recoverable from JSON; safe defaults are assigned *)
+            edit_distance = 0;
+            is_unique = true;
+            confidence;
           }
       | "add_node_arg" ->
           Add_node_arg {
@@ -260,6 +311,7 @@ let suggested_fix_of_yojson json =
             arg = json |> member "arg" |> to_string;
             target_node;
             file; line;
+            confidence;
           }
       | "suggest_identifier" ->
           Suggest_identifier {
@@ -267,6 +319,10 @@ let suggested_fix_of_yojson json =
             suggestion = json |> member "suggestion" |> to_string;
             target_node;
             file; line;
+            (* Signal fields are not recoverable from JSON; safe defaults are assigned *)
+            edit_distance = 0;
+            is_unique = true;
+            confidence;
           }
       | "run_command" ->
           Run_command {
@@ -274,6 +330,7 @@ let suggested_fix_of_yojson json =
             description = json |> member "description" |> to_string;
             target_node;
             file; line;
+            confidence;
           }
       | _ -> NoFix
 
@@ -449,19 +506,30 @@ let known_identifiers_lower_table =
   tbl
 
 (** Extract the variable name and an optional correction from an error message.
-    Returns (name, suggestion option). *)
+    Returns (name, (suggestion * edit_distance * is_unique) option). *)
 let extract_name_and_suggestion msg =
-  let re = Str.regexp "Variable '\\([^']+\\)' is not defined" in
+  let re_var = Str.regexp "Variable '\\([^']+\\)' is not defined" in
+  let re_name = Str.regexp "Name `\\([^`]+\\)` is not defined" in
   try
-    ignore (Str.search_forward re msg 0);
-    let name = Str.matched_group 1 msg in
+    let name =
+      if (try ignore (Str.search_forward re_var msg 0); true with Not_found -> false) then
+        Str.matched_group 1 msg
+      else if (try ignore (Str.search_forward re_name msg 0); true with Not_found -> false) then
+        Str.matched_group 1 msg
+      else
+        raise Not_found
+    in
     let lower_name = String.lowercase_ascii name in
     let candidates = Hashtbl.fold (fun lk _ acc -> lk :: acc) known_identifiers_lower_table [] in
-    let suggestion = match Ast.suggest_name lower_name candidates with
-      | Some lower_match -> Some (Hashtbl.find known_identifiers_lower_table lower_match)
-      | None -> None
-    in
-    (name, suggestion)
+    match Ast.suggest_names_with_scores lower_name candidates with
+    | (best_match, dist) :: runner_up :: _ ->
+        let suggestion = Hashtbl.find known_identifiers_lower_table best_match in
+        let is_unique = snd runner_up > dist in
+        (name, Some (suggestion, dist, is_unique))
+    | [(best_match, dist)] ->
+        let suggestion = Hashtbl.find known_identifiers_lower_table best_match in
+        (name, Some (suggestion, dist, true))
+    | [] -> (name, None)
   with Not_found -> ("", None)
 
 let of_verror ?file (err : Ast.error_info) : diagnostic =
@@ -476,14 +544,14 @@ let of_verror ?file (err : Ast.error_info) : diagnostic =
         (match extract_cross_runtime_info err.message with
          | Some (_dep_runtime, serializer) ->
              let arg = "deserializer = " ^ serializer in
-             Add_node_arg { node = (match node_name with Some n -> n | None -> "");
-                            arg; target_node = node_name; file; line = None }
+             let node = match node_name with Some n -> n | None -> "" in
+             make_add_node_arg_fix ~node ~arg ?target_node:node_name ?file ()
          | None -> NoFix)
     | NameError ->
-        let (name, suggestion) = extract_name_and_suggestion err.message in
-        (match suggestion with
-         | Some s ->
-             Suggest_identifier { name; suggestion = s; target_node = node_name; file; line = None }
+        let (name, suggestion_info) = extract_name_and_suggestion err.message in
+        (match suggestion_info with
+         | Some (s, edit_distance, is_unique) ->
+             make_suggest_identifier_fix ~name ~suggestion:s ~edit_distance ~is_unique ?target_node:node_name ?file ()
          | None -> NoFix)
     | _ -> NoFix
   in

--- a/src/diagnostics.ml
+++ b/src/diagnostics.ml
@@ -120,6 +120,7 @@ type suggested_fix =
   | Suggest_identifier of { name: string; suggestion: string; target_node: string option; file: string option; line: int option; edit_distance: int; is_unique: bool; confidence: confidence }
   | Run_command of { command: string; description: string; target_node: string option; file: string option; line: int option; confidence: confidence }
   | NoFix
+let no_fix = NoFix
 
 let confidence_for_cast ~chain_broken =
   if chain_broken then Medium else High
@@ -134,8 +135,11 @@ let make_cast_fix ~column ~cast_to ~chain_broken ?target_node ?file ?line () =
   let confidence = confidence_for_cast ~chain_broken in
   Cast { column; cast_to; target_node; file; line; chain_broken; confidence }
 
-let make_rename_column_fix ~old_name ~new_name ~edit_distance ~is_unique ?target_node ?file ?line () =
-  let confidence = confidence_for_typo ~edit_distance ~is_unique in
+let make_rename_column_fix ~old_name ~new_name ~edit_distance ~is_unique ?confidence ?target_node ?file ?line () =
+  let confidence = match confidence with
+    | Some c -> c
+    | None -> confidence_for_typo ~edit_distance ~is_unique
+  in
   Rename_column { old_name; new_name; target_node; file; line; edit_distance; is_unique; confidence }
 
 let make_suggest_identifier_fix ~name ~suggestion ~edit_distance ~is_unique ?target_node ?file ?line () =

--- a/src/diagnostics.mli
+++ b/src/diagnostics.mli
@@ -41,6 +41,11 @@ val error_class_of_string : string -> error_class
 val severity_to_string : severity -> string
 val phase_to_string : diagnostic_phase -> string
 
+(** Confidence level for a suggested fix, indicating how deterministic it is.
+    - [High]: highly deterministic — safe to apply automatically (e.g., Cast with intact schema chain, Rename at edit distance 1 with unique match)
+    - [Medium]: heuristic — verify before applying (e.g., Add_node_arg, Cast with broken chain, Rename at edit distance 2)
+    - [Low]: informational — check manually (e.g., Run_command, Suggest_identifier at distance 3+)
+    Confidence is computed dynamically from diagnostic context, not static per fix kind. *)
 type confidence = High | Medium | Low
 
 val confidence_to_string : confidence -> string
@@ -54,10 +59,27 @@ type suggested_fix = private
   | Run_command of { command: string; description: string; target_node: string option; file: string option; line: int option; confidence: confidence }
   | NoFix
 
+(** Smart constructors for suggested_fix. These are the only way to build
+    suggested_fix values — the type is private to enforce this constraint.
+    Each constructor computes confidence automatically from its inputs. *)
+
+(** Cast: inserts a type coercion. Confidence is [High] when [chain_broken]
+    is false (schema propagates through the pipeline), [Medium] otherwise. *)
 val make_cast_fix : column:string -> cast_to:string -> chain_broken:bool -> ?target_node:string -> ?file:string -> ?line:int -> unit -> suggested_fix
+
+(** Rename_column: replaces column references. Confidence computed from edit
+    distance and uniqueness unless explicitly overridden via [?confidence]. *)
 val make_rename_column_fix : old_name:string -> new_name:string -> edit_distance:int -> is_unique:bool -> ?confidence:confidence -> ?target_node:string -> ?file:string -> ?line:int -> unit -> suggested_fix
+
+(** Suggest_identifier: spelling correction. Confidence scales with edit
+    distance and uniqueness: [High] at distance 1 with unique match, down to
+    [Low] at distance 3+. *)
 val make_suggest_identifier_fix : name:string -> suggestion:string -> edit_distance:int -> is_unique:bool -> ?target_node:string -> ?file:string -> ?line:int -> unit -> suggested_fix
+
+(** Add_node_arg: adds a missing argument to a node. Always [Medium]. *)
 val make_add_node_arg_fix : node:string -> arg:string -> ?target_node:string -> ?file:string -> ?line:int -> unit -> suggested_fix
+
+(** Run_command: suggests a shell command. Always [Low]. *)
 val make_run_command_fix : command:string -> description:string -> ?target_node:string -> ?file:string -> ?line:int -> unit -> suggested_fix
 
 type diagnostic = {

--- a/src/diagnostics.mli
+++ b/src/diagnostics.mli
@@ -1,0 +1,113 @@
+(* src/diagnostics.mli *)
+(* Interface for diagnostics module, enforcing private constructors on suggested_fix *)
+
+type diagnostic_phase = Parse | Wire | Schema | Env | Build | Exec
+type severity = Error | Warning
+
+type error_class =
+  | Structural_error
+  | Name_error
+  | Arity_error
+  | Type_error
+  | Parse_error
+  | File_error
+  | Key_error
+  | Index_error
+  | Value_error
+  | Runtime_error
+  | Division_by_zero
+  | Assertion_error
+  | Match_error
+  | Shell_error
+  | Aggregation_error
+  | Na_predicate_error
+  | Missing_artifact
+  | Generic_error
+  | Schema_mismatch
+  | Missing_tproject
+  | Missing_package
+  | Missing_from_lockfile
+  | Nix_generation_error
+  | Nix_eval_error
+  | Na_warning
+  | Nix_error
+  | Unknown_error
+  | Contract_violation
+  | Contract_unverifiable
+  | Invalid_expect_placement
+
+val error_class_to_string : error_class -> string
+val error_class_of_string : string -> error_class
+val severity_to_string : severity -> string
+val phase_to_string : diagnostic_phase -> string
+
+type confidence = High | Medium | Low
+
+val confidence_to_string : confidence -> string
+val confidence_of_string : string -> confidence
+
+type suggested_fix = private
+  | Cast of { column: string; cast_to: string; target_node: string option; file: string option; line: int option; chain_broken: bool; confidence: confidence }
+  | Rename_column of { old_name: string; new_name: string; target_node: string option; file: string option; line: int option; edit_distance: int; is_unique: bool; confidence: confidence }
+  | Add_node_arg of { node: string; arg: string; target_node: string option; file: string option; line: int option; confidence: confidence }
+  | Suggest_identifier of { name: string; suggestion: string; target_node: string option; file: string option; line: int option; edit_distance: int; is_unique: bool; confidence: confidence }
+  | Run_command of { command: string; description: string; target_node: string option; file: string option; line: int option; confidence: confidence }
+  | NoFix
+
+val make_cast_fix : column:string -> cast_to:string -> chain_broken:bool -> ?target_node:string -> ?file:string -> ?line:int -> unit -> suggested_fix
+val make_rename_column_fix : old_name:string -> new_name:string -> edit_distance:int -> is_unique:bool -> ?confidence:confidence -> ?target_node:string -> ?file:string -> ?line:int -> unit -> suggested_fix
+val make_suggest_identifier_fix : name:string -> suggestion:string -> edit_distance:int -> is_unique:bool -> ?target_node:string -> ?file:string -> ?line:int -> unit -> suggested_fix
+val make_add_node_arg_fix : node:string -> arg:string -> ?target_node:string -> ?file:string -> ?line:int -> unit -> suggested_fix
+val make_run_command_fix : command:string -> description:string -> ?target_node:string -> ?file:string -> ?line:int -> unit -> suggested_fix
+
+type diagnostic = {
+  diag_id : string;
+  diag_error_class : error_class;
+  diag_severity : severity;
+  diag_phase : diagnostic_phase;
+  diag_node_id : string option;
+  diag_node_lang : string option;
+  diag_file : string option;
+  diag_line : int option;
+  diag_column : int option;
+  diag_end_line : int option;
+  diag_end_column : int option;
+  diag_message : string;
+  diag_expected : string option;
+  diag_actual : string option;
+  diag_caused_by : string list;
+  diag_suggested_fix : suggested_fix;
+}
+
+type check_result = {
+  cr_schema_version : string;
+  cr_status : string;
+  cr_phase : diagnostic_phase;
+  cr_tier : int;
+  cr_diagnostics : diagnostic list;
+}
+
+val gen_id : unit -> string
+val suggested_fix_to_yojson : suggested_fix -> Yojson.Safe.t
+val suggested_fix_of_yojson : Yojson.Safe.t -> suggested_fix
+val diagnostic_to_yojson : diagnostic -> Yojson.Safe.t
+val check_result_to_yojson : check_result -> Yojson.Safe.t
+val error_code_to_phase : Ast.error_code -> diagnostic_phase
+val error_code_to_error_class : Ast.error_code -> error_class
+val extract_node_name_from_message : string -> string option
+val extract_cycle_nodes : string -> string list
+val extract_cross_runtime_info : string -> (string * string) option
+val no_fix : suggested_fix
+val extract_caused_by_from_context : (string * Ast.value) list -> string list
+val of_verror : ?file:string -> Ast.error_info -> diagnostic
+val of_pipeline_result : ?file:string -> Ast.pipeline_result -> diagnostic list
+val exit_code_of_diagnostics : diagnostic list -> int
+val worst_phase : diagnostic list -> diagnostic_phase
+val worst_tier : diagnostic list -> int
+val diagnostic_phase : diagnostic -> diagnostic_phase
+val diagnostic_severity : diagnostic -> severity
+val diagnostic_error_class : diagnostic -> error_class
+val diagnostic_message : diagnostic -> string
+val check_result_entries : check_result -> diagnostic list
+val make_result : tier:int -> phase:diagnostic_phase -> diagnostic list -> check_result
+val extract_name_and_suggestion : string -> (string * (string * int * bool) option)

--- a/src/env_check.ml
+++ b/src/env_check.ml
@@ -49,13 +49,11 @@ let check_declared_requirements ~file ~tproject_path ~project_root ~tproject_cfg
         diag_expected = Some "tproject.toml";
         diag_actual = None;
         diag_caused_by = [];
-        diag_suggested_fix = Run_command {
-          command = Printf.sprintf "t init %s" project_root;
-          description = "Initialize tproject.toml in project root";
-          target_node = None;
-          file = Some file;
-          line = None;
-        };
+        diag_suggested_fix = Diagnostics.make_run_command_fix
+          ~command:(Printf.sprintf "t init %s" project_root)
+          ~description:"Initialize tproject.toml in project root"
+          ?file:(Some file)
+          ();
       }]
     else []
   | Some cfg ->
@@ -100,13 +98,11 @@ let check_declared_requirements ~file ~tproject_path ~project_root ~tproject_cfg
             diag_expected = Some (Printf.sprintf "%s %s" section pkg);
             diag_actual = None;
             diag_caused_by = [];
-            diag_suggested_fix = Run_command {
-              command = Printf.sprintf "t add %s %s" section_cmd pkg;
-              description = Printf.sprintf "Add %s to %s" pkg section;
-              target_node = None;
-              file = Some file;
-              line = None;
-            };
+            diag_suggested_fix = Diagnostics.make_run_command_fix
+              ~command:(Printf.sprintf "t add %s %s" section_cmd pkg)
+              ~description:(Printf.sprintf "Add %s to %s" pkg section)
+              ?file:(Some file)
+              ();
           } :: !missing_diags
         ) pkgs
       in

--- a/src/env_check.ml
+++ b/src/env_check.ml
@@ -146,7 +146,7 @@ let check_lockfile_consistency ~file ~tproject_cfg (p : Ast.pipeline_result) =
               diag_expected = None;
               diag_actual = None;
               diag_caused_by = [];
-              diag_suggested_fix = NoFix;
+              diag_suggested_fix = Diagnostics.no_fix;
            }
          ) missing)
   | _ -> []
@@ -171,7 +171,7 @@ let check_nix_evaluation ?(offline = false) ~file (p : Ast.pipeline_result) =
         diag_expected = None;
         diag_actual = None;
         diag_caused_by = [];
-        diag_suggested_fix = NoFix;
+        diag_suggested_fix = Diagnostics.no_fix;
       }]
   | Ok (_use_uv, nix_path) ->
       let node_names = List.map fst p.Ast.p_exprs in
@@ -211,7 +211,7 @@ let check_nix_evaluation ?(offline = false) ~file (p : Ast.pipeline_result) =
             diag_expected = None;
             diag_actual = None;
             diag_caused_by = [];
-            diag_suggested_fix = NoFix;
+            diag_suggested_fix = Diagnostics.no_fix;
           }]
 
 (* Main entry point: run all tier 3 env checks *)

--- a/src/fix.ml
+++ b/src/fix.ml
@@ -245,6 +245,10 @@ let apply_add_node_arg ~file ~node ~arg =
   result
 
 let apply_fix ~file (fix : Diagnostics.suggested_fix) =
+  (* NOTE: t fix applies ALL non-NoFix suggestions regardless of confidence.
+     Confidence is informational for agents/tools to decide whether to auto-apply
+     or review first. The fix-kind filtering below (Suggest_identifier -> false,
+     Run_command -> false) is based on fix type, not confidence level. *)
   match fix with
   | Cast { column; cast_to; line; _ } ->
       (match line with

--- a/src/fix.ml
+++ b/src/fix.ml
@@ -246,13 +246,13 @@ let apply_add_node_arg ~file ~node ~arg =
 
 let apply_fix ~file (fix : Diagnostics.suggested_fix) =
   match fix with
-  | Cast { column; cast_to; file = _; line; target_node = _ } ->
+  | Cast { column; cast_to; line; _ } ->
       (match line with
        | Some l -> apply_cast ~file ~line:l ~column ~cast_to; true
        | None -> false)
-  | Rename_column { old_name; new_name; file = _; line = _; target_node = _ } ->
+  | Rename_column { old_name; new_name; _ } ->
       apply_rename_column ~file ~old_name ~new_name; true
-  | Add_node_arg { node; arg; file = _; line = _; target_node = _ } ->
+  | Add_node_arg { node; arg; _ } ->
       apply_add_node_arg ~file ~node ~arg
   | Suggest_identifier _ -> false
   | Run_command _ -> false

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -716,7 +716,7 @@ let check_type_annotations filename =
               diag_expected = Some expected;
               diag_actual = Some actual;
               diag_caused_by = [];
-              diag_suggested_fix = Diagnostics.NoFix;
+              diag_suggested_fix = Diagnostics.no_fix;
             } :: !diags
           end
       | _ -> ()

--- a/src/schema_check.ml
+++ b/src/schema_check.ml
@@ -497,6 +497,7 @@ let validate_col_refs ~node_name ~(file : string option) ~schema ?(rename_mappin
         let suggested_fix = match List.assoc_opt col rename_mapping with
           | Some new_name ->
               let line = match expr.loc with Some l -> Some l.line | None -> None in
+              (* structural rename, not a typo match — distance/uniqueness fields unused *)
               Diagnostics.make_rename_column_fix ~old_name:col ~new_name ~edit_distance:0 ~is_unique:true ~confidence:High ~target_node:node_name ?file ?line ()
           | None -> Diagnostics.no_fix
         in
@@ -567,10 +568,10 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
       let expr = try List.assoc name p_exprs with Not_found -> mk_expr (Value (VNA NAGeneric)) in
 
       (* Determine if any dependency's schema was broken *)
-      let dep_is_broken = match dep_of name with
-        | [] -> false
-        | primary :: _ ->
-            (try Hashtbl.find broken_nodes primary with Not_found -> false)
+      let dep_is_broken =
+        List.exists (fun dep ->
+          try Hashtbl.find broken_nodes dep with Not_found -> false
+        ) (dep_of name)
       in
 
       (* Determine if the current node expression contains unrecognized verbs *)
@@ -597,14 +598,19 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
               (match read_csv_schema full_path with
                | Some cols -> Some cols
                | None ->
-                   let project_root = Builder_utils.get_project_root () in
-                   let proj_path = Filename.concat project_root path in
-                   match read_csv_schema proj_path with
-                   | Some cols -> Some cols
-                   | None ->
-                       match read_csv_schema path with
-                       | Some cols -> Some cols
-                       | None -> None)
+                   let proj_schema =
+                     try
+                       let project_root = Builder_utils.get_project_root () in
+                       let proj_path = Filename.concat project_root path in
+                       read_csv_schema proj_path
+                     with _ -> None
+                   in
+                   (match proj_schema with
+                    | Some cols -> Some cols
+                    | None ->
+                        match read_csv_schema path with
+                        | Some cols -> Some cols
+                        | None -> None))
           | None -> None
         else None
       in

--- a/src/schema_check.ml
+++ b/src/schema_check.ml
@@ -183,6 +183,7 @@ type verb =
   | Slice
   | Count
   | Expect
+  | DataSource
   | Other of string
 
 let classify_verb expr =
@@ -201,6 +202,7 @@ let classify_verb expr =
        | "slice" | "slice_min" | "slice_max" | "slice_sample" -> Slice
        | "count" -> Count
        | "expect" -> Expect
+       | "read_csv" | "t_read_csv" -> DataSource
        | _ -> Other name)
   | _ -> Other "unknown"
 
@@ -226,6 +228,14 @@ let extract_mutate_new_cols args =
          | "as.double" | "as_numeric" -> Some "double"
          | "as.string" | "as_character" -> Some "string"
          | "as_logical" | "as_bool" -> Some "bool"
+         | _ -> None)
+    | Call { fn = { node = DotAccess { target = { node = Var "as"; _ }; field }; _ }; _ } ->
+        (match field with
+         | "int" -> Some "int"
+         | "double" -> Some "double"
+         | "string" -> Some "string"
+         | "character" -> Some "string"
+         | "logical" | "bool" -> Some "bool"
          | _ -> None)
     | _ -> None
   in
@@ -274,7 +284,7 @@ let infer_output_schema input_schema expr =
         else
           { sc_name = c; sc_type = None }
       ) cols
-  | Filter | Ungroup | Slice | Arrange | GroupBy ->
+  | Filter | Ungroup | Slice | Arrange | GroupBy | DataSource ->
       input_schema
   | Mutate ->
       let new_cols = extract_mutate_new_cols
@@ -380,7 +390,7 @@ let extract_contracts args =
     | _ -> None
   ) args
 
-let validate_contracts ~node_name ~file contracts output_schema =
+let validate_contracts ~node_name ~file ~chain_broken contracts output_schema =
   let diags = ref [] in
   List.iter (fun contract ->
     match contract with
@@ -403,7 +413,7 @@ let validate_contracts ~node_name ~file contracts output_schema =
               diag_expected = Some col;
               diag_actual = None;
               diag_caused_by = [];
-              diag_suggested_fix = NoFix;
+              diag_suggested_fix = Diagnostics.no_fix;
             } : Diagnostics.diagnostic) :: !diags
         ) cols
     | Ast.Contract_type (col, expected_type) ->
@@ -428,8 +438,8 @@ let validate_contracts ~node_name ~file contracts output_schema =
                diag_caused_by = [];
                diag_suggested_fix =
                  if List.mem expected_type ["int"; "double"; "string"; "bool"]
-                 then Diagnostics.make_cast_fix ~column:col ~cast_to:expected_type ~chain_broken:false ~target_node:node_name ?file ()
-                 else NoFix;
+                 then Diagnostics.make_cast_fix ~column:col ~cast_to:expected_type ~chain_broken ~target_node:node_name ?file ()
+                 else Diagnostics.no_fix;
              } : Diagnostics.diagnostic) :: !diags
          | _ -> ())
     | Ast.Contract_null_rate (col, _threshold) ->
@@ -450,7 +460,7 @@ let validate_contracts ~node_name ~file contracts output_schema =
             diag_expected = Some col;
             diag_actual = None;
             diag_caused_by = [];
-            diag_suggested_fix = NoFix;
+            diag_suggested_fix = Diagnostics.no_fix;
           } : Diagnostics.diagnostic) :: !diags
         else
           diags := (Diagnostics.{
@@ -469,7 +479,7 @@ let validate_contracts ~node_name ~file contracts output_schema =
             diag_expected = None;
             diag_actual = None;
             diag_caused_by = [];
-            diag_suggested_fix = NoFix;
+            diag_suggested_fix = Diagnostics.no_fix;
           } : Diagnostics.diagnostic) :: !diags
   ) contracts;
   !diags
@@ -487,8 +497,8 @@ let validate_col_refs ~node_name ~(file : string option) ~schema ?(rename_mappin
         let suggested_fix = match List.assoc_opt col rename_mapping with
           | Some new_name ->
               let line = match expr.loc with Some l -> Some l.line | None -> None in
-              Diagnostics.make_rename_column_fix ~old_name:col ~new_name ~edit_distance:1 ~is_unique:true ~target_node:node_name ?file ?line ()
-          | None -> NoFix
+              Diagnostics.make_rename_column_fix ~old_name:col ~new_name ~edit_distance:0 ~is_unique:true ~confidence:High ~target_node:node_name ?file ?line ()
+          | None -> Diagnostics.no_fix
         in
         Some (Diagnostics.{
           diag_id = Diagnostics.gen_id ();
@@ -522,7 +532,11 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
 
   (* Topological order from deps *)
   let node_names = List.map fst p_exprs in
-  let dep_of name = List.assoc_opt name p_deps |> Option.value ~default:[] in
+  let dep_of name =
+    List.assoc_opt name p_deps
+    |> Option.value ~default:[]
+    |> List.filter (fun d -> List.mem d node_names)
+  in
 
   (* Compute topological order *)
   let topo_order =
@@ -541,14 +555,37 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
 
   (* Propagate schemas through the DAG *)
   let schemas : (string, schema) Hashtbl.t = Hashtbl.create 16 in
+  let broken_nodes : (string, bool) Hashtbl.t = Hashtbl.create 16 in
   let diagnostics = ref [] in
 
   List.iter (fun name ->
     let is_noop = try List.assoc name p_noops with Not_found -> false in
-    if is_noop then
-      Hashtbl.add schemas name []
-    else
+    if is_noop then begin
+      Hashtbl.add schemas name [];
+      Hashtbl.add broken_nodes name false
+    end else begin
       let expr = try List.assoc name p_exprs with Not_found -> mk_expr (Value (VNA NAGeneric)) in
+
+      (* Determine if any dependency's schema was broken *)
+      let dep_is_broken = match dep_of name with
+        | [] -> false
+        | primary :: _ ->
+            (try Hashtbl.find broken_nodes primary with Not_found -> false)
+      in
+
+      (* Determine if the current node expression contains unrecognized verbs *)
+      let ops = unwrap_pipe expr in
+      let has_custom_verb = List.exists (fun op ->
+        match op.node with
+        | Var _ -> false
+        | _ ->
+            (match classify_verb op with
+             | Other _ -> true
+             | _ -> false)
+      ) ops in
+
+      let current_chain_broken = dep_is_broken || has_custom_verb in
+      Hashtbl.add broken_nodes name current_chain_broken;
 
       (* First, try to read CSV header for root nodes *)
       let root_schema =
@@ -560,9 +597,14 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
               (match read_csv_schema full_path with
                | Some cols -> Some cols
                | None ->
-                   match read_csv_schema path with
+                   let project_root = Builder_utils.get_project_root () in
+                   let proj_path = Filename.concat project_root path in
+                   match read_csv_schema proj_path with
                    | Some cols -> Some cols
-                   | None -> None)
+                   | None ->
+                       match read_csv_schema path with
+                       | Some cols -> Some cols
+                       | None -> None)
           | None -> None
         else None
       in
@@ -578,7 +620,6 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
       let output_schema = match root_schema with
         | Some cols -> cols
         | None ->
-            let ops = unwrap_pipe expr in
             if List.length ops > 1 then
               List.fold_left apply_pipe_op input_schema ops
             else
@@ -625,9 +666,8 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
             diag_suggested_fix =
               if List.mem expected_type ["int"; "double"; "string"; "bool"]
               then
-                let line = match expr.loc with Some l -> Some l.line | None -> None in
-                Diagnostics.make_cast_fix ~column:col_name ~cast_to:expected_type ~chain_broken:false ~target_node:name ?file:(Some file) ?line ()
-              else NoFix;
+                 Diagnostics.make_cast_fix ~column:col_name ~cast_to:expected_type ~chain_broken:current_chain_broken ~target_node:name ?file:(Some file) ?line:(match expr.loc with Some l -> Some l.line | None -> None) ()
+              else Diagnostics.no_fix;
           } : Diagnostics.diagnostic) :: !diagnostics
         ) mismatches
       end;
@@ -681,7 +721,7 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
               diag_expected = None;
               diag_actual = None;
               diag_caused_by = [];
-              diag_suggested_fix = NoFix;
+              diag_suggested_fix = Diagnostics.no_fix;
             } : Diagnostics.diagnostic) :: !contract_diags
           end else
             (* Last position: validate contracts against final schema *)
@@ -689,7 +729,7 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
               | Call { args; _ } -> extract_contracts args
               | _ -> []
             in
-            let diags = validate_contracts ~node_name:name ~file:(Some file) contracts !current_validation_schema in
+            let diags = validate_contracts ~node_name:name ~file:(Some file) ~chain_broken:current_chain_broken contracts !current_validation_schema in
             contract_diags := diags @ !contract_diags
         end
       ) ops;
@@ -736,7 +776,7 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
                         diag_expected = None;
                         diag_actual = None;
                         diag_caused_by = [];
-                        diag_suggested_fix = NoFix;
+                        diag_suggested_fix = Diagnostics.no_fix;
                       })
                     else None
                   ) all_vars in
@@ -744,6 +784,7 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
                end
            | None -> ())
       | _ -> ()
+    end
   ) topo_order;
 
   !diagnostics

--- a/src/schema_check.ml
+++ b/src/schema_check.ml
@@ -428,13 +428,7 @@ let validate_contracts ~node_name ~file contracts output_schema =
                diag_caused_by = [];
                diag_suggested_fix =
                  if List.mem expected_type ["int"; "double"; "string"; "bool"]
-                 then Diagnostics.Cast {
-                   column = col;
-                   cast_to = expected_type;
-                   target_node = Some node_name;
-                   file;
-                   line = None;
-                 }
+                 then Diagnostics.make_cast_fix ~column:col ~cast_to:expected_type ~chain_broken:false ~target_node:node_name ?file ()
                  else NoFix;
              } : Diagnostics.diagnostic) :: !diags
          | _ -> ())
@@ -491,13 +485,9 @@ let validate_col_refs ~node_name ~(file : string option) ~schema ?(rename_mappin
       if schema_has_col col schema then None
       else
         let suggested_fix = match List.assoc_opt col rename_mapping with
-          | Some new_name -> Diagnostics.Rename_column {
-              old_name = col;
-              new_name;
-              target_node = Some node_name;
-              file;
-              line = (match expr.loc with Some l -> Some l.line | None -> None);
-            }
+          | Some new_name ->
+              let line = match expr.loc with Some l -> Some l.line | None -> None in
+              Diagnostics.make_rename_column_fix ~old_name:col ~new_name ~edit_distance:1 ~is_unique:true ~target_node:node_name ?file ?line ()
           | None -> NoFix
         in
         Some (Diagnostics.{
@@ -634,13 +624,9 @@ let check_pipeline_schemas ~(file : string) (p : pipeline_result) : Diagnostics.
             diag_caused_by = [];
             diag_suggested_fix =
               if List.mem expected_type ["int"; "double"; "string"; "bool"]
-              then Diagnostics.Cast {
-                column = col_name;
-                cast_to = expected_type;
-                target_node = Some name;
-                file = Some file;
-                line = (match expr.loc with Some l -> Some l.line | None -> None);
-              }
+              then
+                let line = match expr.loc with Some l -> Some l.line | None -> None in
+                Diagnostics.make_cast_fix ~column:col_name ~cast_to:expected_type ~chain_broken:false ~target_node:name ?file:(Some file) ?line ()
               else NoFix;
           } : Diagnostics.diagnostic) :: !diagnostics
         ) mismatches

--- a/tests/core/test_lsp_support.ml
+++ b/tests/core/test_lsp_support.ml
@@ -388,7 +388,7 @@ let run_tests pass_count fail_count _failures _eval_string _eval_string_env _tes
                          diag_message = Printf.sprintf "Variable `%s` annotated as %s, but expression infers to %s."
                            name (Ast.Utils.typ_to_string annotation) (Ast.Utils.typ_to_string inferred_ast);
                          diag_expected = None; diag_actual = None; diag_caused_by = [];
-                         diag_suggested_fix = Diagnostics.NoFix } :: !diags
+                         diag_suggested_fix = Diagnostics.no_fix } :: !diags
         | _ -> ()
       ) program;
       List.rev !diags

--- a/tests/golden/t_scripts/schema_cast_broken.t
+++ b/tests/golden/t_scripts/schema_cast_broken.t
@@ -1,0 +1,7 @@
+pipeline {
+  source = read_csv("tests/golden/data/mtcars.csv")
+  broken = source |> some_custom_unrecognized_verb()
+  clean = broken
+    |> mutate(mpg = as.int(1))
+    |> expect(columns = ["mpg"], mpg ~ string())
+}

--- a/tests/golden/t_scripts/schema_cast_unbroken.t
+++ b/tests/golden/t_scripts/schema_cast_unbroken.t
@@ -1,0 +1,5 @@
+pipeline {
+  source = read_csv("tests/golden/data/mtcars.csv")
+  clean = source
+    |> expect(columns = ["mpg"], mpg ~ string())
+}

--- a/tests/test_check.ml
+++ b/tests/test_check.ml
@@ -132,7 +132,7 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
     diag_expected = None;
     diag_actual = None;
     diag_caused_by = ["upstream_node"];
-    diag_suggested_fix = Diagnostics.NoFix;
+    diag_suggested_fix = Diagnostics.no_fix;
   } in
   check_eq "diagnostic_phase accessor"
     (Diagnostics.phase_to_string (Diagnostics.diagnostic_phase test_diag)) "exec";
@@ -365,6 +365,30 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
         with Not_found -> false)
   in
   check "schema rename stale: suggested_fix is rename_column" has_rename_fix;
+  flush stdout;
+
+  Printf.printf "\nschema check cast confidence tests:\n";
+
+  (* Schema cast unbroken: Cast fix has high confidence *)
+  let result = eval_string (Printf.sprintf "t_check(\"%s\", schema=true, json=true)" (golden "schema_cast_unbroken.t")) in
+  let result_str = match result with Ast.VString s -> s | _ -> "" in
+  let is_cast_high =
+    String.length result_str > 0
+    && (try ignore (Str.search_forward (Str.regexp "\"confidence\"[ \t]*:[ \t]*\"high\"") result_str 0); true
+        with Not_found -> false)
+  in
+  check "schema cast unbroken: Cast fix has confidence=high" is_cast_high;
+  flush stdout;
+
+  (* Schema cast broken: Cast fix has medium confidence *)
+  let result = eval_string (Printf.sprintf "t_check(\"%s\", schema=true, json=true)" (golden "schema_cast_broken.t")) in
+  let result_str = match result with Ast.VString s -> s | _ -> "" in
+  let is_cast_medium =
+    String.length result_str > 0
+    && (try ignore (Str.search_forward (Str.regexp "\"confidence\"[ \t]*:[ \t]*\"medium\"") result_str 0); true
+        with Not_found -> false)
+  in
+  check "schema cast broken: Cast fix has confidence=medium" is_cast_medium;
   flush stdout;
 
   Printf.printf "\nmissing package detection:\n";

--- a/tests/test_check.ml
+++ b/tests/test_check.ml
@@ -428,6 +428,8 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
     check "Suggest_identifier serializes kind=suggest_identifier" (kind = "suggest_identifier");
     let suggestion = Yojson.Safe.Util.member "suggestion" fix_json |> Yojson.Safe.Util.to_string in
     check "Suggest_identifier serializes suggestion=print" (suggestion = "print");
+    let confidence = Yojson.Safe.Util.member "confidence" fix_json |> Yojson.Safe.Util.to_string in
+    check "Suggest_identifier serializes confidence=medium" (confidence = "medium");
     let roundtrip = Diagnostics.suggested_fix_of_yojson fix_json in
     (match roundtrip with
      | Diagnostics.Suggest_identifier { name; suggestion = s; _ } ->
@@ -441,11 +443,13 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
   let test_run_command () =
     let fix = Diagnostics.Run_command { command = "t init ."; description = "Initialize tproject.toml"; target_node = None; file = Some "test.t"; line = None } in
     let json = Diagnostics.suggested_fix_to_yojson fix in
+    let confidence = Yojson.Safe.Util.member "confidence" json |> Yojson.Safe.Util.to_string in
+    check "Run_command serializes confidence=low" (confidence = "low");
     let roundtrip = Diagnostics.suggested_fix_of_yojson json in
     (match roundtrip with
-     | Diagnostics.Run_command { command; description; _ } ->
-         check "Run_command roundtrip command" (command = "t init .");
-         check "Run_command roundtrip description" (description = "Initialize tproject.toml")
+     | Diagnostics.Run_command { command = cmd; description = desc; _ } ->
+         check "Run_command roundtrip command" (cmd = "t init .");
+         check "Run_command roundtrip description" (desc = "Initialize tproject.toml")
      | _ -> check "Run_command roundtrip fails" false)
   in
   test_run_command ();

--- a/tests/test_check.ml
+++ b/tests/test_check.ml
@@ -401,11 +401,11 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
   let test_name_suggestion () =
     let (name, suggestion) = Diagnostics.extract_name_and_suggestion "Variable 'prnt' is not defined" in
     check "prnt extracts name" (name = "prnt");
-    check "prnt suggests print" (suggestion = Some "print");
+    check "prnt suggests print" (suggestion = Some ("print", 1, true));
     let (_name2, suggestion2) = Diagnostics.extract_name_and_suggestion "Variable 'flter' is not defined" in
-    check "flter suggests filter" (suggestion2 = Some "filter");
+    check "flter suggests filter" (suggestion2 = Some ("filter", 1, true));
     let (_name3, suggestion3) = Diagnostics.extract_name_and_suggestion "Variable 'mutat' is not defined" in
-    check "mutat suggests mutate" (suggestion3 = Some "mutate");
+    check "mutat suggests mutate" (suggestion3 = Some ("mutate", 1, true));
     let (_name4, suggestion4) = Diagnostics.extract_name_and_suggestion "Variable 'xyzzy_unknown' is not defined" in
     check "unknown name has no suggestion" (suggestion4 = None)
   in
@@ -420,7 +420,7 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
       diag_end_line = None; diag_end_column = None;
       diag_message = "Variable 'prnt' is not defined"; diag_expected = None; diag_actual = None;
       diag_caused_by = [];
-      diag_suggested_fix = Diagnostics.Suggest_identifier { name = "prnt"; suggestion = "print"; target_node = None; file = Some "test.t"; line = Some 1 };
+      diag_suggested_fix = Diagnostics.make_suggest_identifier_fix ~name:"prnt" ~suggestion:"print" ~edit_distance:1 ~is_unique:true ?file:(Some "test.t") ?line:(Some 1) ();
     } in
     let json = Diagnostics.diagnostic_to_yojson d in
     let fix_json = Yojson.Safe.Util.member "suggested_fix" json in
@@ -429,7 +429,7 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
     let suggestion = Yojson.Safe.Util.member "suggestion" fix_json |> Yojson.Safe.Util.to_string in
     check "Suggest_identifier serializes suggestion=print" (suggestion = "print");
     let confidence = Yojson.Safe.Util.member "confidence" fix_json |> Yojson.Safe.Util.to_string in
-    check "Suggest_identifier serializes confidence=medium" (confidence = "medium");
+    check "Suggest_identifier serializes confidence=high" (confidence = "high");
     let roundtrip = Diagnostics.suggested_fix_of_yojson fix_json in
     (match roundtrip with
      | Diagnostics.Suggest_identifier { name; suggestion = s; _ } ->
@@ -441,7 +441,7 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
 
   Printf.printf "\nRun_command fix:\n";
   let test_run_command () =
-    let fix = Diagnostics.Run_command { command = "t init ."; description = "Initialize tproject.toml"; target_node = None; file = Some "test.t"; line = None } in
+    let fix = Diagnostics.make_run_command_fix ~command:"t init ." ~description:"Initialize tproject.toml" ?file:(Some "test.t") () in
     let json = Diagnostics.suggested_fix_to_yojson fix in
     let confidence = Yojson.Safe.Util.member "confidence" json |> Yojson.Safe.Util.to_string in
     check "Run_command serializes confidence=low" (confidence = "low");
@@ -456,16 +456,43 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
 
   Printf.printf "\nCast and Rename_column confidence:\n";
   let test_cast_and_rename_confidence () =
-    let cast_fix = Diagnostics.Cast { column = "x"; cast_to = "double"; target_node = None; file = Some "test.t"; line = Some 1 } in
+    let cast_fix = Diagnostics.make_cast_fix ~column:"x" ~cast_to:"double" ~chain_broken:false ?file:(Some "test.t") ?line:(Some 1) () in
     let cast_json = Diagnostics.suggested_fix_to_yojson cast_fix in
     let cast_conf = Yojson.Safe.Util.member "confidence" cast_json |> Yojson.Safe.Util.to_string in
-    check "Cast serializes confidence=high" (cast_conf = "high");
+    check "Cast unbroken serializes confidence=high" (cast_conf = "high");
 
-    let rename_fix = Diagnostics.Rename_column { old_name = "x"; new_name = "y"; target_node = None; file = Some "test.t"; line = Some 1 } in
+    let cast_broken = Diagnostics.make_cast_fix ~column:"x" ~cast_to:"double" ~chain_broken:true ?file:(Some "test.t") ?line:(Some 1) () in
+    let cast_broken_json = Diagnostics.suggested_fix_to_yojson cast_broken in
+    let cast_broken_conf = Yojson.Safe.Util.member "confidence" cast_broken_json |> Yojson.Safe.Util.to_string in
+    check "Cast broken serializes confidence=medium" (cast_broken_conf = "medium");
+
+    let rename_fix = Diagnostics.make_rename_column_fix ~old_name:"x" ~new_name:"y" ~edit_distance:1 ~is_unique:true ?file:(Some "test.t") ?line:(Some 1) () in
     let rename_json = Diagnostics.suggested_fix_to_yojson rename_fix in
     let rename_conf = Yojson.Safe.Util.member "confidence" rename_json |> Yojson.Safe.Util.to_string in
-    check "Rename_column serializes confidence=high" (rename_conf = "high")
+    check "Rename dist=1 unique=true confidence=high" (rename_conf = "high");
+
+    let rename_fix2 = Diagnostics.make_rename_column_fix ~old_name:"x" ~new_name:"y" ~edit_distance:2 ~is_unique:true ?file:(Some "test.t") ?line:(Some 1) () in
+    let rename_json2 = Diagnostics.suggested_fix_to_yojson rename_fix2 in
+    let rename_conf2 = Yojson.Safe.Util.member "confidence" rename_json2 |> Yojson.Safe.Util.to_string in
+    check "Rename dist=2 unique=true confidence=medium" (rename_conf2 = "medium");
+
+    let rename_fix3 = Diagnostics.make_rename_column_fix ~old_name:"x" ~new_name:"y" ~edit_distance:1 ~is_unique:false ?file:(Some "test.t") ?line:(Some 1) () in
+    let rename_json3 = Diagnostics.suggested_fix_to_yojson rename_fix3 in
+    let rename_conf3 = Yojson.Safe.Util.member "confidence" rename_json3 |> Yojson.Safe.Util.to_string in
+    check "Rename dist=1 unique=false confidence=medium" (rename_conf3 = "medium");
+
+    let rename_fix4 = Diagnostics.make_rename_column_fix ~old_name:"x" ~new_name:"y" ~edit_distance:2 ~is_unique:false ?file:(Some "test.t") ?line:(Some 1) () in
+    let rename_json4 = Diagnostics.suggested_fix_to_yojson rename_fix4 in
+    let rename_conf4 = Yojson.Safe.Util.member "confidence" rename_json4 |> Yojson.Safe.Util.to_string in
+    check "Rename dist=2 unique=false confidence=low" (rename_conf4 = "low");
+
+    let rename_fix5 = Diagnostics.make_rename_column_fix ~old_name:"x" ~new_name:"y" ~edit_distance:3 ~is_unique:true ?file:(Some "test.t") ?line:(Some 1) () in
+    let rename_json5 = Diagnostics.suggested_fix_to_yojson rename_fix5 in
+    let rename_conf5 = Yojson.Safe.Util.member "confidence" rename_json5 |> Yojson.Safe.Util.to_string in
+    check "Rename dist=3 unique=true confidence=low" (rename_conf5 = "low");
+
+    ()
   in
   test_cast_and_rename_confidence ();
 
-  Printf.printf "\n";
+  Printf.printf "\n";;

--- a/tests/test_check.ml
+++ b/tests/test_check.ml
@@ -454,4 +454,18 @@ let run_tests pass_count fail_count failures eval_string _eval_string_env _test 
   in
   test_run_command ();
 
+  Printf.printf "\nCast and Rename_column confidence:\n";
+  let test_cast_and_rename_confidence () =
+    let cast_fix = Diagnostics.Cast { column = "x"; cast_to = "double"; target_node = None; file = Some "test.t"; line = Some 1 } in
+    let cast_json = Diagnostics.suggested_fix_to_yojson cast_fix in
+    let cast_conf = Yojson.Safe.Util.member "confidence" cast_json |> Yojson.Safe.Util.to_string in
+    check "Cast serializes confidence=high" (cast_conf = "high");
+
+    let rename_fix = Diagnostics.Rename_column { old_name = "x"; new_name = "y"; target_node = None; file = Some "test.t"; line = Some 1 } in
+    let rename_json = Diagnostics.suggested_fix_to_yojson rename_fix in
+    let rename_conf = Yojson.Safe.Util.member "confidence" rename_json |> Yojson.Safe.Util.to_string in
+    check "Rename_column serializes confidence=high" (rename_conf = "high")
+  in
+  test_cast_and_rename_confidence ();
+
   Printf.printf "\n";

--- a/tests/test_fix.ml
+++ b/tests/test_fix.ml
@@ -149,13 +149,13 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
   Printf.printf "\nsuggested_fix roundtrip:\n";
   let test_roundtrip () =
     let fixes : Diagnostics.suggested_fix list = [
-      Cast { column = "x"; cast_to = "double"; target_node = Some "clean"; file = Some "test.t"; line = Some 5 };
-      Cast { column = "y"; cast_to = "string"; target_node = None; file = Some "test.t"; line = Some 6 };
-      Rename_column { old_name = "a"; new_name = "b"; target_node = Some "step2"; file = Some "test.t"; line = None };
-      Add_node_arg { node = "filter"; arg = "na_rm=true"; target_node = None; file = Some "test.t"; line = None };
-      Suggest_identifier { name = "prnt"; suggestion = "print"; target_node = None; file = Some "test.t"; line = None };
-      Run_command { command = "t init ."; description = "Initialize tproject.toml"; target_node = None; file = Some "test.t"; line = None };
-      NoFix;
+      Diagnostics.make_cast_fix ~column:"x" ~cast_to:"double" ~chain_broken:false ?target_node:(Some "clean") ?file:(Some "test.t") ?line:(Some 5) ();
+      Diagnostics.make_cast_fix ~column:"y" ~cast_to:"string" ~chain_broken:false ?file:(Some "test.t") ?line:(Some 6) ();
+      Diagnostics.make_rename_column_fix ~old_name:"a" ~new_name:"b" ~edit_distance:1 ~is_unique:true ?target_node:(Some "step2") ?file:(Some "test.t") ();
+      Diagnostics.make_add_node_arg_fix ~node:"filter" ~arg:"na_rm=true" ?file:(Some "test.t") ();
+      Diagnostics.make_suggest_identifier_fix ~name:"prnt" ~suggestion:"print" ~edit_distance:1 ~is_unique:true ?file:(Some "test.t") ();
+      Diagnostics.make_run_command_fix ~command:"t init ." ~description:"Initialize tproject.toml" ?file:(Some "test.t") ();
+      Diagnostics.NoFix;
     ] in
     let all_ok = List.for_all (fun fix ->
       let json = Diagnostics.suggested_fix_to_yojson fix in
@@ -254,7 +254,7 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
     let oc = open_out tmp in
     output_string oc "raw = node(\n  command = read_csv(\"data.csv\"),\n  runtime = T\n)\n";
     close_out oc;
-    let r = Fix.apply_fix ~file:tmp (Diagnostics.Add_node_arg { node = "raw"; arg = "serializer = ^csv"; target_node = Some "raw"; file = Some tmp; line = None }) in
+    let r = Fix.apply_fix ~file:tmp (Diagnostics.make_add_node_arg_fix ~node:"raw" ~arg:"serializer = ^csv" ?target_node:(Some "raw") ?file:(Some tmp) ()) in
     let ch = open_in tmp in
     let content = really_input_string ch (in_channel_length ch) in
     close_in ch;
@@ -272,7 +272,7 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
     let oc = open_out tmp in
     output_string oc "other = node(\n  command = read_csv(\"data.csv\")\n)\n";
     close_out oc;
-    let r = Fix.apply_fix ~file:tmp (Diagnostics.Add_node_arg { node = "nonexistent"; arg = "serializer = ^csv"; target_node = None; file = Some tmp; line = None }) in
+    let r = Fix.apply_fix ~file:tmp (Diagnostics.make_add_node_arg_fix ~node:"nonexistent" ~arg:"serializer = ^csv" ?file:(Some tmp) ()) in
     Sys.remove tmp;
     check "apply_fix returns false for non-existent node" (r = false)
   in
@@ -287,15 +287,15 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
       diag_end_line = None; diag_end_column = None;
       diag_message = "first"; diag_expected = None; diag_actual = None;
       diag_caused_by = [];
-      diag_suggested_fix = Cast { column = "x"; cast_to = "double"; target_node = None; file = Some "test.t"; line = Some 3 };
+      diag_suggested_fix = Diagnostics.make_cast_fix ~column:"x" ~cast_to:"double" ~chain_broken:false ?file:(Some "test.t") ?line:(Some 3) ();
     } in
     let d2 = { d1 with diag_id = "T0002"; diag_line = Some 10;
       diag_message = "second";
-      diag_suggested_fix = Cast { column = "y"; cast_to = "double"; target_node = None; file = Some "test.t"; line = Some 10 };
+      diag_suggested_fix = Diagnostics.make_cast_fix ~column:"y" ~cast_to:"double" ~chain_broken:false ?file:(Some "test.t") ?line:(Some 10) ();
     } in
     let d3 = { d1 with diag_id = "T0003"; diag_line = Some 5;
       diag_message = "third";
-      diag_suggested_fix = Cast { column = "z"; cast_to = "double"; target_node = None; file = Some "test.t"; line = Some 5 };
+      diag_suggested_fix = Diagnostics.make_cast_fix ~column:"z" ~cast_to:"double" ~chain_broken:false ?file:(Some "test.t") ?line:(Some 5) ();
     } in
     let sorted = Fix.sort_fixes_by_descending_line [d1; d2; d3] in
     let lines = List.filter_map (fun d -> d.Diagnostics.diag_line) sorted in
@@ -332,15 +332,15 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
       diag_end_line = None; diag_end_column = None;
       diag_message = "Column 'x' expected double, got int";
       diag_expected = None; diag_actual = None; diag_caused_by = [];
-      diag_suggested_fix = Cast { column = "x"; cast_to = "double"; target_node = None; file = Some "test.t"; line = Some 5 };
+      diag_suggested_fix = Diagnostics.make_cast_fix ~column:"x" ~cast_to:"double" ~chain_broken:false ?file:(Some "test.t") ?line:(Some 5) ();
     } in
     let d2 = { d1 with diag_id = "T1002"; diag_line = Some 8;
       diag_message = "Column 'y' expected string, got int";
-      diag_suggested_fix = Cast { column = "y"; cast_to = "string"; target_node = None; file = Some "test.t"; line = Some 8 };
+      diag_suggested_fix = Diagnostics.make_cast_fix ~column:"y" ~cast_to:"string" ~chain_broken:false ?file:(Some "test.t") ?line:(Some 8) ();
     } in
     let d3 = { d1 with diag_id = "T1003"; diag_line = Some 12;
       diag_message = "Node `pyn` depends on `rn` but has no explicit deserializer";
-      diag_suggested_fix = Add_node_arg { node = "pyn"; arg = "deserializer = ^csv"; target_node = Some "pyn"; file = Some "test.t"; line = None };
+      diag_suggested_fix = Diagnostics.make_add_node_arg_fix ~node:"pyn" ~arg:"deserializer = ^csv" ?file:(Some "test.t") ();
     } in
     let fixes = [d1; d2; d3] in
     let result = Fix.apply_fixes ~dry_run:true ~default_file:"test.t" fixes in
@@ -363,7 +363,7 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
       diag_end_line = None; diag_end_column = None;
       diag_message = "type mismatch"; diag_expected = None; diag_actual = None;
       diag_caused_by = [];
-      diag_suggested_fix = Cast { column = "x"; cast_to = "double"; target_node = None; file = Some tmp_cast; line = Some 3 };
+      diag_suggested_fix = Diagnostics.make_cast_fix ~column:"x" ~cast_to:"double" ~chain_broken:false ?file:(Some tmp_cast) ?line:(Some 3) ();
     } in
     let result = Fix.apply_fixes ~dry_run:false ~default_file:tmp_cast [d1] in
     check "non-dry-run: applied = 1" (result.Fix.applied = 1);

--- a/tests/test_fix.ml
+++ b/tests/test_fix.ml
@@ -155,7 +155,7 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
       Diagnostics.make_add_node_arg_fix ~node:"filter" ~arg:"na_rm=true" ?file:(Some "test.t") ();
       Diagnostics.make_suggest_identifier_fix ~name:"prnt" ~suggestion:"print" ~edit_distance:1 ~is_unique:true ?file:(Some "test.t") ();
       Diagnostics.make_run_command_fix ~command:"t init ." ~description:"Initialize tproject.toml" ?file:(Some "test.t") ();
-      Diagnostics.NoFix;
+      Diagnostics.no_fix;
     ] in
     let all_ok = List.for_all (fun fix ->
       let json = Diagnostics.suggested_fix_to_yojson fix in
@@ -244,7 +244,7 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
 
   Printf.printf "\napply_fix dispatch:\n";
   let test_apply_fix_noop () =
-    let r = Fix.apply_fix ~file:"/dev/null" Diagnostics.NoFix in
+    let r = Fix.apply_fix ~file:"/dev/null" Diagnostics.no_fix in
     check "apply_fix returns false for NoFix" (r = false)
   in
   test_apply_fix_noop ();

--- a/tests/test_runner.ml
+++ b/tests/test_runner.ml
@@ -165,7 +165,9 @@ let () =
 
   (* t check / Diagnostics tests *)
   Test_check.run_tests pass_count fail_count failures eval_string eval_string_env test;
+  flush stdout;
   Test_fix.run_tests pass_count fail_count failures eval_string eval_string_env test;
+  flush stdout;
 
   (* NDJSON streaming tests *)
   Test_ndjson.run_tests pass_count fail_count failures eval_string eval_string_env test;


### PR DESCRIPTION
…low rules

- diagnostics.ml: serialize confidence level ('high', 'medium', 'low') inside suggested_fix JSON objects.
- test_check.ml: add assertions verifying confidence level serialization.
- AGENTS.md, skill-t-project.md: document t fix idempotency constraints, watch-mode avoidance, and custom function schema tracking limits.