### PR TITLE
fix(nix): escape single quotes in user code embedded in Nix '' strings

### DIFF
--- a/src/pipeline/nix_emit_node.ml
+++ b/src/pipeline/nix_emit_node.ml
@@ -2664,7 +2664,7 @@ EOF
 EOF
       echo "    with open(os.path.join(os.environ['out'], 'class'), 'w') as f: f.write(py_visual_class(__node_result))" >> node_script.py
       echo "    py_write_warnings(captured_warns, os.path.join(os.environ['out'], 'warnings'))" >> node_script.py|}
-            (if globals_decl = "" then "" else Printf.sprintf "      echo %s >> node_script.py\n" (shell_single_quote globals_decl))
+            (if globals_decl = "" then "" else Printf.sprintf "      echo %s >> node_script.py\n" (Nix_utils.nix_escape_indented_code (shell_single_quote globals_decl)))
             (Nix_utils.nix_escape_indented_code (indent_string expr_s_no_imports 4)) (Nix_utils.nix_escape_indented_code (py_emit_artifact "__node_result"))
       else
         Printf.sprintf {|      echo "import warnings" >> node_script.py

--- a/src/pipeline/nix_emit_node.ml
+++ b/src/pipeline/nix_emit_node.ml
@@ -2238,7 +2238,7 @@ Base.setproperty!(ns::TlangNamespace, sym::Symbol, val) = (getfield(ns, :dict)[s
               let expr_str = to_t_expr child in
               Printf.sprintf {|      cat <<'EOF' >> node_script.t
 %s = %s
-EOF|} k expr_str
+EOF|} k (Nix_utils.nix_escape_indented_code expr_str)
             ) children
       in
 
@@ -2372,7 +2372,7 @@ EOF|} k expr_str
       if imports = [] then ""
       else
         let code = String.concat "\n" (List.map String.trim imports) in
-        Printf.sprintf "      cat <<'EOF' >> node_script.%s\n%s\nEOF\n" ext code
+        Printf.sprintf "      cat <<'EOF' >> node_script.%s\n%s\nEOF\n" ext (Nix_utils.nix_escape_indented_code code)
     else ""
   in
 
@@ -2590,7 +2590,7 @@ EOF
 EOF
        echo "  writeLines(r_visual_class(node_result), file.path(Sys.getenv('out'), 'class'))" >> node_script.R
        echo "  r_write_warnings(captured_warns, file.path(Sys.getenv('out'), 'warnings'))" >> node_script.R
-       echo "}" >> node_script.R|} expr_s_no_imports (r_emit_artifact "node_result")
+       echo "}" >> node_script.R|} (Nix_utils.nix_escape_indented_code expr_s_no_imports) (Nix_utils.nix_escape_indented_code (r_emit_artifact "node_result"))
       else
         Printf.sprintf {|      echo "captured_warns <- list()" >> node_script.R
       echo "tryCatch({" >> node_script.R
@@ -2614,7 +2614,7 @@ EOF
 EOF
        echo "  writeLines(r_visual_class(node_result), file.path(Sys.getenv('out'), 'class'))" >> node_script.R
        echo "  r_write_warnings(captured_warns, file.path(Sys.getenv('out'), 'warnings'))" >> node_script.R
-       echo "}" >> node_script.R|} expr_s (r_emit_artifact "node_result")
+       echo "}" >> node_script.R|} (Nix_utils.nix_escape_indented_code expr_s) (Nix_utils.nix_escape_indented_code (r_emit_artifact "node_result"))
     else if runtime = "Python" then
       if is_raw_code then
         if raw_assigns_to name expr_s then
@@ -2637,7 +2637,7 @@ EOF
 %s
 EOF
       echo "    with open(os.path.join(os.environ['out'], 'class'), 'w') as f: f.write(py_visual_class(__node_result))" >> node_script.py
-      echo "    py_write_warnings(captured_warns, os.path.join(os.environ['out'], 'warnings'))" >> node_script.py|} (indent_string expr_s 8) name (py_emit_artifact "__node_result")
+      echo "    py_write_warnings(captured_warns, os.path.join(os.environ['out'], 'warnings'))" >> node_script.py|} (Nix_utils.nix_escape_indented_code (indent_string expr_s 8)) name (Nix_utils.nix_escape_indented_code (py_emit_artifact "__node_result"))
         else
           let globals_decl =
             if deps = [] then ""
@@ -2665,7 +2665,7 @@ EOF
       echo "    with open(os.path.join(os.environ['out'], 'class'), 'w') as f: f.write(py_visual_class(__node_result))" >> node_script.py
       echo "    py_write_warnings(captured_warns, os.path.join(os.environ['out'], 'warnings'))" >> node_script.py|}
             (if globals_decl = "" then "" else Printf.sprintf "      echo %s >> node_script.py\n" (shell_single_quote globals_decl))
-            (indent_string expr_s_no_imports 4) (py_emit_artifact "__node_result")
+            (Nix_utils.nix_escape_indented_code (indent_string expr_s_no_imports 4)) (Nix_utils.nix_escape_indented_code (py_emit_artifact "__node_result"))
       else
         Printf.sprintf {|      echo "import warnings" >> node_script.py
       echo "try:" >> node_script.py
@@ -2684,10 +2684,10 @@ EOF
 %s
 EOF
       echo "    with open(os.path.join(os.environ['out'], 'class'), 'w') as f: f.write(py_visual_class(__node_result))" >> node_script.py
-      echo "    py_write_warnings(captured_warns, os.path.join(os.environ['out'], 'warnings'))" >> node_script.py|} (indent_string (Printf.sprintf "__node_result = %s" expr_s) 8) (py_emit_artifact "__node_result")
+      echo "    py_write_warnings(captured_warns, os.path.join(os.environ['out'], 'warnings'))" >> node_script.py|} (Nix_utils.nix_escape_indented_code (indent_string (Printf.sprintf "__node_result = %s" expr_s) 8)) (Nix_utils.nix_escape_indented_code (py_emit_artifact "__node_result"))
     else if runtime = "Julia" then
-      let emitted_expr = indent_string expr_s_no_imports 12 in
-      let emitted_artifact = julia_emit_artifact "__node_result" in
+      let emitted_expr = Nix_utils.nix_escape_indented_code (indent_string expr_s_no_imports 12) in
+      let emitted_artifact = Nix_utils.nix_escape_indented_code (julia_emit_artifact "__node_result") in
       String.concat "\n"
         [
           {|      echo "captured_logger = TCaptureLogger()" >> node_script.jl|};
@@ -2717,7 +2717,7 @@ EOF
     else if runtime = "sh" then
       (match expr.Ast.node with
       | RawCode { raw_text; _ } ->
-          Printf.sprintf "      cat <<'EOF' >> node_script.sh\n%s\nEOF" raw_text
+          Printf.sprintf "      cat <<'EOF' >> node_script.sh\n%s\nEOF" (Nix_utils.nix_escape_indented_code raw_text)
       | Value (VString cmd) | Value (VSymbol cmd) ->
           if shell = None && shell_args_tokens = [] && sh_cli_args_tokens <> [] && is_simple_exec_command cmd then
             let set_args = shell_set_args_block sh_cli_args_tokens in
@@ -2728,7 +2728,7 @@ EOF
             let set_args = shell_set_args_block sh_cli_args_tokens in
             Printf.sprintf {|%s      cat <<'EOF' >> node_script.sh
 %s
-EOF|} set_args cmd
+EOF|} set_args (Nix_utils.nix_escape_indented_code cmd)
       | _ -> "      printf '%%s\\n' true >> node_script.sh")
     else (* T runtime *)
       if is_raw_code then
@@ -2741,7 +2741,7 @@ EOF
       echo "%s" >> node_script.t
       echo "      if (is_error(res1)) { print(\"Serialization failed:\"); print(res1); exit(1) } else { 0 }" >> node_script.t
       echo "      res2 = write_text(\"$out/class\", type(__node_result))" >> node_script.t
-      echo "      if (is_error(res2)) { print(\"Class write failed:\"); print(res2); exit(1) } else { 0 }" >> node_script.t|} expr_s_no_imports res1_line_local
+      echo "      if (is_error(res2)) { print(\"Class write failed:\"); print(res2); exit(1) } else { 0 }" >> node_script.t|} (Nix_utils.nix_escape_indented_code expr_s_no_imports) res1_line_local
       else
         let res1_line_local = res1_line_for "__node_result" in
         Printf.sprintf {|      cat <<'EOF' >> node_script.t
@@ -2750,7 +2750,7 @@ EOF
       echo "%s" >> node_script.t
       echo "      if (is_error(res1)) { print(\"Serialization failed:\"); print(res1); exit(1) } else { 0 }" >> node_script.t
       echo "      res2 = write_text(\"$out/class\", type(__node_result))" >> node_script.t
-      echo "      if (is_error(res2)) { print(\"Class write failed:\"); print(res2); exit(1) } else { 0 }" >> node_script.t|} expr_s res1_line_local
+      echo "      if (is_error(res2)) { print(\"Class write failed:\"); print(res2); exit(1) } else { 0 }" >> node_script.t|} (Nix_utils.nix_escape_indented_code expr_s) res1_line_local
   in
 
   let runtime_base_packages =

--- a/src/pipeline/nix_utils.ml
+++ b/src/pipeline/nix_utils.ml
@@ -37,3 +37,17 @@ let nix_double_quote s =
     | c -> Buffer.add_char buffer c
   ) s;
   "\"" ^ Buffer.contents buffer ^ "\""
+
+(** Escape user code for safe embedding inside Nix ''...'' strings.
+    Every ' is replaced by ${"'"}, which Nix interpolates back to a literal '.
+    This prevents user code containing '' (e.g. Python empty strings) from
+    terminating the Nix indented string prematurely. *)
+let nix_escape_indented_code s =
+  let buf = Buffer.create (String.length s * 5) in
+  String.iter (fun c ->
+    if c = '\'' then
+      Buffer.add_string buf "${\"'\"}"
+    else
+      Buffer.add_char buf c
+  ) s;
+  Buffer.contents buf

--- a/src/pipeline/nix_utils.ml
+++ b/src/pipeline/nix_utils.ml
@@ -39,13 +39,17 @@ let nix_double_quote s =
   "\"" ^ Buffer.contents buffer ^ "\""
 
 (** Escape user code for safe embedding inside Nix ''...'' strings.
-    Every ' is replaced by ${"'"}, which Nix interpolates back to a literal '.
+    Every $ is replaced by ${"$"}, and every ' is replaced by ${"'"},
+    which Nix interpolates back to their literal values.
     This prevents user code containing '' (e.g. Python empty strings) from
-    terminating the Nix indented string prematurely. *)
+    terminating the Nix indented string, and ${...} from triggering Nix
+    interpolation. Order matters: $ must be escaped before '. *)
 let nix_escape_indented_code s =
-  let buf = Buffer.create (String.length s * 5) in
+  let buf = Buffer.create (String.length s * 7) in
   String.iter (fun c ->
-    if c = '\'' then
+    if c = '$' then
+      Buffer.add_string buf "${\"$\"}"
+    else if c = '\'' then
       Buffer.add_string buf "${\"'\"}"
     else
       Buffer.add_char buf c

--- a/src/pipeline/nix_utils.ml
+++ b/src/pipeline/nix_utils.ml
@@ -39,19 +39,22 @@ let nix_double_quote s =
   "\"" ^ Buffer.contents buffer ^ "\""
 
 (** Escape user code for safe embedding inside Nix ''...'' strings.
-    Every $ is replaced by ${"$"}, and every ' is replaced by ${"'"},
+    ${ is replaced by ${"$"}, and every ' is replaced by ${"'"},
     which Nix interpolates back to their literal values.
-    This prevents user code containing '' (e.g. Python empty strings) from
-    terminating the Nix indented string, and ${...} from triggering Nix
-    interpolation. Order matters: $ must be escaped before '. *)
+    Bare $ (not followed by {) is safe in Nix indented strings and is
+    left unchanged so shell references like $1, $out, $PATH work. *)
 let nix_escape_indented_code s =
-  let buf = Buffer.create (String.length s * 7) in
-  String.iter (fun c ->
-    if c = '$' then
+  let len = String.length s in
+  let buf = Buffer.create (len * 7) in
+  let i = ref 0 in
+  while !i < len do
+    let c = s.[!i] in
+    if c = '$' && !i + 1 < len && s.[!i + 1] = '{' then
       Buffer.add_string buf "${\"$\"}"
     else if c = '\'' then
       Buffer.add_string buf "${\"'\"}"
     else
-      Buffer.add_char buf c
-  ) s;
+      Buffer.add_char buf c;
+    i := !i + 1
+  done;
   Buffer.contents buf

--- a/tests/pipeline/test_nix_emit.ml
+++ b/tests/pipeline/test_nix_emit.ml
@@ -149,17 +149,21 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
     (Nix_utils.nix_escape_indented_code "abc'")
     "abc${\"'\"}";
 
-  check "dollar alone"
+  check "dollar alone (bare $ is safe)"
     (Nix_utils.nix_escape_indented_code "$")
-    "${\"$\"}";
+    "$";
 
   check "dollar-brace (Nix interpolation)"
     (Nix_utils.nix_escape_indented_code "${expr}")
     "${\"$\"}{expr}";
 
+  check "dollar followed by non-brace"
+    (Nix_utils.nix_escape_indented_code "$PATH")
+    "$PATH";
+
   check "mixed quotes and dollars"
     (Nix_utils.nix_escape_indented_code "$'hello'")
-    "${\"$\"}${\"'\"}hello${\"'\"}";
+    "$${\"'\"}hello${\"'\"}";
 
   check "Python str.replace pattern"
     (Nix_utils.nix_escape_indented_code "df['col'].str.replace('', '')")

--- a/tests/pipeline/test_nix_emit.ml
+++ b/tests/pipeline/test_nix_emit.ml
@@ -126,4 +126,43 @@ let run_tests pass_count fail_count failures _eval_string _eval_string_env _test
     (replace_var_wb prefix "pkgs" "pkgs.bash and ${pkgs.gcc}")
     "env_foo.pkgs.bash and ${env_foo.pkgs.gcc}";
 
+  (* --- nix_escape_indented_code --- *)
+  Printf.printf "  nix_escape_indented_code:\n";
+
+  check "no quotes or dollars"
+    (Nix_utils.nix_escape_indented_code "hello world")
+    "hello world";
+
+  check "single quote"
+    (Nix_utils.nix_escape_indented_code "a'b")
+    "a${\"'\"}b";
+
+  check "double single quotes (Python empty string)"
+    (Nix_utils.nix_escape_indented_code "''")
+    "${\"'\"}${\"'\"}";
+
+  check "triple single quotes"
+    (Nix_utils.nix_escape_indented_code "'''")
+    "${\"'\"}${\"'\"}${\"'\"}";
+
+  check "quote at end"
+    (Nix_utils.nix_escape_indented_code "abc'")
+    "abc${\"'\"}";
+
+  check "dollar alone"
+    (Nix_utils.nix_escape_indented_code "$")
+    "${\"$\"}";
+
+  check "dollar-brace (Nix interpolation)"
+    (Nix_utils.nix_escape_indented_code "${expr}")
+    "${\"$\"}{expr}";
+
+  check "mixed quotes and dollars"
+    (Nix_utils.nix_escape_indented_code "$'hello'")
+    "${\"$\"}${\"'\"}hello${\"'\"}";
+
+  check "Python str.replace pattern"
+    (Nix_utils.nix_escape_indented_code "df['col'].str.replace('', '')")
+    "df[${\"'\"}col${\"'\"}].str.replace(${\"'\"}${\"'\"}, ${\"'\"}${\"'\"})";
+
   print_newline ()

--- a/tests/pipeline/test_pipeline.ml
+++ b/tests/pipeline/test_pipeline.ml
@@ -1356,7 +1356,7 @@ p_cross = pipeline {
          contains_substring nix "r_extract_plot_metadata <- function(object)" &&
          contains_substring nix "r_save_viz_metadata <- function(object, path)" &&
          contains_substring nix "file.path(Sys.getenv('out'), 'class')" &&
-         contains_substring nix "r_save_viz_metadata(node_result, file.path(Sys.getenv('out'), 'viz'))"
+          contains_substring nix {|r_save_viz_metadata(node_result, file.path(Sys.getenv(${"'"}out${"'"}), ${"'"}viz${"'"})|}
        in
         let has_py_plot_helpers =
           contains_substring nix "def py_extract_plot_metadata(obj):" &&
@@ -1364,7 +1364,7 @@ p_cross = pipeline {
           contains_substring nix "\"class\": \"plotnine\"" &&
           contains_substring nix "\"backend\": \"Python\"" &&
           contains_substring nix "py_visual_class(__node_result)" &&
-          contains_substring nix "py_save_viz_metadata(__node_result, os.path.join(os.environ['out'], 'viz'))"
+           contains_substring nix {|py_save_viz_metadata(__node_result, os.path.join(os.environ[${"'"}out${"'"}], ${"'"}viz${"'"})|}
         in
         let has_jl_plot_helpers =
           contains_substring nix "function jl_extract_plot_metadata(obj)" &&

--- a/tests/pipeline/test_sh_node.ml
+++ b/tests/pipeline/test_sh_node.ml
@@ -187,9 +187,9 @@ let run_tests pass_count fail_count _failures _eval_string eval_string_env test 
   (match v_sh_shell_args_nix with
    | Ast.VPipeline p ->
        let nix = Nix_emit_pipeline.emit_pipeline p in
-       if contains_substring nix "set -- 'alpha' 'line1" &&
-          contains_substring nix {|printf '%s|%s' "$1" "$2"|} &&
-          contains_substring nix ". ./node_script.sh"
+        if contains_substring nix "set -- 'alpha' 'line1" &&
+           contains_substring nix {|printf ${"'"}%s|%s${"'"} "$1" "$2"|} &&
+           contains_substring nix ". ./node_script.sh"
        then
          begin incr pass_count; Printf.printf "  ✓ sh shell mode passes args positionally\n" end
        else


### PR DESCRIPTION
Python empty strings ('') and other single-quote patterns in user code break Nix indented strings (''...'') by terminating them prematurely. Added nix_escape_indented_code to replace ' with ${"'"} interpolation, applied at all cat <<'EOF' heredocs that embed user code.