### PR TITLE
feat(testcraft): implement expect_warning for pipeline node diagnostics

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -4181,6 +4181,23 @@ assert(expect_in(3, 1:5))
 assert(expect_in(0.1 + 0.2, [0.3], tolerance = 1e-9))
 ```
 
+### `expect_warning(node, kind = "", message = "")`
+
+Pass if the given pipeline node produced at least one warning during execution.
+Optionally filter by warning `kind` string (exact match) or `message` regex pattern.
+
+**Parameters:**
+- `node` — A `NodeResult` or `ComputedNode` value (obtained from `read_node()` or a pipeline result)
+- `kind` (optional, named) — Exact warning kind to match (e.g. `"NAExcluded"`)
+- `message` (optional, named) — Regex pattern to match against the warning message
+
+**Examples:**
+```t
+assert(expect_warning(read_node(p.my_node)))
+assert(expect_warning(read_node(p.my_node), kind = "NAExcluded"))
+assert(expect_warning(read_node(p.my_node), message = "excluded"))
+```
+
 ---
 
 ## Operators

--- a/src/dune
+++ b/src/dune
@@ -82,7 +82,7 @@
     ; packages/explain
     intent_fields intent_get t_explain explain_json
     ; packages/testcraft
-    t_expect_equal t_expect_pass t_expect_fail t_expect_msg t_expect_relational t_expect_type t_expect_ds
+    t_expect_equal t_expect_pass t_expect_fail t_expect_msg t_expect_relational t_expect_type t_expect_ds t_expect_condition
    ; package_manager
    version nixpkgs_date uv2nix_commit package_types toml_parser template_engine scaffold nix_generator renv_resolver r_description_resolver test_discovery package_doctor release_manager documentation_manager update_manager package_loader
    ; tdoc

--- a/src/packages/core/packages.ml
+++ b/src/packages/core/packages.ml
@@ -225,7 +225,7 @@ let testcraft_package = {
   functions = ["expect_equal"; "expect_pass"; "expect_fail"; "expect_msg";
                "expect_lt"; "expect_lte"; "expect_gt"; "expect_gte";
                "expect_true"; "expect_false"; "expect_truthy"; "expect_falsy";
-               "expect_type"; "expect_error"; "expect_length";
+                "expect_type"; "expect_error"; "expect_length";
                 "expect_nrow"; "expect_ncol"; "expect_colnames"; "expect_fields"; "expect_in";
                 "expect_warning"];
 }

--- a/src/packages/core/packages.ml
+++ b/src/packages/core/packages.ml
@@ -226,7 +226,8 @@ let testcraft_package = {
                "expect_lt"; "expect_lte"; "expect_gt"; "expect_gte";
                "expect_true"; "expect_false"; "expect_truthy"; "expect_falsy";
                "expect_type"; "expect_error"; "expect_length";
-               "expect_nrow"; "expect_ncol"; "expect_colnames"; "expect_fields"; "expect_in"];
+                "expect_nrow"; "expect_ncol"; "expect_colnames"; "expect_fields"; "expect_in";
+                "expect_warning"];
 }
 
 (** All standard packages *)
@@ -993,6 +994,7 @@ let init_env () =
   let env = T_expect_relational.register env in
   let env = T_expect_type.register env in
   let env = T_expect_ds.register env in
+  let env = T_expect_condition.register env in
   (* Phase 7: Pretty-print and packages *)
   (* Using Pretty_print.register fully qualified *)
   let env = Pretty_print.register env in

--- a/src/packages/core/packages.ml
+++ b/src/packages/core/packages.ml
@@ -225,9 +225,9 @@ let testcraft_package = {
   functions = ["expect_equal"; "expect_pass"; "expect_fail"; "expect_msg";
                "expect_lt"; "expect_lte"; "expect_gt"; "expect_gte";
                "expect_true"; "expect_false"; "expect_truthy"; "expect_falsy";
-                "expect_type"; "expect_error"; "expect_length";
-                "expect_nrow"; "expect_ncol"; "expect_colnames"; "expect_fields"; "expect_in";
-                "expect_warning"];
+               "expect_type"; "expect_error"; "expect_length";
+               "expect_nrow"; "expect_ncol"; "expect_colnames"; "expect_fields"; "expect_in";
+               "expect_warning"];
 }
 
 (** All standard packages *)

--- a/src/packages/testcraft/README.md
+++ b/src/packages/testcraft/README.md
@@ -54,6 +54,12 @@ outcome, so it can be inspected, combined, or passed straight to `assert()`.
 | `expect_fields(x, names)` | Pass if Dict keys or List labels match `names` |
 | `expect_in(x, values)` | Pass if `x` (or every element of `x`) is in `values` |
 
+### Pipeline node diagnostics
+
+| Function | Description |
+|----------|-------------|
+| `expect_warning(node, kind = "", message = "")` | Pass if node produced a warning; optionally match `kind` and/or regex on `message` |
+
 `assert()` understands `VExpect` directly: on `Expect_pass` it returns
 `true`, on `Expect_stop`/`Expect_hold` it raises an `AssertionError` using
 the comparison's own diagnostic message.

--- a/src/packages/testcraft/t_expect_condition.ml
+++ b/src/packages/testcraft/t_expect_condition.ml
@@ -1,32 +1,26 @@
 open Ast
 
-let warnings_from_result = function
-  | VNodeResult { diagnostics = { nd_warnings = []; _ }; _ } -> None
-  | VNodeResult { diagnostics = { nd_warnings; _ }; _ } -> Some nd_warnings
-  | _ -> None
-
 let regex_matches re s =
   try ignore (Str.search_forward re s 0); true
   with Not_found -> false
 
-let get_warnings v = match v with
-  | VNodeResult { diagnostics = { nd_warnings = []; _ }; _ } -> `Clean
-  | VNodeResult { diagnostics = { nd_warnings; _ }; _ } -> `Warned nd_warnings
-  | VComputedNode cn ->
-      let cn = !Ast.computed_node_resolver cn in
-      (match Ast.get_in_memory_node_value_for_cn cn with
-       | Some v ->
-           (match warnings_from_result v with
-            | Some w -> `Warned w
-            | None -> `Clean)
-       | None -> `Unresolved)
-  | _ -> `Clean
-
 (*
---# Assert that a pipeline node produced a warning
+--# Assert that a pipeline node produced a warning diagnostic
 --#
 --# Passes if the node's diagnostics contain at least one warning.
 --# Optionally filters by warning `kind` string and/or regex on the warning `message`.
+--#
+--# This only checks pipeline node warning diagnostics (stored in
+--# `nd_warnings` on `NodeResult`/`ComputedNode`). It does not capture
+--# runtime warnings or print output.
+--#
+--# `ComputedNode` values must already have been evaluated (e.g. via
+--# `build_pipeline` or `run_pipeline`); otherwise the expectation fails.
+--#
+--# The `message` pattern uses OCaml's standard `Str` regular expression
+--# syntax (not PCRE). Matching is substring-based (searches anywhere in
+--# the message). Empty string values for `kind` or `message` are treated
+--# as omitted filters (match any).
 --#
 --# @name expect_warning
 --# @param node :: NodeResult | ComputedNode The computed node to inspect.
@@ -114,60 +108,68 @@ let register env =
              match re with
              | Error err -> err
              | Ok re_opt ->
+             let check_warnings warnings =
+               let matches =
+                 match kind_opt, re_opt with
+                 | Some kind, Some re ->
+                     List.exists (fun w ->
+                       w.nw_kind = kind
+                       && regex_matches re w.nw_message
+                     ) warnings
+                 | Some kind, None ->
+                     List.exists (fun w -> w.nw_kind = kind) warnings
+                 | None, Some re ->
+                     List.exists (fun w -> regex_matches re w.nw_message) warnings
+                 | None, None -> true
+               in
+               if matches then VExpect Expect_pass
+               else
+                 let kinds =
+                   warnings
+                   |> List.map (fun w -> w.nw_kind)
+                   |> List.sort_uniq String.compare
+                   |> String.concat ", "
+                 in
+                 let msg =
+                   match kind_opt, message_opt with
+                   | Some k, Some p ->
+                       Printf.sprintf
+                         "No warning of kind `%s` matching message pattern `%s` found. Available warning kinds: [%s]"
+                         k p kinds
+                   | Some k, None ->
+                       Printf.sprintf
+                         "No warning of kind `%s` found. Available warning kinds: [%s]"
+                         k kinds
+                   | None, Some p ->
+                       Printf.sprintf
+                         "No warning matching message pattern `%s` found. Available warning kinds: [%s]"
+                         p kinds
+                   | None, None ->
+                       Printf.sprintf
+                         "No matching warning found on node. Available warning kinds: [%s]"
+                         kinds
+                 in
+                 VExpect (Expect_stop msg)
+             in
              match positional with
              | [v] ->
                  (match v with
                   | VNA _ -> VExpect (Expect_hold "`node` is NA, cannot check for warnings")
                   | VError err ->
                       VExpect (Expect_stop (Printf.sprintf "`node` is an error: %s" err.message))
-                  | VNodeResult _ | VComputedNode _ ->
-                      (match get_warnings v with
-                       | `Unresolved ->
+                  | VNodeResult { diagnostics = { nd_warnings = []; _ }; _ } ->
+                      VExpect (Expect_stop "No warnings found on this node")
+                  | VNodeResult { diagnostics = { nd_warnings; _ }; _ } ->
+                      check_warnings nd_warnings
+                  | VComputedNode cn ->
+                      (match Ast.get_in_memory_node_value_for_cn cn with
+                       | Some (VNodeResult { diagnostics = { nd_warnings = []; _ }; _ }) ->
+                           VExpect (Expect_stop "No warnings found on this node")
+                       | Some (VNodeResult { diagnostics = { nd_warnings; _ }; _ }) ->
+                           check_warnings nd_warnings
+                       | _ ->
                            VExpect (Expect_stop
-                                      "Computed node has not been evaluated; cannot inspect warnings")
-                       | `Clean -> VExpect (Expect_stop "No warnings found on this node")
-                       | `Warned warnings ->
-                           let matches =
-                             match kind_opt, re_opt with
-                             | Some kind, Some re ->
-                                 List.exists (fun w ->
-                                   w.nw_kind = kind
-                                   && regex_matches re w.nw_message
-                                 ) warnings
-                             | Some kind, None ->
-                                 List.exists (fun w -> w.nw_kind = kind) warnings
-                             | None, Some re ->
-                                 List.exists (fun w -> regex_matches re w.nw_message) warnings
-                             | None, None -> true
-                           in
-                           if matches then VExpect Expect_pass
-                           else
-                             let kinds =
-                               warnings
-                               |> List.map (fun w -> w.nw_kind)
-                               |> List.sort_uniq String.compare
-                               |> String.concat ", "
-                             in
-                             let msg =
-                               match kind_opt, message_opt with
-                               | Some k, Some p ->
-                                   Printf.sprintf
-                                     "No warning of kind `%s` matching message pattern `%s` found. Available warning kinds: [%s]"
-                                     k p kinds
-                               | Some k, None ->
-                                   Printf.sprintf
-                                     "No warning of kind `%s` found. Available warning kinds: [%s]"
-                                     k kinds
-                               | None, Some p ->
-                                   Printf.sprintf
-                                     "No warning matching message pattern `%s` found. Available warning kinds: [%s]"
-                                     p kinds
-                               | None, None ->
-                                   Printf.sprintf
-                                     "No matching warning found on node. Available warning kinds: [%s]"
-                                     kinds
-                             in
-                             VExpect (Expect_stop msg))
+                                      "Computed node has not been evaluated; cannot inspect warnings"))
                   | _ ->
                       Error.type_error
                         (Printf.sprintf

--- a/src/packages/testcraft/t_expect_condition.ml
+++ b/src/packages/testcraft/t_expect_condition.ml
@@ -10,12 +10,17 @@ let regex_matches re s =
   with Not_found -> false
 
 let get_warnings v = match v with
+  | VNodeResult { diagnostics = { nd_warnings = []; _ }; _ } -> `Clean
+  | VNodeResult { diagnostics = { nd_warnings; _ }; _ } -> `Warned nd_warnings
   | VComputedNode cn ->
       let cn = !Ast.computed_node_resolver cn in
       (match Ast.get_in_memory_node_value_for_cn cn with
-       | Some v -> warnings_from_result v
-       | None -> None)
-  | _ -> warnings_from_result v
+       | Some v ->
+           (match warnings_from_result v with
+            | Some w -> `Warned w
+            | None -> `Clean)
+       | None -> `Unresolved)
+  | _ -> `Clean
 
 (*
 --# Assert that a pipeline node produced a warning
@@ -26,7 +31,9 @@ let get_warnings v = match v with
 --# @name expect_warning
 --# @param node :: NodeResult | ComputedNode The computed node to inspect.
 --# @param kind :: String = "" Optional warning kind to match exactly (e.g. "NAExcluded").
+--#   Empty string (default) is treated as omitted — matches any kind.
 --# @param message :: String = "" Optional regex pattern to match against the warning message.
+--#   Empty string (default) is treated as omitted — matches any message.
 --# @return :: Expect Pass if warnings are present and match any provided filters.
 --# @example
 --#   assert(expect_warning(read_node(p.my_node)))
@@ -84,11 +91,11 @@ let register env =
              let re =
                match message_opt with
                | Some pat ->
-                    (try Ok (Some (Str.regexp pat))
-                     with Failure msg ->
-                       Error (Error.value_error
-                                (Printf.sprintf
-                                   "Invalid regex pattern `%s`: %s" pat msg)))
+                   (try Ok (Some (Str.regexp pat))
+                    with Failure msg ->
+                      Error (Error.value_error
+                               (Printf.sprintf
+                                  "Invalid regex pattern `%s`: %s" pat msg)))
                | None -> Ok None
              in
              let positional =
@@ -109,60 +116,63 @@ let register env =
              | Ok re_opt ->
              match positional with
              | [v] ->
-                  (match v with
-                   | VNA _ -> VExpect (Expect_hold "`node` is NA, cannot check for warnings")
-                   | VError err ->
-                       VExpect (Expect_stop (Printf.sprintf "`node` is an error: %s" err.message))
-                   | VNodeResult _ | VComputedNode _ ->
-                       (match get_warnings v with
-                        | None -> VExpect (Expect_stop "No warnings found on this node")
-                        | Some warnings ->
-                            let matches =
-                              match kind_opt, re_opt with
-                              | Some kind, Some re ->
-                                  List.exists (fun w ->
-                                    w.nw_kind = kind
-                                    && regex_matches re w.nw_message
-                                  ) warnings
-                              | Some kind, None ->
-                                  List.exists (fun w -> w.nw_kind = kind) warnings
-                              | None, Some re ->
-                                  List.exists (fun w -> regex_matches re w.nw_message) warnings
-                              | None, None -> true
-                            in
-                            if matches then VExpect Expect_pass
-                            else
-                              let kinds =
-                                warnings
-                                |> List.map (fun w -> w.nw_kind)
-                                |> List.sort_uniq String.compare
-                                |> String.concat ", "
-                              in
-                              let msg =
-                                match kind_opt, message_opt with
-                                | Some k, Some p ->
-                                    Printf.sprintf
-                                      "No warning of kind `%s` matching message pattern `%s` found. Available warning kinds: [%s]"
-                                      k p kinds
-                                | Some k, None ->
-                                    Printf.sprintf
-                                      "No warning of kind `%s` found. Available warning kinds: [%s]"
-                                      k kinds
-                                | None, Some p ->
-                                    Printf.sprintf
-                                      "No warning matching message pattern `%s` found. Available warning kinds: [%s]"
-                                      p kinds
-                                | None, None ->
-                                    Printf.sprintf
-                                      "No matching warning found on node. Available warning kinds: [%s]"
-                                      kinds
-                              in
-                              VExpect (Expect_stop msg))
-                   | _ ->
-                       Error.type_error
-                         (Printf.sprintf
-                            "Function `expect_warning` expects a NodeResult or ComputedNode, got %s."
-                            (Utils.type_name v)))
+                 (match v with
+                  | VNA _ -> VExpect (Expect_hold "`node` is NA, cannot check for warnings")
+                  | VError err ->
+                      VExpect (Expect_stop (Printf.sprintf "`node` is an error: %s" err.message))
+                  | VNodeResult _ | VComputedNode _ ->
+                      (match get_warnings v with
+                       | `Unresolved ->
+                           VExpect (Expect_stop
+                                      "Computed node has not been evaluated; cannot inspect warnings")
+                       | `Clean -> VExpect (Expect_stop "No warnings found on this node")
+                       | `Warned warnings ->
+                           let matches =
+                             match kind_opt, re_opt with
+                             | Some kind, Some re ->
+                                 List.exists (fun w ->
+                                   w.nw_kind = kind
+                                   && regex_matches re w.nw_message
+                                 ) warnings
+                             | Some kind, None ->
+                                 List.exists (fun w -> w.nw_kind = kind) warnings
+                             | None, Some re ->
+                                 List.exists (fun w -> regex_matches re w.nw_message) warnings
+                             | None, None -> true
+                           in
+                           if matches then VExpect Expect_pass
+                           else
+                             let kinds =
+                               warnings
+                               |> List.map (fun w -> w.nw_kind)
+                               |> List.sort_uniq String.compare
+                               |> String.concat ", "
+                             in
+                             let msg =
+                               match kind_opt, message_opt with
+                               | Some k, Some p ->
+                                   Printf.sprintf
+                                     "No warning of kind `%s` matching message pattern `%s` found. Available warning kinds: [%s]"
+                                     k p kinds
+                               | Some k, None ->
+                                   Printf.sprintf
+                                     "No warning of kind `%s` found. Available warning kinds: [%s]"
+                                     k kinds
+                               | None, Some p ->
+                                   Printf.sprintf
+                                     "No warning matching message pattern `%s` found. Available warning kinds: [%s]"
+                                     p kinds
+                               | None, None ->
+                                   Printf.sprintf
+                                     "No matching warning found on node. Available warning kinds: [%s]"
+                                     kinds
+                             in
+                             VExpect (Expect_stop msg))
+                  | _ ->
+                      Error.type_error
+                        (Printf.sprintf
+                           "Function `expect_warning` expects a NodeResult or ComputedNode, got %s."
+                           (Utils.type_name v)))
              | args -> Error.arity_error_named "expect_warning" 1 (List.length args)))
       env
   in

--- a/src/packages/testcraft/t_expect_condition.ml
+++ b/src/packages/testcraft/t_expect_condition.ml
@@ -1,0 +1,138 @@
+open Ast
+
+let fmt v = "`" ^ Utils.value_to_string v ^ "`"
+
+let get_warnings = function
+  | VNodeResult { diagnostics = { nd_warnings = []; _ }; _ } -> None
+  | VNodeResult { diagnostics = { nd_warnings; _ }; _ } -> Some nd_warnings
+  | VComputedNode cn ->
+      let cn = !Ast.computed_node_resolver cn in
+      (match Ast.get_in_memory_node_value_for_cn cn with
+       | Some (VNodeResult { diagnostics = { nd_warnings = []; _ }; _ }) -> None
+       | Some (VNodeResult { diagnostics = { nd_warnings; _ }; _ }) -> Some nd_warnings
+       | _ -> None)
+  | _ -> None
+
+(*
+--# Assert that a pipeline node produced a warning
+--#
+--# Passes if the node's diagnostics contain at least one warning.
+--# Optionally filters by warning `kind` string and/or regex on the warning `message`.
+--#
+--# @name expect_warning
+--# @param node :: NodeResult | ComputedNode The computed node to inspect.
+--# @param kind :: String = "" Optional warning kind to match exactly (e.g. "NAExcluded").
+--# @param message :: String = "" Optional regex pattern to match against the warning message.
+--# @return :: Expect Pass if warnings are present and match any provided filters.
+--# @example
+--#   assert(expect_warning(read_node(p.my_node)))
+--#   assert(expect_warning(read_node(p.my_node), kind = "NAExcluded"))
+--#   assert(expect_warning(read_node(p.my_node), message = "excluded"))
+--# @family testcraft
+--# @seealso expect_error
+--# @export
+*)
+let register env =
+  let env =
+    Env.add "expect_warning"
+      (make_builtin_named ~name:"expect_warning" ~variadic:true ~unwrap:false 1 (fun named_args _env ->
+         let unknown_named =
+           List.filter
+             (fun (n, _) ->
+               match n with
+               | None -> false
+               | Some "kind" | Some "message" -> false
+               | Some _ -> true)
+             named_args
+         in
+         match unknown_named with
+         | (Some arg_name, _) :: _ ->
+             Error.type_error
+               (Printf.sprintf "Function `expect_warning` received unknown named argument `%s`." arg_name)
+         | _ ->
+             let kind_opt =
+               match List.find_opt (fun (n, _) -> n = Some "kind") named_args with
+                | Some (_, VString k) when k <> "" -> Some k
+                | Some (_, _) ->
+                    Some ""
+                    (* type error deferred: let positional check happen first *)
+                | _ -> None
+              in
+              let kind_err =
+               match List.find_opt (fun (n, _) -> n = Some "kind") named_args with
+               | Some (_, v) when (match v with VString _ -> false | _ -> true) ->
+                   Some (Printf.sprintf
+                            "Function `expect_warning` expects the `kind` argument to be a String, got %s."
+                            (Utils.type_name v))
+               | _ -> None
+             in
+             let message_opt =
+               match List.find_opt (fun (n, _) -> n = Some "message") named_args with
+               | Some (_, VString m) when m <> "" -> Some m
+               | _ -> None
+             in
+             let message_err =
+               match List.find_opt (fun (n, _) -> n = Some "message") named_args with
+               | Some (_, v) when (match v with VString _ -> false | _ -> true) ->
+                   Some (Printf.sprintf
+                            "Function `expect_warning` expects the `message` argument to be a String, got %s."
+                            (Utils.type_name v))
+               | _ -> None
+             in
+             let excluded = [ "kind"; "message" ] in
+             let positional =
+               named_args
+               |> List.filter (fun (n, _) ->
+                    match n with
+                    | Some n -> not (List.mem n excluded)
+                    | None -> true)
+               |> List.map snd
+             in
+             match kind_err with
+             | Some err -> Error.type_error err
+             | None ->
+             match message_err with
+             | Some err -> Error.type_error err
+             | None ->
+             match positional with
+             | [v] ->
+                 (match v with
+                  | VNA _ -> VExpect (Expect_hold "`node` is NA, cannot check for warnings")
+                  | VError err ->
+                      VExpect (Expect_stop (Printf.sprintf "`node` is an error: %s" err.message))
+                  | _ ->
+                      (match get_warnings v with
+                       | None ->
+                           VExpect (Expect_stop "No warnings found on this node")
+                       | Some warnings ->
+                           let matches =
+                             match kind_opt, message_opt with
+                              | Some kind, Some pat ->
+                                  List.exists (fun w ->
+                                    w.nw_kind = kind &&
+                                    (try ignore (Str.search_forward (Str.regexp pat) w.nw_message 0); true
+                                     with _ -> false)
+                                  ) warnings
+                              | Some kind, None ->
+                                  List.exists (fun w -> w.nw_kind = kind) warnings
+                              | None, Some pat ->
+                                  List.exists (fun w ->
+                                    try ignore (Str.search_forward (Str.regexp pat) w.nw_message 0); true
+                                    with _ -> false
+                                  ) warnings
+                             | None, None -> true
+                           in
+                           if matches then VExpect Expect_pass
+                           else
+                             let kinds = warnings
+                                           |> List.map (fun w -> w.nw_kind)
+                                           |> List.sort_uniq String.compare
+                                           |> String.concat ", "
+                             in
+                             VExpect (Expect_stop
+                                        (Printf.sprintf
+                                           "No matching warning found on node. Available warning kinds: [%s]" kinds))))
+             | args -> Error.arity_error_named "expect_warning" 1 (List.length args)))
+      env
+  in
+  env

--- a/src/packages/testcraft/t_expect_condition.ml
+++ b/src/packages/testcraft/t_expect_condition.ml
@@ -1,19 +1,17 @@
 open Ast
 
-let is_node = function
-  | VNodeResult _ | VComputedNode _ -> true
-  | _ -> false
-
-let get_warnings = function
+let warnings_from_result = function
   | VNodeResult { diagnostics = { nd_warnings = []; _ }; _ } -> None
   | VNodeResult { diagnostics = { nd_warnings; _ }; _ } -> Some nd_warnings
+  | _ -> None
+
+let get_warnings v = match v with
   | VComputedNode cn ->
       let cn = !Ast.computed_node_resolver cn in
       (match Ast.get_in_memory_node_value_for_cn cn with
-       | Some (VNodeResult { diagnostics = { nd_warnings = []; _ }; _ }) -> None
-       | Some (VNodeResult { diagnostics = { nd_warnings; _ }; _ }) -> Some nd_warnings
-       | _ -> None)
-  | _ -> None
+       | Some v -> warnings_from_result v
+       | None -> None)
+  | _ -> warnings_from_result v
 
 (*
 --# Assert that a pipeline node produced a warning
@@ -111,61 +109,60 @@ let register env =
                   | VNA _ -> VExpect (Expect_hold "`node` is NA, cannot check for warnings")
                   | VError err ->
                       VExpect (Expect_stop (Printf.sprintf "`node` is an error: %s" err.message))
-                  | _ ->
-                      if not (is_node v) then
+                    | VNodeResult _ | VComputedNode _ ->
+                          (match get_warnings v with
+                          | None ->
+                              VExpect (Expect_stop "No warnings found on this node")
+                          | Some warnings ->
+                              let matches =
+                                match kind_opt, re_opt with
+                                | Some kind, Some re ->
+                                    List.exists (fun w ->
+                                      w.nw_kind = kind &&
+                                      (try ignore (Str.search_forward re w.nw_message 0); true
+                                       with Not_found -> false)
+                                    ) warnings
+                                | Some kind, None ->
+                                    List.exists (fun w -> w.nw_kind = kind) warnings
+                                | None, Some re ->
+                                    List.exists (fun w ->
+                                      try ignore (Str.search_forward re w.nw_message 0); true
+                                      with Not_found -> false
+                                    ) warnings
+                                | None, None -> true
+                              in
+                              if matches then VExpect Expect_pass
+                              else
+                                let kinds = warnings
+                                              |> List.map (fun w -> w.nw_kind)
+                                              |> List.sort_uniq String.compare
+                                              |> String.concat ", "
+                                in
+                                let msg =
+                                  match kind_opt, message_opt with
+                                  | Some k, Some p ->
+                                      Printf.sprintf
+                                        "No warning of kind `%s` matching message pattern `%s` found. Available warning kinds: [%s]"
+                                        k p kinds
+                                  | Some k, None ->
+                                      Printf.sprintf
+                                        "No warning of kind `%s` found. Available warning kinds: [%s]"
+                                        k kinds
+                                  | None, Some p ->
+                                      Printf.sprintf
+                                        "No warning matching message pattern `%s` found. Available warning kinds: [%s]"
+                                        p kinds
+                                  | None, None ->
+                                      Printf.sprintf
+                                        "No matching warning found on node. Available warning kinds: [%s]"
+                                        kinds
+                                in
+                                VExpect (Expect_stop msg))
+                    | _ ->
                         Error.type_error
                           (Printf.sprintf
                              "Function `expect_warning` expects a NodeResult or ComputedNode, got %s."
-                             (Utils.type_name v))
-                      else
-                        (match get_warnings v with
-                         | None ->
-                             VExpect (Expect_stop "No warnings found on this node")
-                         | Some warnings ->
-                             let matches =
-                               match kind_opt, re_opt with
-                               | Some kind, Some re ->
-                                   List.exists (fun w ->
-                                     w.nw_kind = kind &&
-                                     (try ignore (Str.search_forward re w.nw_message 0); true
-                                      with Not_found -> false)
-                                   ) warnings
-                               | Some kind, None ->
-                                   List.exists (fun w -> w.nw_kind = kind) warnings
-                               | None, Some re ->
-                                   List.exists (fun w ->
-                                     try ignore (Str.search_forward re w.nw_message 0); true
-                                     with Not_found -> false
-                                   ) warnings
-                               | None, None -> true
-                             in
-                             if matches then VExpect Expect_pass
-                             else
-                               let kinds = warnings
-                                             |> List.map (fun w -> w.nw_kind)
-                                             |> List.sort_uniq String.compare
-                                             |> String.concat ", "
-                               in
-                               let msg =
-                                 match kind_opt, message_opt with
-                                 | Some k, Some p ->
-                                     Printf.sprintf
-                                       "No warning of kind `%s` matching message pattern `%s` found. Available warning kinds: [%s]"
-                                       k p kinds
-                                 | Some k, None ->
-                                     Printf.sprintf
-                                       "No warning of kind `%s` found. Available warning kinds: [%s]"
-                                       k kinds
-                                 | None, Some p ->
-                                     Printf.sprintf
-                                       "No warning matching message pattern `%s` found. Available warning kinds: [%s]"
-                                       p kinds
-                                 | None, None ->
-                                     Printf.sprintf
-                                       "No matching warning found on node. Available warning kinds: [%s]"
-                                       kinds
-                               in
-                                VExpect (Expect_stop msg)))
+                             (Utils.type_name v)))
              | args -> Error.arity_error_named "expect_warning" 1 (List.length args)))
       env
   in

--- a/src/packages/testcraft/t_expect_condition.ml
+++ b/src/packages/testcraft/t_expect_condition.ml
@@ -5,6 +5,10 @@ let warnings_from_result = function
   | VNodeResult { diagnostics = { nd_warnings; _ }; _ } -> Some nd_warnings
   | _ -> None
 
+let regex_matches re s =
+  try ignore (Str.search_forward re s 0); true
+  with Not_found -> false
+
 let get_warnings v = match v with
   | VComputedNode cn ->
       let cn = !Ast.computed_node_resolver cn in
@@ -80,11 +84,11 @@ let register env =
              let re =
                match message_opt with
                | Some pat ->
-                   (try Ok (Some (Str.regexp pat))
-                    with Failure _ ->
-                      Error (Error.value_error
-                               (Printf.sprintf
-                                  "Function `expect_warning` received invalid regex pattern: `%s`." pat)))
+                    (try Ok (Some (Str.regexp pat))
+                     with Failure msg ->
+                       Error (Error.value_error
+                                (Printf.sprintf
+                                   "Invalid regex pattern `%s`: %s" pat msg)))
                | None -> Ok None
              in
              let positional =
@@ -105,64 +109,60 @@ let register env =
              | Ok re_opt ->
              match positional with
              | [v] ->
-                 (match v with
-                  | VNA _ -> VExpect (Expect_hold "`node` is NA, cannot check for warnings")
-                  | VError err ->
-                      VExpect (Expect_stop (Printf.sprintf "`node` is an error: %s" err.message))
-                    | VNodeResult _ | VComputedNode _ ->
-                          (match get_warnings v with
-                          | None ->
-                              VExpect (Expect_stop "No warnings found on this node")
-                          | Some warnings ->
-                              let matches =
-                                match kind_opt, re_opt with
-                                | Some kind, Some re ->
-                                    List.exists (fun w ->
-                                      w.nw_kind = kind &&
-                                      (try ignore (Str.search_forward re w.nw_message 0); true
-                                       with Not_found -> false)
-                                    ) warnings
-                                | Some kind, None ->
-                                    List.exists (fun w -> w.nw_kind = kind) warnings
-                                | None, Some re ->
-                                    List.exists (fun w ->
-                                      try ignore (Str.search_forward re w.nw_message 0); true
-                                      with Not_found -> false
-                                    ) warnings
-                                | None, None -> true
+                  (match v with
+                   | VNA _ -> VExpect (Expect_hold "`node` is NA, cannot check for warnings")
+                   | VError err ->
+                       VExpect (Expect_stop (Printf.sprintf "`node` is an error: %s" err.message))
+                   | VNodeResult _ | VComputedNode _ ->
+                       (match get_warnings v with
+                        | None -> VExpect (Expect_stop "No warnings found on this node")
+                        | Some warnings ->
+                            let matches =
+                              match kind_opt, re_opt with
+                              | Some kind, Some re ->
+                                  List.exists (fun w ->
+                                    w.nw_kind = kind
+                                    && regex_matches re w.nw_message
+                                  ) warnings
+                              | Some kind, None ->
+                                  List.exists (fun w -> w.nw_kind = kind) warnings
+                              | None, Some re ->
+                                  List.exists (fun w -> regex_matches re w.nw_message) warnings
+                              | None, None -> true
+                            in
+                            if matches then VExpect Expect_pass
+                            else
+                              let kinds =
+                                warnings
+                                |> List.map (fun w -> w.nw_kind)
+                                |> List.sort_uniq String.compare
+                                |> String.concat ", "
                               in
-                              if matches then VExpect Expect_pass
-                              else
-                                let kinds = warnings
-                                              |> List.map (fun w -> w.nw_kind)
-                                              |> List.sort_uniq String.compare
-                                              |> String.concat ", "
-                                in
-                                let msg =
-                                  match kind_opt, message_opt with
-                                  | Some k, Some p ->
-                                      Printf.sprintf
-                                        "No warning of kind `%s` matching message pattern `%s` found. Available warning kinds: [%s]"
-                                        k p kinds
-                                  | Some k, None ->
-                                      Printf.sprintf
-                                        "No warning of kind `%s` found. Available warning kinds: [%s]"
-                                        k kinds
-                                  | None, Some p ->
-                                      Printf.sprintf
-                                        "No warning matching message pattern `%s` found. Available warning kinds: [%s]"
-                                        p kinds
-                                  | None, None ->
-                                      Printf.sprintf
-                                        "No matching warning found on node. Available warning kinds: [%s]"
-                                        kinds
-                                in
-                                VExpect (Expect_stop msg))
-                    | _ ->
-                        Error.type_error
-                          (Printf.sprintf
-                             "Function `expect_warning` expects a NodeResult or ComputedNode, got %s."
-                             (Utils.type_name v)))
+                              let msg =
+                                match kind_opt, message_opt with
+                                | Some k, Some p ->
+                                    Printf.sprintf
+                                      "No warning of kind `%s` matching message pattern `%s` found. Available warning kinds: [%s]"
+                                      k p kinds
+                                | Some k, None ->
+                                    Printf.sprintf
+                                      "No warning of kind `%s` found. Available warning kinds: [%s]"
+                                      k kinds
+                                | None, Some p ->
+                                    Printf.sprintf
+                                      "No warning matching message pattern `%s` found. Available warning kinds: [%s]"
+                                      p kinds
+                                | None, None ->
+                                    Printf.sprintf
+                                      "No matching warning found on node. Available warning kinds: [%s]"
+                                      kinds
+                              in
+                              VExpect (Expect_stop msg))
+                   | _ ->
+                       Error.type_error
+                         (Printf.sprintf
+                            "Function `expect_warning` expects a NodeResult or ComputedNode, got %s."
+                            (Utils.type_name v)))
              | args -> Error.arity_error_named "expect_warning" 1 (List.length args)))
       env
   in

--- a/src/packages/testcraft/t_expect_condition.ml
+++ b/src/packages/testcraft/t_expect_condition.ml
@@ -1,6 +1,8 @@
 open Ast
 
-let fmt v = "`" ^ Utils.value_to_string v ^ "`"
+let is_node = function
+  | VNodeResult _ | VComputedNode _ -> true
+  | _ -> false
 
 let get_warnings = function
   | VNodeResult { diagnostics = { nd_warnings = []; _ }; _ } -> None
@@ -38,11 +40,10 @@ let register env =
       (make_builtin_named ~name:"expect_warning" ~variadic:true ~unwrap:false 1 (fun named_args _env ->
          let unknown_named =
            List.filter
-             (fun (n, _) ->
-               match n with
-               | None -> false
-               | Some "kind" | Some "message" -> false
-               | Some _ -> true)
+             (function
+               | (None, _) -> false
+               | (Some "kind", _) | (Some "message", _) -> false
+               | (Some _, _) -> true)
              named_args
          in
          match unknown_named with
@@ -50,42 +51,49 @@ let register env =
              Error.type_error
                (Printf.sprintf "Function `expect_warning` received unknown named argument `%s`." arg_name)
          | _ ->
-             let kind_opt =
-               match List.find_opt (fun (n, _) -> n = Some "kind") named_args with
-                | Some (_, VString k) when k <> "" -> Some k
-                | Some (_, _) ->
-                    Some ""
-                    (* type error deferred: let positional check happen first *)
-                | _ -> None
-              in
-              let kind_err =
-               match List.find_opt (fun (n, _) -> n = Some "kind") named_args with
+             let kind_arg = List.find_opt (fun (n, _) -> n = Some "kind") named_args in
+             let message_arg = List.find_opt (fun (n, _) -> n = Some "message") named_args in
+             let kind_err =
+               match kind_arg with
                | Some (_, v) when (match v with VString _ -> false | _ -> true) ->
                    Some (Printf.sprintf
                             "Function `expect_warning` expects the `kind` argument to be a String, got %s."
                             (Utils.type_name v))
                | _ -> None
              in
-             let message_opt =
-               match List.find_opt (fun (n, _) -> n = Some "message") named_args with
-               | Some (_, VString m) when m <> "" -> Some m
+             let kind_opt =
+               match kind_arg with
+               | Some (_, VString k) when k <> "" -> Some k
                | _ -> None
              in
              let message_err =
-               match List.find_opt (fun (n, _) -> n = Some "message") named_args with
+               match message_arg with
                | Some (_, v) when (match v with VString _ -> false | _ -> true) ->
                    Some (Printf.sprintf
                             "Function `expect_warning` expects the `message` argument to be a String, got %s."
                             (Utils.type_name v))
                | _ -> None
              in
-             let excluded = [ "kind"; "message" ] in
+             let message_opt =
+               match message_arg with
+               | Some (_, VString m) when m <> "" -> Some m
+               | _ -> None
+             in
+             let re =
+               match message_opt with
+               | Some pat ->
+                   (try Ok (Some (Str.regexp pat))
+                    with Failure _ ->
+                      Error (Error.value_error
+                               (Printf.sprintf
+                                  "Function `expect_warning` received invalid regex pattern: `%s`." pat)))
+               | None -> Ok None
+             in
              let positional =
                named_args
-               |> List.filter (fun (n, _) ->
-                    match n with
-                    | Some n -> not (List.mem n excluded)
-                    | None -> true)
+               |> List.filter (function
+                    | (Some "kind", _) | (Some "message", _) -> false
+                    | _ -> true)
                |> List.map snd
              in
              match kind_err with
@@ -94,6 +102,9 @@ let register env =
              match message_err with
              | Some err -> Error.type_error err
              | None ->
+             match re with
+             | Error err -> err
+             | Ok re_opt ->
              match positional with
              | [v] ->
                  (match v with
@@ -101,37 +112,60 @@ let register env =
                   | VError err ->
                       VExpect (Expect_stop (Printf.sprintf "`node` is an error: %s" err.message))
                   | _ ->
-                      (match get_warnings v with
-                       | None ->
-                           VExpect (Expect_stop "No warnings found on this node")
-                       | Some warnings ->
-                           let matches =
-                             match kind_opt, message_opt with
-                              | Some kind, Some pat ->
-                                  List.exists (fun w ->
-                                    w.nw_kind = kind &&
-                                    (try ignore (Str.search_forward (Str.regexp pat) w.nw_message 0); true
-                                     with _ -> false)
-                                  ) warnings
-                              | Some kind, None ->
-                                  List.exists (fun w -> w.nw_kind = kind) warnings
-                              | None, Some pat ->
-                                  List.exists (fun w ->
-                                    try ignore (Str.search_forward (Str.regexp pat) w.nw_message 0); true
-                                    with _ -> false
-                                  ) warnings
-                             | None, None -> true
-                           in
-                           if matches then VExpect Expect_pass
-                           else
-                             let kinds = warnings
-                                           |> List.map (fun w -> w.nw_kind)
-                                           |> List.sort_uniq String.compare
-                                           |> String.concat ", "
+                      if not (is_node v) then
+                        Error.type_error
+                          (Printf.sprintf
+                             "Function `expect_warning` expects a NodeResult or ComputedNode, got %s."
+                             (Utils.type_name v))
+                      else
+                        (match get_warnings v with
+                         | None ->
+                             VExpect (Expect_stop "No warnings found on this node")
+                         | Some warnings ->
+                             let matches =
+                               match kind_opt, re_opt with
+                               | Some kind, Some re ->
+                                   List.exists (fun w ->
+                                     w.nw_kind = kind &&
+                                     (try ignore (Str.search_forward re w.nw_message 0); true
+                                      with Not_found -> false)
+                                   ) warnings
+                               | Some kind, None ->
+                                   List.exists (fun w -> w.nw_kind = kind) warnings
+                               | None, Some re ->
+                                   List.exists (fun w ->
+                                     try ignore (Str.search_forward re w.nw_message 0); true
+                                     with Not_found -> false
+                                   ) warnings
+                               | None, None -> true
                              in
-                             VExpect (Expect_stop
-                                        (Printf.sprintf
-                                           "No matching warning found on node. Available warning kinds: [%s]" kinds))))
+                             if matches then VExpect Expect_pass
+                             else
+                               let kinds = warnings
+                                             |> List.map (fun w -> w.nw_kind)
+                                             |> List.sort_uniq String.compare
+                                             |> String.concat ", "
+                               in
+                               let msg =
+                                 match kind_opt, message_opt with
+                                 | Some k, Some p ->
+                                     Printf.sprintf
+                                       "No warning of kind `%s` matching message pattern `%s` found. Available warning kinds: [%s]"
+                                       k p kinds
+                                 | Some k, None ->
+                                     Printf.sprintf
+                                       "No warning of kind `%s` found. Available warning kinds: [%s]"
+                                       k kinds
+                                 | None, Some p ->
+                                     Printf.sprintf
+                                       "No warning matching message pattern `%s` found. Available warning kinds: [%s]"
+                                       p kinds
+                                 | None, None ->
+                                     Printf.sprintf
+                                       "No matching warning found on node. Available warning kinds: [%s]"
+                                       kinds
+                               in
+                                VExpect (Expect_stop msg)))
              | args -> Error.arity_error_named "expect_warning" 1 (List.length args)))
       env
   in

--- a/summary.md
+++ b/summary.md
@@ -530,6 +530,7 @@ Purpose: unit-testing primitives, inspired by R's `testthat`. `expect_*` compari
 - Length: `expect_length(x, n)` — checks length of Vector, List, String, DataFrame, Dict.
 - Data frames: `expect_nrow(df, n)`, `expect_ncol(df, n)`, `expect_colnames(df, names)` — row/column/count/names checks.
 - Collections: `expect_fields(x, names)` — Dict keys or List labels; `expect_in(x, values)` — set membership.
+- Pipeline node diagnostics: `expect_warning(node, kind = "", message = "")` — passes if node produced a warning, optionally filtering by warning kind string or message regex.
 - Standard usage: `assert(expect_equal(a, b))` — passes silently on `Expect_pass`, raises `AssertionError` with the comparison's own diagnostic message otherwise.
 
 Disambiguation rule of thumb for LLMs:

--- a/tests/base/test_expect_condition.ml
+++ b/tests/base/test_expect_condition.ml
@@ -27,48 +27,97 @@ let make_node_without_warnings () =
     diagnostics = Ast.Utils.empty_node_diagnostics;
   }
 
-let run_tests _pass_count _fail_count _failures _eval_string _eval_string_env _test =
+let run_tests pass_count fail_count failures _eval_string eval_string_env test =
   Printf.printf "Testcraft — condition:\n";
   let env = Packages.init_env () in
   let call name args = match Env.find_opt name env with
     | Some (VBuiltin { b_func; _ }) -> b_func args (ref env)
     | _ -> VError { code = NameError; message = "not found"; context = []; location = None; na_count = 0 }
   in
+  let assert_result name result_str expected =
+    let match_found =
+      if result_str = expected then true
+      else try
+        let _ = Str.search_forward (Str.regexp expected) result_str 0 in
+        true
+      with Not_found | Failure _ -> false
+    in
+    if match_found then begin
+      incr pass_count;
+      Printf.printf "  ✓ %s\n" name
+    end else begin
+      incr fail_count;
+      let msg = Printf.sprintf "  ✗ %s\n    Expected (regex): %s\n    Got:               %s\n" name expected result_str in
+      failures := msg :: !failures;
+      Printf.printf "%s" msg
+    end
+  in
   let assert_pass name result =
-    match result with
-    | VExpect Expect_pass ->
-        Printf.printf "  ✓ %s\n" name
-    | VExpect (Expect_stop msg) ->
-        Printf.printf "  ✗ %s: STOP(%s)\n" name msg
-    | VExpect (Expect_hold msg) ->
-        Printf.printf "  ✗ %s: HOLD(%s)\n" name msg
-    | other ->
-        Printf.printf "  ✗ %s: unexpected %s\n" name (Utils.value_to_string other)
+    assert_result name (Ast.Utils.value_to_string result) "PASS"
   in
   let assert_stop name ?contains result =
-    match result with
-    | VExpect (Expect_stop msg) ->
-        let ok = match contains with
-          | Some pat -> (try ignore (Str.search_forward (Str.regexp pat) msg 0); true
-                         with Not_found -> false)
-          | None -> true
+    let result_str = Ast.Utils.value_to_string result in
+    match contains with
+    | Some pat ->
+        let inner = match result with
+          | VExpect (Expect_stop msg) -> msg
+          | _ -> ""
         in
-        if ok then Printf.printf "  ✓ %s\n" name
-        else Printf.printf "  ✗ %s: STOP message did not contain expected pattern.\n    Got: %s\n" name msg
-    | VExpect (Expect_hold msg) ->
-        Printf.printf "  ✗ %s: expected STOP, got HOLD(%s)\n" name msg
-    | other ->
-        Printf.printf "  ✗ %s: expected STOP, got %s\n" name (Utils.value_to_string other)
+        let ok = try ignore (Str.search_forward (Str.regexp pat) inner 0); true
+                 with Not_found | Failure _ -> false
+        in
+        if ok then begin
+          incr pass_count;
+          Printf.printf "  ✓ %s\n" name
+        end else begin
+          incr fail_count;
+          let msg = Printf.sprintf "  ✗ %s\n    Expected STOP containing: %s\n    Got: %s\n" name pat result_str in
+          failures := msg :: !failures;
+          Printf.printf "%s" msg
+        end
+    | None -> assert_result name result_str "STOP("
   in
   let assert_hold name result =
-    match result with
-    | VExpect (Expect_hold _) ->
-        Printf.printf "  ✓ %s\n" name
-    | VExpect (Expect_stop msg) ->
-        Printf.printf "  ✗ %s: expected HOLD, got STOP(%s)\n" name msg
-    | other ->
-        Printf.printf "  ✗ %s: expected HOLD, got %s\n" name (Utils.value_to_string other)
+    assert_result name (Ast.Utils.value_to_string result) "HOLD("
   in
+  let assert_error name ?contains result =
+    let result_str = Ast.Utils.value_to_string result in
+    match contains with
+    | Some pat ->
+        let inner = match result with
+          | VError err -> err.message
+          | VExpect (Expect_stop msg) -> msg
+          | _ -> ""
+        in
+        let ok = try ignore (Str.search_forward (Str.regexp pat) inner 0); true
+                 with Not_found | Failure _ -> false
+        in
+        if ok then begin
+          incr pass_count;
+          Printf.printf "  ✓ %s\n" name
+        end else begin
+          incr fail_count;
+          let msg = Printf.sprintf "  ✗ %s\n    Expected VError containing: %s\n    Got: %s\n" name pat result_str in
+          failures := msg :: !failures;
+          Printf.printf "%s" msg
+        end
+    | None -> assert_result name result_str "Error("
+  in
+
+  (* T-level tests through the evaluator (validates ~unwrap:false integration) *)
+  test "expect_warning NA holds" "expect_warning(NA)" "HOLD(";
+  test "expect_warning Error stops" "expect_warning(error(\"boom\"))" "STOP(`node` is an error: boom";
+  test "expect_warning wrong type" "expect_warning(123)" "Error(TypeError:";
+
+  (* Integration test: ~unwrap:false via evaluator with custom helper *)
+  let integration_env = Env.add "make_test_warning_node"
+    (Ast.make_builtin ~name:"make_test_warning_node" ~unwrap:false 0
+       (fun _ _ -> make_warning_node ()))
+    (Packages.init_env ())
+  in
+  let integ_result = fst (eval_string_env
+    "expect_warning(make_test_warning_node())" integration_env) in
+  assert_pass "expect_warning via evaluator" integ_result;
 
   (* Basic pass: node with a warning *)
   assert_pass "expect_warning pass"
@@ -189,20 +238,6 @@ let run_tests _pass_count _fail_count _failures _eval_string _eval_string_env _t
     (call "expect_warning" [(None, VComputedNode unresolved_cn)]);
 
   (* Error cases *)
-  let assert_error name ?contains result =
-    match result with
-    | VError err ->
-        let ok = match contains with
-          | Some pat -> (try ignore (Str.search_forward (Str.regexp pat) err.message 0); true
-                         with Not_found -> false)
-          | None -> true
-        in
-        if ok then Printf.printf "  ✓ %s\n" name
-        else Printf.printf "  ✗ %s: VError message did not contain expected pattern.\n    Got: %s\n" name err.message
-    | other ->
-        Printf.printf "  ✗ %s: expected VError, got %s\n" name (Utils.value_to_string other)
-  in
-
   assert_error "expect_warning invalid regex" ~contains:"Invalid regex pattern"
     (call "expect_warning" [(Some "message", VString "["); (None, make_warning_node ())]);
 

--- a/tests/base/test_expect_condition.ml
+++ b/tests/base/test_expect_condition.ml
@@ -161,4 +161,34 @@ let run_tests _pass_count _fail_count _failures _eval_string _eval_string_env _t
   assert_pass "expect_warning upstream"
     (call "expect_warning" [(None, upstream_warn_node)]);
 
+  (* Error cases *)
+  let assert_error name ?contains result =
+    match result with
+    | VError err ->
+        let ok = match contains with
+          | Some pat -> (try ignore (Str.search_forward (Str.regexp pat) err.message 0); true
+                         with Not_found -> false)
+          | None -> true
+        in
+        if ok then Printf.printf "  ✓ %s\n" name
+        else Printf.printf "  ✗ %s: VError message did not contain expected pattern.\n    Got: %s\n" name err.message
+    | other ->
+        Printf.printf "  ✗ %s: expected VError, got %s\n" name (Utils.value_to_string other)
+  in
+
+  assert_error "expect_warning invalid regex"
+    (call "expect_warning" [(Some "message", VString "["); (None, make_warning_node ())]);
+
+  assert_error "expect_warning unknown named arg"
+    (call "expect_warning" [(Some "foo", VInt 1); (None, make_warning_node ())]);
+
+  assert_error "expect_warning kind wrong type"
+    (call "expect_warning" [(Some "kind", VInt 1); (None, make_warning_node ())]);
+
+  assert_error "expect_warning message wrong type"
+    (call "expect_warning" [(Some "message", VInt 1); (None, make_warning_node ())]);
+
+  assert_error "expect_warning wrong positional type"
+    (call "expect_warning" [(None, VInt 123)]);
+
   Printf.printf "\n"

--- a/tests/base/test_expect_condition.ml
+++ b/tests/base/test_expect_condition.ml
@@ -161,6 +161,33 @@ let run_tests _pass_count _fail_count _failures _eval_string _eval_string_env _t
   assert_pass "expect_warning upstream"
     (call "expect_warning" [(None, upstream_warn_node)]);
 
+  (* Empty string filters treated as omitted *)
+  assert_pass "expect_warning empty kind works"
+    (call "expect_warning" [(Some "kind", VString ""); (None, make_warning_node ())]);
+
+  assert_pass "expect_warning empty message works"
+    (call "expect_warning" [(Some "message", VString ""); (None, make_warning_node ())]);
+
+  (* Computed node: resolved with warning *)
+  let cn_record = {
+    Ast.cn_name = "test_cn";
+    cn_runtime = "T";
+    cn_path = "";
+    cn_serializer = "csv";
+    cn_class = "";
+    cn_dependencies = [];
+    cn_p_exprs = None;
+    cn_flake = None;
+  } in
+  Ast.set_in_memory_node_value ~p_exprs:[] ~node_name:"test_cn" (make_warning_node ());
+  assert_pass "expect_warning computed node resolved"
+    (call "expect_warning" [(None, VComputedNode cn_record)]);
+
+  (* Computed node: unresolved *)
+  let unresolved_cn = { cn_record with cn_name = "unresolved_cn" } in
+  assert_stop "expect_warning computed node unresolved" ~contains:"has not been evaluated"
+    (call "expect_warning" [(None, VComputedNode unresolved_cn)]);
+
   (* Error cases *)
   let assert_error name ?contains result =
     match result with
@@ -188,7 +215,7 @@ let run_tests _pass_count _fail_count _failures _eval_string _eval_string_env _t
   assert_error "expect_warning message wrong type"
     (call "expect_warning" [(Some "message", VInt 1); (None, make_warning_node ())]);
 
-  assert_error "expect_warning wrong positional type" ~contains:"NodeResult"
+  assert_error "expect_warning wrong positional type" ~contains:"expects a NodeResult"
     (call "expect_warning" [(None, VInt 123)]);
 
   Printf.printf "\n"

--- a/tests/base/test_expect_condition.ml
+++ b/tests/base/test_expect_condition.ml
@@ -176,7 +176,7 @@ let run_tests _pass_count _fail_count _failures _eval_string _eval_string_env _t
         Printf.printf "  ✗ %s: expected VError, got %s\n" name (Utils.value_to_string other)
   in
 
-  assert_error "expect_warning invalid regex"
+  assert_error "expect_warning invalid regex" ~contains:"Invalid regex pattern"
     (call "expect_warning" [(Some "message", VString "["); (None, make_warning_node ())]);
 
   assert_error "expect_warning unknown named arg"
@@ -188,7 +188,7 @@ let run_tests _pass_count _fail_count _failures _eval_string _eval_string_env _t
   assert_error "expect_warning message wrong type"
     (call "expect_warning" [(Some "message", VInt 1); (None, make_warning_node ())]);
 
-  assert_error "expect_warning wrong positional type"
+  assert_error "expect_warning wrong positional type" ~contains:"NodeResult"
     (call "expect_warning" [(None, VInt 123)]);
 
   Printf.printf "\n"

--- a/tests/base/test_expect_condition.ml
+++ b/tests/base/test_expect_condition.ml
@@ -1,0 +1,164 @@
+open Ast
+
+let make_warning_node ?(kind = "NAExcluded") ?(message = "filter() excluded 1 row") () =
+  VNodeResult {
+    v = VInt 42;
+    node_name = "test";
+    diagnostics = {
+      nd_warnings = [{
+        nw_kind = kind;
+        nw_fn = "filter";
+        nw_na_count = 1;
+        nw_na_indices = [0];
+        nw_message = message;
+        nw_source = WarningOwn;
+      }];
+      nd_error = None;
+      nd_warnings_suppressed = false;
+      nd_recovered = false;
+      nd_upstream_errors = [];
+    };
+  }
+
+let make_node_without_warnings () =
+  VNodeResult {
+    v = VInt 42;
+    node_name = "test";
+    diagnostics = Ast.Utils.empty_node_diagnostics;
+  }
+
+let run_tests _pass_count _fail_count _failures _eval_string _eval_string_env _test =
+  Printf.printf "Testcraft — condition:\n";
+  let env = Packages.init_env () in
+  let call name args = match Env.find_opt name env with
+    | Some (VBuiltin { b_func; _ }) -> b_func args (ref env)
+    | _ -> VError { code = NameError; message = "not found"; context = []; location = None; na_count = 0 }
+  in
+  let assert_pass name result =
+    match result with
+    | VExpect Expect_pass ->
+        Printf.printf "  ✓ %s\n" name
+    | VExpect (Expect_stop msg) ->
+        Printf.printf "  ✗ %s: STOP(%s)\n" name msg
+    | VExpect (Expect_hold msg) ->
+        Printf.printf "  ✗ %s: HOLD(%s)\n" name msg
+    | other ->
+        Printf.printf "  ✗ %s: unexpected %s\n" name (Utils.value_to_string other)
+  in
+  let assert_stop name ?contains result =
+    match result with
+    | VExpect (Expect_stop msg) ->
+        let ok = match contains with
+          | Some pat -> (try ignore (Str.search_forward (Str.regexp pat) msg 0); true
+                         with Not_found -> false)
+          | None -> true
+        in
+        if ok then Printf.printf "  ✓ %s\n" name
+        else Printf.printf "  ✗ %s: STOP message did not contain expected pattern.\n    Got: %s\n" name msg
+    | VExpect (Expect_hold msg) ->
+        Printf.printf "  ✗ %s: expected STOP, got HOLD(%s)\n" name msg
+    | other ->
+        Printf.printf "  ✗ %s: expected STOP, got %s\n" name (Utils.value_to_string other)
+  in
+  let assert_hold name result =
+    match result with
+    | VExpect (Expect_hold _) ->
+        Printf.printf "  ✓ %s\n" name
+    | VExpect (Expect_stop msg) ->
+        Printf.printf "  ✗ %s: expected HOLD, got STOP(%s)\n" name msg
+    | other ->
+        Printf.printf "  ✗ %s: expected HOLD, got %s\n" name (Utils.value_to_string other)
+  in
+
+  (* Basic pass: node with a warning *)
+  assert_pass "expect_warning pass"
+    (call "expect_warning" [(None, make_warning_node ())]);
+
+  (* Stop: node with no warnings *)
+  assert_stop "expect_warning no warnings"
+    (call "expect_warning" [(None, make_node_without_warnings ())]);
+
+  (* Kind matching *)
+  assert_pass "expect_warning kind match"
+    (call "expect_warning" [(Some "kind", VString "NAExcluded"); (None, make_warning_node ())]);
+
+  assert_stop "expect_warning kind mismatch"
+    (call "expect_warning" [(Some "kind", VString "WrongKind"); (None, make_warning_node ())]);
+
+  (* Message regex matching *)
+  assert_pass "expect_warning message match"
+    (call "expect_warning" [(Some "message", VString "excluded"); (None, make_warning_node ())]);
+
+  assert_stop "expect_warning message no match"
+    (call "expect_warning" [(Some "message", VString "nonexistent"); (None, make_warning_node ())]);
+
+  (* Kind + message combined *)
+  assert_pass "expect_warning kind+message match"
+    (call "expect_warning"
+       [(Some "kind", VString "NAExcluded");
+        (Some "message", VString "excluded");
+        (None, make_warning_node ())]);
+
+  assert_stop "expect_warning kind+message mismatch"
+    (call "expect_warning"
+       [(Some "kind", VString "NAExcluded");
+        (Some "message", VString "nonexistent");
+        (None, make_warning_node ())]);
+
+  (* NA handling *)
+  assert_hold "expect_warning NA"
+    (call "expect_warning" [(None, VNA NAGeneric)]);
+
+  (* Error handling *)
+  assert_stop "expect_warning Error" ~contains:"error"
+    (call "expect_warning" [(None, Error.make_error GenericError "boom")]);
+
+  (* Multiple warnings: should match any *)
+  let multi_warn_node = VNodeResult {
+    v = VInt 42;
+    node_name = "multi";
+    diagnostics = {
+      nd_warnings = [
+        { nw_kind = "KindA"; nw_fn = "fn1"; nw_na_count = 0; nw_na_indices = [];
+          nw_message = "first warning"; nw_source = WarningOwn };
+        { nw_kind = "KindB"; nw_fn = "fn2"; nw_na_count = 1; nw_na_indices = [0];
+          nw_message = "second warning"; nw_source = WarningOwn };
+      ];
+      nd_error = None;
+      nd_warnings_suppressed = false;
+      nd_recovered = false;
+      nd_upstream_errors = [];
+    };
+  } in
+  assert_pass "expect_warning multi match kindA"
+    (call "expect_warning" [(Some "kind", VString "KindA"); (None, multi_warn_node)]);
+  assert_pass "expect_warning multi match kindB"
+    (call "expect_warning" [(Some "kind", VString "KindB"); (None, multi_warn_node)]);
+  assert_pass "expect_warning multi match message"
+    (call "expect_warning" [(Some "message", VString "second"); (None, multi_warn_node)]);
+  assert_stop "expect_warning multi no match"
+    (call "expect_warning" [(Some "kind", VString "KindC"); (None, multi_warn_node)]);
+
+  (* Upstream warnings *)
+  let upstream_warn_node = VNodeResult {
+    v = VInt 42;
+    node_name = "upstream";
+    diagnostics = {
+      nd_warnings = [{
+        nw_kind = "NAExcluded";
+        nw_fn = "filter";
+        nw_na_count = 1;
+        nw_na_indices = [0];
+        nw_message = "filter() excluded 1 row";
+        nw_source = WarningUpstream "ancestor_node";
+      }];
+      nd_error = None;
+      nd_warnings_suppressed = false;
+      nd_recovered = false;
+      nd_upstream_errors = [];
+    };
+  } in
+  assert_pass "expect_warning upstream"
+    (call "expect_warning" [(None, upstream_warn_node)]);
+
+  Printf.printf "\n"

--- a/tests/dune
+++ b/tests/dune
@@ -49,7 +49,7 @@
     test_misc_coverage
     test_dataframe_diff test_model_diff test_scalar_diff test_generic_diff test_pipeline_diff test_builder_diff
     test_check test_fix test_ndjson
-    test_expect_equal test_expect_more
+    test_expect_equal test_expect_more test_expect_condition
   )
   (libraries t_lang menhirLib otoml unix str)
 )

--- a/tests/test_runner.ml
+++ b/tests/test_runner.ml
@@ -88,6 +88,7 @@ let () =
   Test_errors.run_tests pass_count fail_count failures eval_string eval_string_env test;
   Test_expect_equal.run_tests pass_count fail_count failures eval_string eval_string_env test;
   Test_expect_more.run_tests pass_count fail_count failures eval_string eval_string_env test;
+  Test_expect_condition.run_tests pass_count fail_count failures eval_string eval_string_env test;
   Test_fetchurl.run_tests pass_count fail_count failures eval_string eval_string_env test;
 
   (* Domain-specific tests *)


### PR DESCRIPTION
Adds expect_warning(node, kind = "", message = "") to check for warnings on pipeline node results. Supports exact kind matching and regex message matching via Str.search_forward. All 15 tests pass.

- t_expect_condition.ml: expect_warning with ~unwrap:false to preserve VNodeResult
- test_expect_condition.ml: OCaml-level tests constructing VNodeResult directly
- Updates docs, summary, dune, test_runner