### PR TITLE
feat: implement agentic test features for T

### DIFF
--- a/agents/skill-t-project.md
+++ b/agents/skill-t-project.md
@@ -415,5 +415,6 @@ When modifying a pipeline:
 - `t check --schema src/pipeline.t` passes with no errors or warnings.
 - `t run src/pipeline.t` (or the project's entry pipeline) completes without an unhandled `Error`.
 - `t diff src/pipeline.t` shows only the nodes you intended to change (no unexpected cascades).
+- If you modified test files or test-related code, run `t test --json` and verify `"status": "passed"`.
 - If you touched `tproject.toml`, you ran `t update` afterward.
 - If the project already uses `intent { ... }` blocks, continue that convention when making analytical decisions.

--- a/docs/agent-pairing-tutorial.md
+++ b/docs/agent-pairing-tutorial.md
@@ -443,6 +443,75 @@ The `root_causes` field tells the agent which node is the actual source of the f
 
 ---
 
+## Programmatic test results with `t test --json`
+
+When an agent needs to verify that its changes don't break existing tests, it can
+use `t test --json` to get structured test results. This is essential for agent
+workflows where test results must be consumed programmatically.
+
+```bash
+$ t test --json tests/
+```
+
+The output is a JSON object with the test suite summary:
+
+```json
+{
+  "schema_version": "1",
+  "status": "passed",
+  "total": 15,
+  "passed": 14,
+  "failed": 1,
+  "duration_ms": 2340,
+  "results": [
+    {
+      "file": "tests/test_arithmetic.t",
+      "status": "passed",
+      "duration_ms": 120,
+      "error": null
+    },
+    {
+      "file": "tests/test_strings.t",
+      "status": "failed",
+      "duration_ms": 85,
+      "error": "Assertion failed at line 42: expected \"hello\" but got \"world\""
+    }
+  ]
+}
+```
+
+**Agent workflow for test-driven iteration:**
+
+1. Agent modifies code
+2. Agent runs `t test --json tests/`
+3. Agent parses JSON to check `status` field
+4. If `status` is `"failed"`, agent reads `error` field from failed results
+5. Agent fixes the issue and re-runs tests
+
+The JSON output follows the same schema version as `t check --json` and `t run --json`,
+making it easy to integrate with existing agent tooling.
+
+### REPL-callable version
+
+For agents working in the REPL, `t_test()` returns a DataFrame with the same results:
+
+```t
+results = t_test()
+-- DataFrame with columns: file, status, duration_ms, error
+
+-- Filter to show only failed tests
+failed = results |> filter($status == "failed")
+nrow(failed)  -- 0 if all tests passed
+```
+
+The DataFrame columns are:
+- `file`: Path to the test file
+- `status`: "passed" or "failed"
+- `duration_ms`: Duration in milliseconds
+- `error`: Error message (NA for passed tests)
+
+---
+
 ## Tips for effective pairing
 
 ### What to tell the agent

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3788,6 +3788,63 @@ $ t check --json pipeline.t | jq '.diagnostics[].suggested_fix'
 
 ---
 
+### `t_test()`
+
+REPL-callable version of `t test`. Runs the test suite and returns a DataFrame with structured results for programmatic inspection.
+
+**Returns:** `DataFrame` — columns: `file` (String), `status` ("passed" or "failed"), `duration_ms` (Float), `error` (String or NA)
+
+**Examples:**
+
+```t
+results = t_test()
+-- DataFrame with columns: file, status, duration_ms, error
+
+-- Filter to show only failed tests
+failed = results |> filter($status == "failed")
+nrow(failed)  -- 0 if all tests passed
+
+-- Count passed tests
+results |> filter($status == "passed") |> nrow()
+```
+
+---
+
+### CLI: `t test`
+
+Runs the test suite for the current project. Discovers test files (`test-*.t`, `test_*.t`, or `*_test.t`) recursively in the `tests/` directory.
+
+```bash
+t test                        # human-readable output
+t test --json                 # structured JSON output (no preamble)
+t test --json <dir>           # specify project directory
+```
+
+**JSON schema (when using `--json`):**
+
+```json
+{
+  "schema_version": "1",
+  "status": "passed|failed",
+  "total": N,
+  "passed": N,
+  "failed": N,
+  "duration_ms": N,
+  "results": [
+    {
+      "file": "tests/test_arithmetic.t",
+      "status": "passed",
+      "duration_ms": 120,
+      "error": null
+    }
+  ]
+}
+```
+
+The `--json` flag produces clean JSON output with no preamble, making it safe for piping to `jq` or parsing with agent tooling.
+
+---
+
 ## Explain Package
 
 Introspection and LLM tooling.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3794,6 +3794,8 @@ REPL-callable version of `t test`. Runs the test suite and returns a DataFrame w
 
 **Returns:** `DataFrame` — columns: `file` (String), `status` ("passed" or "failed"), `duration_ms` (Float), `error` (String or NA)
 
+Note: `duration_ms` is a Float in the REPL DataFrame, but an integer in CLI `--json` output. Both represent milliseconds.
+
 **Examples:**
 
 ```t
@@ -3817,7 +3819,7 @@ Runs the test suite for the current project. Discovers test files (`test-*.t`, `
 ```bash
 t test                        # human-readable output
 t test --json                 # structured JSON output (no preamble)
-t test --json <dir>           # specify project directory
+t test --json tests/          # specify project directory
 ```
 
 **JSON schema (when using `--json`):**
@@ -3841,7 +3843,9 @@ t test --json <dir>           # specify project directory
 }
 ```
 
-The `--json` flag produces clean JSON output with no preamble, making it safe for piping to `jq` or parsing with agent tooling.
+All fields except `error` are present in every result object. `duration_ms` is an integer (milliseconds, rounded). `error` is `null` for passed tests, or a string containing the error message for failed tests.
+
+The `--json` flag produces clean JSON output with no preamble, making it safe for piping to `jq` or parsing with agent tooling. Note: `--verbose` combined with `--json` is a no-op — verbose per-test error printing is suppressed when JSON mode is active.
 
 ---
 

--- a/docs/llm-collaboration.md
+++ b/docs/llm-collaboration.md
@@ -166,6 +166,68 @@ This is useful for verifying that a code change only affected the intended nodes
 
 ---
 
+## Programmatic Test Results: `t test --json`
+
+When agents modify code, they need to verify that existing tests still pass. T provides
+structured test output via `t test --json`:
+
+```bash
+t test --json tests/
+```
+
+This returns a JSON object with test results:
+
+```json
+{
+  "schema_version": "1",
+  "status": "passed",
+  "total": 15,
+  "passed": 14,
+  "failed": 1,
+  "duration_ms": 2340,
+  "results": [
+    {
+      "file": "tests/test_arithmetic.t",
+      "status": "passed",
+      "duration_ms": 120,
+      "error": null
+    },
+    {
+      "file": "tests/test_strings.t",
+      "status": "failed",
+      "duration_ms": 85,
+      "error": "Assertion failed at line 42: expected \"hello\" but got \"world\""
+    }
+  ]
+}
+```
+
+**Agent workflow:**
+
+1. Agent modifies code
+2. Agent runs `t test --json tests/`
+3. Agent parses JSON to check `status` field
+4. If `status` is `"failed"`, agent reads `error` field from failed results
+5. Agent fixes the issue and re-runs tests
+
+The JSON output follows the same schema version as `t check --json` and `t run --json`,
+enabling consistent tooling across all T commands.
+
+### REPL-callable version
+
+For agents working in the REPL, `t_test()` returns a DataFrame with the same results:
+
+```t
+results = t_test()
+-- DataFrame with columns: file, status, duration_ms, error
+
+-- Filter to show only failed tests
+failed = results |> filter($status == "failed")
+nrow(failed)  -- 0 if all tests passed
+```
+
+---
+
 ## Intent Blocks
 
 Intent blocks are **machine-readable metadata** that capture analytical goals.

--- a/docs/package_development.md
+++ b/docs/package_development.md
@@ -132,6 +132,16 @@ Run all tests with:
 
 ```bash
 $ t test
+
+# Structured JSON output for agents and automation:
+$ t test --json
+```
+
+In the REPL, `t_test()` returns a DataFrame with test results:
+
+```t
+results = t_test()
+results |> filter($status == "failed")
 ```
 
 ### Why Use `expect_*` Functions with `assert()`?

--- a/spec_files/skills/skill-t-project.md
+++ b/spec_files/skills/skill-t-project.md
@@ -53,6 +53,7 @@ Tabular outputs use Arrow by default (`serializer = ^arrow`). Do not serialize t
 5. **Nix env check:** `t doctor` catches environment drift (stale flake, missing Nix inputs) before you debug code.
 6. **Use `nix develop` first:** Always run `nix develop` (or `nix develop -c <command>`) to enter the T environment. Without it, `t`, R, Python, and Julia with tlang packages are not available.
 7. **Inspect from R/Python/Julia directly:** The companion packages (`tlang` in R, `tlang` in Python, `Tlang` in Julia) expose `read_node()`, `inspect_node()`, and `inspect_pipeline()`. It can be easier to explore node contents in R/Python/Julia than in the T REPL — especially for plotting, statistical summaries, or DataFrame manipulation.
+8. **Verify tests pass:** Run `t test --json` for structured output, or `t_test()` in the REPL for a DataFrame. Check `"status": "passed"` or filter `results |> filter($status == "failed")`.
 
 ## Development workflow: check, fix, build, diff
 

--- a/src/cli_args.ml
+++ b/src/cli_args.ml
@@ -4,6 +4,7 @@ type path_kind =
 
 type test_options = {
   verbose : bool;
+  json : bool;
   target_dir : string;
 }
 
@@ -123,15 +124,20 @@ let validate_cli_flags ~mode_flag ~unsafe_flag ~failfast_flag (args : string lis
     @return [Ok test_options] if successfully parsed, or [Error message] on unexpected arguments. *)
 let parse_test_args ~cwd (args : string list) : (test_options, string) result =
   let verbose = ref false in
+  let json = ref false in
   let target_dir = ref None in
   let rec parse = function
     | [] ->
         Ok {
           verbose = !verbose;
+          json = !json;
           target_dir = (match !target_dir with Some dir -> dir | None -> cwd);
         }
     | ("--verbose" | "-v") :: rest ->
         verbose := true;
+        parse rest
+    | "--json" :: rest ->
+        json := true;
         parse rest
     | arg :: _ when String.length arg > 0 && arg.[0] = '-' ->
         Error (Printf.sprintf "Unknown option: %s" arg)

--- a/src/package_manager/test_discovery.ml
+++ b/src/package_manager/test_discovery.ml
@@ -194,7 +194,7 @@ let test_result_to_yojson r =
   `Assoc [
     ("file", `String r.file);
     ("status", `String (if r.success then "passed" else "failed"));
-    ("duration_ms", `Int (int_of_float (r.duration *. 1000.0)));
+    ("duration_ms", `Int (Int.of_float (Float.round (r.duration *. 1000.0))));
     ("error", (match r.error_msg with Some e -> `String e | None -> `Null));
   ]
 
@@ -205,24 +205,24 @@ let suite_result_to_yojson r =
     ("total", `Int r.total);
     ("passed", `Int r.passed);
     ("failed", `Int r.failed);
-    ("duration_ms", `Int (int_of_float (r.total_duration *. 1000.0)));
+    ("duration_ms", `Int (Int.of_float (Float.round (r.total_duration *. 1000.0))));
     ("results", `List (List.map test_result_to_yojson r.results));
   ]
 
 (** Run a full test suite: discover + execute all tests *)
-let run_suite ?(verbose=false) (dir : string) : suite_result =
+let run_suite ?(verbose=false) ?(quiet=false) (dir : string) : suite_result =
   let test_dir = Filename.concat dir "tests" in
   if not (Sys.file_exists test_dir && Sys.is_directory test_dir) then begin
-    Printf.printf "No tests/ directory found.\n";
+    if not quiet then Printf.printf "No tests/ directory found.\n";
     { total = 0; passed = 0; failed = 0; results = []; total_duration = 0.0 }
   end else begin
     let files = discover_tests test_dir in
     if files = [] then begin
-      Printf.printf "No test files found (looking for test-*.t, test_*.t, or *_test.t).\n";
+      if not quiet then Printf.printf "No test files found (looking for test-*.t, test_*.t, or *_test.t).\n";
       { total = 0; passed = 0; failed = 0; results = []; total_duration = 0.0 }
     end else begin
       let start_total = Unix.gettimeofday () in
-      Printf.printf "Running %d test file%s...\n\n"
+      if not quiet then Printf.printf "Running %d test file%s...\n\n"
         (List.length files) (if List.length files > 1 then "s" else "");
       let results = List.map (fun file ->
         let r = run_test_file file in
@@ -231,14 +231,16 @@ let run_suite ?(verbose=false) (dir : string) : suite_result =
             String.sub file (String.length dir + 1) (String.length file - String.length dir - 1)
           else file
         in
-        if r.success then
-          Printf.printf "  ✓ %s (%s)\n" short_name (format_duration r.duration)
-        else begin
-          Printf.printf "  ✗ %s (%s)\n" short_name (format_duration r.duration);
-          if verbose then
-            match r.error_msg with
-            | Some msg -> Printf.printf "    → %s\n" msg
-            | None -> ()
+        if not quiet then begin
+          if r.success then
+            Printf.printf "  ✓ %s (%s)\n" short_name (format_duration r.duration)
+          else begin
+            Printf.printf "  ✗ %s (%s)\n" short_name (format_duration r.duration);
+            if verbose then
+              match r.error_msg with
+              | Some msg -> Printf.printf "    → %s\n" msg
+              | None -> ()
+          end
         end;
         r
       ) files in
@@ -246,24 +248,26 @@ let run_suite ?(verbose=false) (dir : string) : suite_result =
       let passed_results = List.filter (fun r -> r.success) results in
       let passed = List.length passed_results in
       let failed = List.length results - passed in
-      Printf.printf "\n";
-      if failed = 0 then
-        Printf.printf "✓ All %d test%s passed (%s)\n"
-          passed (if passed > 1 then "s" else "") (format_duration total_duration)
-      else begin
-        Printf.printf "✗ %d/%d test%s failed (%s)\n\n"
-          failed (List.length results)
-          (if List.length results > 1 then "s" else "")
-          (format_duration total_duration);
-        (* Show failure details *)
-        List.iter (fun r ->
-          if not r.success then begin
-            Printf.printf "FAIL: %s\n" r.file;
-            match r.error_msg with
-            | Some msg -> Printf.printf "  %s\n" msg
-            | None -> ()
-          end
-        ) results
+      if not quiet then begin
+        Printf.printf "\n";
+        if failed = 0 then
+          Printf.printf "✓ All %d test%s passed (%s)\n"
+            passed (if passed > 1 then "s" else "") (format_duration total_duration)
+        else begin
+          Printf.printf "✗ %d/%d test%s failed (%s)\n\n"
+            failed (List.length results)
+            (if List.length results > 1 then "s" else "")
+            (format_duration total_duration);
+          (* Show failure details *)
+          List.iter (fun r ->
+            if not r.success then begin
+              Printf.printf "FAIL: %s\n" r.file;
+              match r.error_msg with
+              | Some msg -> Printf.printf "  %s\n" msg
+              | None -> ()
+            end
+          ) results
+        end
       end;
       { total = List.length results; passed; failed; results; total_duration }
     end

--- a/src/package_manager/test_discovery.ml
+++ b/src/package_manager/test_discovery.ml
@@ -1,5 +1,5 @@
 (* src/package_manager/test_discovery.ml *)
-(* Test runner for T packages: discovers and runs test-*.t files *)
+(* Test runner for T packages: discovers and runs test-*.t, test_*.t, or *_test.t files *)
 
 (** Single test result *)
 type test_result = {
@@ -19,7 +19,7 @@ type suite_result = {
 }
 
 (** Discover test files in a directory.
-    Matches files named test-*.t or *_test.t, recursively. *)
+    Matches files named test-*.t, test_*.t, or *_test.t, recursively. *)
 let discover_tests (dir : string) : string list =
   let results = ref [] in
   let rec scan path =
@@ -34,15 +34,18 @@ let discover_tests (dir : string) : string list =
         if Sys.is_directory full_path then
           scan full_path
         else if Filename.check_suffix entry ".t" then begin
-          (* Match test-*.t or *_test.t *)
+          (* Match test-*.t, test_*.t, or *_test.t *)
           let base = Filename.remove_extension entry in
           let is_test_prefix =
             String.length base >= 5 &&
             String.sub base 0 5 = "test-" in
+          let is_test_underscore =
+            String.length base >= 5 &&
+            String.sub base 0 5 = "test_" in
           let is_test_suffix =
             String.length base >= 5 &&
             String.sub base (String.length base - 5) 5 = "_test" in
-          if is_test_prefix || is_test_suffix then
+          if is_test_prefix || is_test_underscore || is_test_suffix then
             results := full_path :: !results
         end
       ) entries
@@ -186,6 +189,26 @@ let format_duration d =
   else if d < 1.0 then Printf.sprintf "%.0fms" (d *. 1000.0)
   else Printf.sprintf "%.2fs" d
 
+(** JSON serialization for test results *)
+let test_result_to_yojson r =
+  `Assoc [
+    ("file", `String r.file);
+    ("status", `String (if r.success then "passed" else "failed"));
+    ("duration_ms", `Int (int_of_float (r.duration *. 1000.0)));
+    ("error", (match r.error_msg with Some e -> `String e | None -> `Null));
+  ]
+
+let suite_result_to_yojson r =
+  `Assoc [
+    ("schema_version", `String "1");
+    ("status", `String (if r.failed = 0 then "passed" else "failed"));
+    ("total", `Int r.total);
+    ("passed", `Int r.passed);
+    ("failed", `Int r.failed);
+    ("duration_ms", `Int (int_of_float (r.total_duration *. 1000.0)));
+    ("results", `List (List.map test_result_to_yojson r.results));
+  ]
+
 (** Run a full test suite: discover + execute all tests *)
 let run_suite ?(verbose=false) (dir : string) : suite_result =
   let test_dir = Filename.concat dir "tests" in
@@ -195,7 +218,7 @@ let run_suite ?(verbose=false) (dir : string) : suite_result =
   end else begin
     let files = discover_tests test_dir in
     if files = [] then begin
-      Printf.printf "No test files found (looking for test-*.t or *_test.t).\n";
+      Printf.printf "No test files found (looking for test-*.t, test_*.t, or *_test.t).\n";
       { total = 0; passed = 0; failed = 0; results = []; total_duration = 0.0 }
     end else begin
       let start_total = Unix.gettimeofday () in

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -1052,6 +1052,10 @@ let cmd_test args =
    | Ok () -> ()
    | Error msg -> exit_with_error msg);
   let suite_result = Test_discovery.run_suite ~verbose:opts.verbose opts.target_dir in
+  if opts.json then begin
+    let json = Test_discovery.suite_result_to_yojson suite_result in
+    print_endline (Yojson.Safe.pretty_to_string json)
+  end;
   if suite_result.failed > 0 then exit 1
 
 let cmd_doctor () = Package_doctor.run_doctor ()
@@ -1611,11 +1615,14 @@ let () =
 (*
 --# Run tests
 --#
---# Runs the test suite for the current package.
+--# Runs the test suite for the current package and returns a DataFrame with results.
 --# Wraps the CLI `t test` command for use within the REPL.
 --#
 --# @name t_test
---# @return :: NA Returns NA on success, or an Error if tests fail.
+--# @return :: DataFrame A DataFrame with columns: file, status, duration_ms, error.
+--# @example
+--#   results = t_test()
+--#   results |> filter($status == "failed")
 --# @family repl
 --# @export
 *)
@@ -1624,12 +1631,44 @@ let () =
       b_func = (fun _named_args _env_ref ->
         let dir = Sys.getcwd () in
         let suite_result = Test_discovery.run_suite ~verbose:false dir in
-        if suite_result.failed > 0 then
-          Ast.VError { code = Ast.GenericError; message = Printf.sprintf "%d test(s) failed." suite_result.failed; context = []; location = None; na_count = 0 }
-        else begin
-          Printf.printf "All %d test(s) passed.\n" suite_result.passed;
+        let n = List.length suite_result.results in
+        if n = 0 then begin
+          Printf.printf "No test files found.\n";
           flush stdout;
-          Ast.(VNA NAGeneric)
+          Ast.VDataFrame { arrow_table = Arrow_table.empty; group_keys = [] }
+        end else begin
+          let files = Array.init n (fun i ->
+            let r = List.nth suite_result.results i in
+            Ast.VString r.file
+          ) in
+          let statuses = Array.init n (fun i ->
+            let r = List.nth suite_result.results i in
+            Ast.VString (if r.success then "passed" else "failed")
+          ) in
+          let durations = Array.init n (fun i ->
+            let r = List.nth suite_result.results i in
+            Ast.VFloat (r.duration *. 1000.0)
+          ) in
+          let errors = Array.init n (fun i ->
+            let r = List.nth suite_result.results i in
+            match r.error_msg with
+            | Some msg -> Ast.VString msg
+            | None -> Ast.VNA NAGeneric
+          ) in
+          let columns = [
+            ("file", files);
+            ("status", statuses);
+            ("duration_ms", durations);
+            ("error", errors);
+          ] in
+          (match Arrow_bridge.table_from_value_columns columns n with
+           | Ok arrow_table -> begin
+               Printf.printf "Ran %d test(s): %d passed, %d failed.\n"
+                 suite_result.total suite_result.passed suite_result.failed;
+               flush stdout;
+               Ast.VDataFrame { arrow_table; group_keys = [] }
+           end
+           | Error err -> err)
         end)
     })
     env

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -1051,7 +1051,7 @@ let cmd_test args =
   (match Cli_args.validate_path ~kind:Cli_args.Directory opts.target_dir with
    | Ok () -> ()
    | Error msg -> exit_with_error msg);
-  let suite_result = Test_discovery.run_suite ~verbose:opts.verbose opts.target_dir in
+  let suite_result = Test_discovery.run_suite ~verbose:opts.verbose ~quiet:opts.json opts.target_dir in
   if opts.json then begin
     let json = Test_discovery.suite_result_to_yojson suite_result in
     print_endline (Yojson.Safe.pretty_to_string json)
@@ -1630,28 +1630,25 @@ let () =
     (Ast.VBuiltin { b_name = Some "t_test"; b_arity = 0; b_variadic = false;
       b_func = (fun _named_args _env_ref ->
         let dir = Sys.getcwd () in
-        let suite_result = Test_discovery.run_suite ~verbose:false dir in
-        let n = List.length suite_result.results in
+        let suite_result = Test_discovery.run_suite ~verbose:false ~quiet:true dir in
+        let results_arr = Array.of_list suite_result.results in
+        let n = Array.length results_arr in
         if n = 0 then begin
           Printf.printf "No test files found.\n";
           flush stdout;
           Ast.VDataFrame { arrow_table = Arrow_table.empty; group_keys = [] }
         end else begin
           let files = Array.init n (fun i ->
-            let r = List.nth suite_result.results i in
-            Ast.VString r.file
+            Ast.VString results_arr.(i).file
           ) in
           let statuses = Array.init n (fun i ->
-            let r = List.nth suite_result.results i in
-            Ast.VString (if r.success then "passed" else "failed")
+            Ast.VString (if results_arr.(i).success then "passed" else "failed")
           ) in
           let durations = Array.init n (fun i ->
-            let r = List.nth suite_result.results i in
-            Ast.VFloat (r.duration *. 1000.0)
+            Ast.VFloat (results_arr.(i).duration *. 1000.0)
           ) in
           let errors = Array.init n (fun i ->
-            let r = List.nth suite_result.results i in
-            match r.error_msg with
+            match results_arr.(i).error_msg with
             | Some msg -> Ast.VString msg
             | None -> Ast.VNA NAGeneric
           ) in

--- a/summary.md
+++ b/summary.md
@@ -100,6 +100,9 @@ result = t_fix("path/to/script.t", dry_run = true)
 
 t test
 
+# Run tests with structured JSON output (for agents and automation):
+t test --json tests/
+
 t doc --parse --generate
 
 t doctor
@@ -397,7 +400,7 @@ Purpose: printing, introspection, collections, metaprogramming, filesystem/path 
 - Converters: `to_integer(x)`, `to_float(x)`, `to_numeric(x)`
 - Execution and shell/file helpers: `run(command, ...)`, `exit(code = 0)`, `getwd()`, `file_exists(path)`, `dir_exists(path)`, `read_file(path)`, `list_files(path = ".")`, `env(name)`
 - Path helpers: `path_join(...)`, `path_basename(path)`, `path_dirname(path)`, `path_ext(path)`, `path_stem(path)`, `path_abs(path)`
-- Tooling wrappers discussed in the docs/reference: `t_run(path)`, `t_test(path = na())`, `t_doc(...)`
+- Tooling wrappers discussed in the docs/reference: `t_run(path)`, `t_test()`, `t_doc(...)`
 
 ### `dataframe`
 

--- a/tests/cli/test_cli.ml
+++ b/tests/cli/test_cli.ml
@@ -49,11 +49,11 @@ let run_tests pass_count fail_count _failures _eval_string _eval_string_env test
      | Ok _ -> false);
   test_message "parse_test_args defaults to cwd"
     (match Cli_args.parse_test_args ~cwd [] with
-     | Ok { Cli_args.verbose = verbose; target_dir } -> (not verbose) && target_dir = cwd
+     | Ok { Cli_args.verbose = verbose; json; target_dir } -> (not verbose) && (not json) && target_dir = cwd
      | Error _ -> false);
   test_message "parse_test_args accepts verbose flag and explicit directory"
     (match Cli_args.parse_test_args ~cwd ["--verbose"; "tests"] with
-     | Ok { Cli_args.verbose = verbose; target_dir } -> verbose && target_dir = "tests"
+     | Ok { Cli_args.verbose = verbose; json; target_dir } -> verbose && (not json) && target_dir = "tests"
      | Error _ -> false);
   test_message "parse_test_args rejects unknown flags"
     (match Cli_args.parse_test_args ~cwd ["--wat"] with

--- a/tests/test_misc_coverage.ml
+++ b/tests/test_misc_coverage.ml
@@ -950,4 +950,72 @@ min_version = "0.51.0"
         in
         inspect_ok && invalid_regex_ok && missing_drv_ok && copy_ok && copy_missing_ok && invalid_mode_ok))
   );
+  test_case "test_discovery JSON serialization produces valid JSON" (fun () ->
+    let test_result : Test_discovery.test_result = {
+      file = "tests/test-example.t";
+      success = true;
+      error_msg = None;
+      duration = 0.123;
+    } in
+    let json = Test_discovery.test_result_to_yojson test_result in
+    let json_str = Yojson.Safe.pretty_to_string json in
+    let has_file = contains json_str "test-example.t" in
+    let has_status = contains json_str "\"passed\"" in
+    let has_duration = contains json_str "duration_ms" in
+    has_file && has_status && has_duration
+  );
+  test_case "test_discovery JSON serialization handles failures" (fun () ->
+    let test_result : Test_discovery.test_result = {
+      file = "tests/test-fail.t";
+      success = false;
+      error_msg = Some "AssertionError: test failed";
+      duration = 0.456;
+    } in
+    let json = Test_discovery.test_result_to_yojson test_result in
+    let json_str = Yojson.Safe.pretty_to_string json in
+    let has_file = contains json_str "test-fail.t" in
+    let has_status = contains json_str "\"failed\"" in
+    let has_error = contains json_str "AssertionError" in
+    has_file && has_status && has_error
+  );
+  test_case "test_discovery suite_result_to_yojson produces valid JSON" (fun () ->
+    let suite_result : Test_discovery.suite_result = {
+      total = 3;
+      passed = 2;
+      failed = 1;
+      results = [
+        { file = "test-pass1.t"; success = true; error_msg = None; duration = 0.1 };
+        { file = "test-pass2.t"; success = true; error_msg = None; duration = 0.2 };
+        { file = "test-fail.t"; success = false; error_msg = Some "Error"; duration = 0.3 };
+      ];
+      total_duration = 0.6;
+    } in
+    let json = Test_discovery.suite_result_to_yojson suite_result in
+    let json_str = Yojson.Safe.pretty_to_string json in
+    let has_schema = contains json_str "\"schema_version\": \"1\"" in
+    let has_status = contains json_str "\"status\": \"failed\"" in
+    let has_total = contains json_str "\"total\": 3" in
+    let has_passed = contains json_str "\"passed\": 2" in
+    let has_failed = contains json_str "\"failed\": 1" in
+    let has_results = contains json_str "results" in
+    has_schema && has_status && has_total && has_passed && has_failed && has_results
+  );
+  test_case "cli_args parse_test_args handles --json flag" (fun () ->
+    let ok_json = Cli_args.parse_test_args ~cwd:"/tmp" ["--json"] in
+    let ok_verbose_json = Cli_args.parse_test_args ~cwd:"/tmp" ["--verbose"; "--json"] in
+    let ok_json_verbose = Cli_args.parse_test_args ~cwd:"/tmp" ["--json"; "--verbose"] in
+    let err_unknown = Cli_args.parse_test_args ~cwd:"/tmp" ["--unknown"] in
+    (match ok_json with
+     | Ok opts -> opts.json = true && opts.verbose = false
+     | Error _ -> false)
+    && (match ok_verbose_json with
+     | Ok opts -> opts.json = true && opts.verbose = true
+     | Error _ -> false)
+    && (match ok_json_verbose with
+     | Ok opts -> opts.json = true && opts.verbose = true
+     | Error _ -> false)
+    && (match err_unknown with
+     | Error _ -> true
+     | Ok _ -> false)
+  );
   print_newline ()


### PR DESCRIPTION
- Add t test --json for structured test output (schema version 1)
- Enhance t_test() REPL function to return DataFrame with columns: file, status, duration_ms, error
- Expand test discovery to match test_*.t pattern in addition to test-*.t and *_test.t
- Add unit tests for JSON serialization and CLI arg parsing
- Update documentation with examples and agent workflows

Phase 1: t test --json CLI command with structured JSON output
Phase 2: Enhanced t_test() REPL function returning DataFrame
Phase 3: Cancelled (not needed - t test and t_test() provide sufficient functionality)