### PR TITLE
populate_pipeline: update in-memory cache with build-log diagnostics …

### DIFF
--- a/src/ast.ml
+++ b/src/ast.ml
@@ -400,6 +400,9 @@ and typ =
 
 type program = stmt list
 
+(** Sentinel path used when a computed node has not been built yet. *)
+let unbuilt_path = "<unbuilt>"
+
 (** Located constructors and accessors *)
 let mk_expr ?loc node = { node; loc }
 let mk_stmt ?loc node = { node; loc }

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -2015,7 +2015,7 @@ and eval_pipeline ?(verbose=true) env_ref (nodes : (string * Ast.expr) list) : v
       else VComputedNode {
         cn_name = name;
         cn_runtime = un.un_runtime;
-        cn_path = "<unbuilt>";
+        cn_path = Ast.unbuilt_path;
         cn_serializer = Nix_unparse.expr_to_string un.un_serializer;
         cn_class = "Unknown";
         cn_dependencies = (match List.assoc_opt name deps with Some d -> d | None -> []);
@@ -2162,14 +2162,14 @@ and rerun_pipeline ?(strict=false) ?(verbose=true) env_ref (prev : Ast.pipeline_
                Error.make_error NameError (Printf.sprintf "Pipeline node `%s` depends on unknown identifier `%s`." name missing)
             | None ->
                 VComputedNode {
-                  cn_name = name; cn_runtime = un.un_runtime; cn_path = "<unbuilt>";
+                  cn_name = name; cn_runtime = un.un_runtime; cn_path = Ast.unbuilt_path;
                   cn_serializer = (match un.un_serializer.node with Ast.Value (Ast.VString s) -> s | _ -> Nix_unparse.expr_to_string un.un_serializer);
                   cn_class = "Unknown"; cn_dependencies = node_deps; cn_p_exprs = Some prev.p_exprs;
                   cn_flake = un.un_flake;
                 }
            end else
             VComputedNode {
-              cn_name = name; cn_runtime = un.un_runtime; cn_path = "<unbuilt>";
+              cn_name = name; cn_runtime = un.un_runtime; cn_path = Ast.unbuilt_path;
               cn_serializer = (match un.un_serializer.node with Ast.Value (Ast.VString s) -> s | _ -> Nix_unparse.expr_to_string un.un_serializer);
               cn_class = "Unknown"; cn_dependencies = node_deps; cn_p_exprs = Some prev.p_exprs;
               cn_flake = un.un_flake;
@@ -2549,7 +2549,7 @@ and try_lazy_expand_branch (p : Ast.pipeline_result) (env : value Env.t) (field 
     Some (Ast.VComputedNode {
       Ast.cn_name = field;
       Ast.cn_runtime;
-      Ast.cn_path = "<unbuilt>";
+      Ast.cn_path = Ast.unbuilt_path;
       Ast.cn_serializer;
       Ast.cn_class = "Unknown";
       Ast.cn_dependencies;
@@ -2693,7 +2693,7 @@ and get_pipeline_member p field =
          | Ok entries ->
              (match List.assoc_opt cn.cn_name entries with
               | Some logged_cn ->
-                  let cn_path = if cn.cn_path = "<unbuilt>" || cn.cn_path = "" then logged_cn.cn_path else cn.cn_path in
+                  let cn_path = if cn.cn_path = Ast.unbuilt_path || cn.cn_path = "" then logged_cn.cn_path else cn.cn_path in
                   let cn_class = if cn.cn_class = "Unknown" || cn.cn_class = "" then logged_cn.cn_class else cn.cn_class in
                   let cn_runtime = if cn.cn_runtime = "T" || cn.cn_runtime = "" then logged_cn.cn_runtime else cn.cn_runtime in
                   let cn_serializer = if cn.cn_serializer = "default" || cn.cn_serializer = "" then logged_cn.cn_serializer else cn.cn_serializer in
@@ -2726,7 +2726,7 @@ and get_pipeline_member p field =
                 Some (VComputedNode (resolved_cn p {
                   cn_name = field;
                   cn_runtime;
-                  cn_path = "<unbuilt>";
+                  cn_path = Ast.unbuilt_path;
                   cn_serializer;
                   cn_class = "Unknown";
                   cn_dependencies;
@@ -2852,7 +2852,7 @@ and eval_dot_access_val env_ref target_val field =
       | "path" ->
           (match !Ast.node_resolver s with
            | Some (VComputedNode cn) -> VString (!Ast.computed_node_resolver cn).cn_path
-           | Some (VNode _) -> VString "<unbuilt>"
+           | Some (VNode _) -> VString Ast.unbuilt_path
            | _ -> Error.make_error KeyError (Printf.sprintf "Symbol `%s` has no field `path` (and no built node with this name was found)." s))
       | _ -> Error.make_error Ast.KeyError (Printf.sprintf "Symbol has no field `%s`" field))
   | VList named_items ->
@@ -2912,7 +2912,7 @@ and eval_dot_access_val env_ref target_val field =
            | Some (VNodeResult { diagnostics; _ }) ->
                VString (Ast.Utils.format_warning_messages diagnostics.nd_warnings)
            | _ ->
-               if cn.cn_path <> "" && cn.cn_path <> "<unbuilt>" then
+               if cn.cn_path <> "" && cn.cn_path <> Ast.unbuilt_path then
                  let diag = Builder_read_node.logged_node_diagnostics cn.cn_name cn in
                  VString (Ast.Utils.format_warning_messages diag.nd_warnings)
                else VString "")
@@ -2922,7 +2922,7 @@ and eval_dot_access_val env_ref target_val field =
       | "command" -> VString (Nix_unparse.unparse_expr un.un_command)
       | "script" -> (match un.un_script with Some p -> VString p | None -> (VNA NAGeneric))
       | "runtime" -> VString un.un_runtime
-      | "path" -> VString "<unbuilt>"
+      | "path" -> VString Ast.unbuilt_path
       | "serializer" -> VString (Nix_unparse.unparse_expr un.un_serializer)
       | "deserializer" -> VString (Nix_unparse.unparse_expr un.un_deserializer)
       | "args" -> VDict un.un_args

--- a/src/packages/base/error_utils.ml
+++ b/src/packages/base/error_utils.ml
@@ -60,7 +60,7 @@ let resolve_error_val = function
        | None -> None)
   | VComputedNode cn ->
       let cn = !Ast.computed_node_resolver cn in
-      if cn.cn_path = "" || cn.cn_path = "<unbuilt>" then
+      if cn.cn_path = "" || cn.cn_path = Ast.unbuilt_path then
         (* No store path exists; must be a hard nix-build failure *)
         (match find_logged_error cn.cn_name with
          | Some (code, message) ->
@@ -101,7 +101,7 @@ let resolve_warning_val = function
            let s = Ast.Utils.format_warning_messages diagnostics.nd_warnings in
            if s <> "" then Some s else None
        | _ ->
-           if cn.cn_path <> "" && cn.cn_path <> "<unbuilt>" then
+           if cn.cn_path <> "" && cn.cn_path <> Ast.unbuilt_path then
              let diag = Builder.logged_node_diagnostics cn.cn_name cn in
              let s = Ast.Utils.format_warning_messages diag.nd_warnings in
              if s <> "" then Some s else None

--- a/src/packages/core/pretty_print.ml
+++ b/src/packages/core/pretty_print.ml
@@ -145,7 +145,7 @@ let rec render_tree_entry prefix is_last (label, value) =
   | VComputedNode cn ->
       let cn = !Ast.computed_node_resolver cn in
       let lines =
-        let path_str = if cn.cn_path = "<unbuilt>" || cn.cn_path = "" then "" else "\npath: " ^ cn.cn_path in
+        let path_str = if cn.cn_path = Ast.unbuilt_path || cn.cn_path = "" then "" else "\npath: " ^ cn.cn_path in
         Printf.sprintf "computed_node<%s>%s\nserializer: %s\nclass: %s"
           cn.cn_runtime path_str cn.cn_serializer cn.cn_class
       in
@@ -315,7 +315,7 @@ let rec pretty_print_value v =
         s
   | VComputedNode cn ->
       let cn = !Ast.computed_node_resolver cn in
-      let path_str = if cn.cn_path = "<unbuilt>" || cn.cn_path = "" then "" else "\npath: " ^ cn.cn_path in
+      let path_str = if cn.cn_path = Ast.unbuilt_path || cn.cn_path = "" then "" else "\npath: " ^ cn.cn_path in
       Printf.sprintf "computed_node<%s>%s\nserializer: %s\nclass: %s\n"
         cn.cn_runtime path_str cn.cn_serializer cn.cn_class
   | VBuildLog bl ->

--- a/src/packages/core/show_plot.ml
+++ b/src/packages/core/show_plot.ml
@@ -543,12 +543,12 @@ let resolve_plot_node input_value =
           "show_plot: only unbuilt R/Python/Julia plot nodes are supported. Pass an R/Python/Julia plot node or a built plot node."
       else
         build_ephemeral_plot_node temp_name un
-  | VComputedNode cn when cn.cn_path <> "<unbuilt>" && supported_plot_class cn.cn_class ->
+  | VComputedNode cn when cn.cn_path <> Ast.unbuilt_path && supported_plot_class cn.cn_class ->
       Ok cn
   | VComputedNode _ ->
       Error
         "show_plot: expected a built plot node, an unbuilt R/Python/Julia plot node, or a `read_node()` result for a built plot."
-  | VNodeResult { v = VComputedNode cn; _ } when cn.cn_path <> "<unbuilt>" && supported_plot_class cn.cn_class ->
+  | VNodeResult { v = VComputedNode cn; _ } when cn.cn_path <> Ast.unbuilt_path && supported_plot_class cn.cn_class ->
       Ok cn
   | VNodeResult { node_name; _ } ->
       computed_node_from_registry node_name

--- a/src/packages/lens/lens.ml
+++ b/src/packages/lens/lens.ml
@@ -323,7 +323,7 @@ let update_pipeline_node p node_name val_v =
   let placeholder = VComputedNode {
     cn_name = node_name;
     cn_runtime = (match List.assoc_opt node_name p.p_runtimes with Some r -> r | None -> "T");
-    cn_path = "<unbuilt>";
+    cn_path = Ast.unbuilt_path;
     cn_serializer = (match List.assoc_opt node_name p.p_serializers with
                      | Some e -> Nix_unparse.expr_to_string e
                      | None -> "default");

--- a/src/packages/pipeline/build_log.ml
+++ b/src/packages/pipeline/build_log.ml
@@ -570,7 +570,7 @@ let node_diff_fn named_args _env =
                                    else Builder_read_node.read_standard_node_value logged_cn )
              in
              match log_val with
-             | VString "latest" when cn.cn_path <> "" && cn.cn_path <> "<unbuilt>" && Sys.file_exists cn.cn_path ->
+             | VString "latest" when cn.cn_path <> "" && cn.cn_path <> Ast.unbuilt_path && Sys.file_exists cn.cn_path ->
                  Ok
                    ( "latest",
                      if preserve_native_object cn

--- a/src/packages/pipeline/pipeline_report.ml
+++ b/src/packages/pipeline/pipeline_report.ml
@@ -133,7 +133,7 @@ let rec classify_node name p log_entries_map =
 
 and classify_node_by_value name p =
   match List.assoc_opt name p.p_nodes with
-  | Some (VComputedNode cn) when cn.cn_path <> "" && cn.cn_path <> "<unbuilt>" -> Built
+  | Some (VComputedNode cn) when cn.cn_path <> "" && cn.cn_path <> Ast.unbuilt_path -> Built
   | Some (VComputedNode _) -> Unbuilt
   | Some (VNode _) -> Unbuilt
   | Some (VError _) -> Errored

--- a/src/packages/pipeline/populate_pipeline.ml
+++ b/src/packages/pipeline/populate_pipeline.ml
@@ -198,16 +198,17 @@ let register env =
                                    when logged_cn.cn_path <> "" && logged_cn.cn_path <> Ast.unbuilt_path ->
                                      if logged_cn.cn_name <> name then
                                        Printf.eprintf "[pipeline] warning: log entry name '%s' != node name '%s' (skipping diagnostics update)\n" logged_cn.cn_name name
-                                     else
-                                     let resolved = { cn with
-                                       cn_path = logged_cn.cn_path;
-                                       cn_class = logged_cn.cn_class;
-                                       cn_runtime = logged_cn.cn_runtime;
-                                       cn_serializer = logged_cn.cn_serializer;
-                                     } in
-                                     let diag = Builder.logged_node_diagnostics resolved.cn_name resolved in
-                                     Ast.set_in_memory_node_value ~p_exprs:p.p_exprs ~node_name:name
-                                       (VNodeResult { v; node_name = name; diagnostics = diag })
+                                      else (
+                                      let resolved = { cn with
+                                        cn_path = logged_cn.cn_path;
+                                        cn_class = logged_cn.cn_class;
+                                        cn_runtime = logged_cn.cn_runtime;
+                                        cn_serializer = logged_cn.cn_serializer;
+                                      } in
+                                      let diag = Builder.logged_node_diagnostics resolved.cn_name resolved in
+                                      Ast.set_in_memory_node_value ~p_exprs:p.p_exprs ~node_name:name
+                                        (VNodeResult { v; node_name = name; diagnostics = diag })
+                                      )
                                | _ -> ()
                              ) p.p_nodes
                          | Error e ->

--- a/src/packages/pipeline/populate_pipeline.ml
+++ b/src/packages/pipeline/populate_pipeline.ml
@@ -196,9 +196,10 @@ let register env =
                                match v, Hashtbl.find_opt entry_tbl name with
                                | VComputedNode cn, Some logged_cn
                                    when logged_cn.cn_path <> "" && logged_cn.cn_path <> Ast.unbuilt_path ->
-                                   (* name and logged_cn.cn_name are identical by construction —
-                                      both originate from the same node name in the pipeline JSON. *)
-                                   let resolved = { cn with
+                                    (* name and logged_cn.cn_name are identical by construction —
+                                       both originate from the same node name in the pipeline JSON. *)
+                                    assert (logged_cn.cn_name = name);
+                                    let resolved = { cn with
                                      cn_path = logged_cn.cn_path;
                                      cn_class = logged_cn.cn_class;
                                      cn_runtime = logged_cn.cn_runtime;

--- a/src/packages/pipeline/populate_pipeline.ml
+++ b/src/packages/pipeline/populate_pipeline.ml
@@ -196,18 +196,18 @@ let register env =
                                match v, Hashtbl.find_opt entry_tbl name with
                                | VComputedNode cn, Some logged_cn
                                    when logged_cn.cn_path <> "" && logged_cn.cn_path <> Ast.unbuilt_path ->
-                                    (* name and logged_cn.cn_name are identical by construction —
-                                       both originate from the same node name in the pipeline JSON. *)
-                                    assert (logged_cn.cn_name = name);
-                                    let resolved = { cn with
-                                     cn_path = logged_cn.cn_path;
-                                     cn_class = logged_cn.cn_class;
-                                     cn_runtime = logged_cn.cn_runtime;
-                                     cn_serializer = logged_cn.cn_serializer;
-                                   } in
-                                   let diag = Builder.logged_node_diagnostics resolved.cn_name resolved in
-                                   Ast.set_in_memory_node_value ~p_exprs:p.p_exprs ~node_name:name
-                                     (VNodeResult { v; node_name = name; diagnostics = diag })
+                                     if logged_cn.cn_name <> name then
+                                       Printf.eprintf "[pipeline] warning: log entry name '%s' != node name '%s' (skipping diagnostics update)\n" logged_cn.cn_name name
+                                     else
+                                     let resolved = { cn with
+                                       cn_path = logged_cn.cn_path;
+                                       cn_class = logged_cn.cn_class;
+                                       cn_runtime = logged_cn.cn_runtime;
+                                       cn_serializer = logged_cn.cn_serializer;
+                                     } in
+                                     let diag = Builder.logged_node_diagnostics resolved.cn_name resolved in
+                                     Ast.set_in_memory_node_value ~p_exprs:p.p_exprs ~node_name:name
+                                       (VNodeResult { v; node_name = name; diagnostics = diag })
                                | _ -> ()
                              ) p.p_nodes
                          | Error e ->

--- a/src/packages/pipeline/populate_pipeline.ml
+++ b/src/packages/pipeline/populate_pipeline.ml
@@ -182,25 +182,35 @@ let register env =
                   (match Builder.find_log_for_out_path out_path with
                    | Some log_path ->
                        Hashtbl.replace Ast.pipeline_build_logs p.p_exprs log_path;
-                       (* Update in-memory cache with build-log diagnostics (warnings, errors). *)
-                       (match Builder_logs.read_log log_path with
-                        | Ok entries ->
-                            List.iter (fun (name, v) ->
-                              match v, List.assoc_opt name entries with
-                              | VComputedNode cn, Some logged_cn
-                                  when logged_cn.cn_path <> "" && logged_cn.cn_path <> "<unbuilt>" ->
-                                  let resolved = { cn with
-                                    cn_path = logged_cn.cn_path;
-                                    cn_class = logged_cn.cn_class;
-                                    cn_runtime = logged_cn.cn_runtime;
-                                    cn_serializer = logged_cn.cn_serializer;
-                                  } in
-                                  let diag = Builder.logged_node_diagnostics resolved.cn_name resolved in
-                                  Ast.set_in_memory_node_value ~p_exprs:p.p_exprs ~node_name:name
-                                    (VNodeResult { v; node_name = name; diagnostics = diag })
-                              | _ -> ()
-                            ) p.p_nodes
-                        | _ -> ())
+                        (* Update in-memory cache with build-log diagnostics (warnings, errors).
+                           Only nodes that appear in the build log are updated; unmatched nodes
+                           retain whatever diagnostics they already have (populate-phase or prior
+                           build results). This is safe because pipeline node sets are fixed once
+                           created — within the same pipeline expression no nodes "drop out" between
+                           successive populate_pipeline calls. *)
+                        (match Builder_logs.read_log log_path with
+                         | Ok entries ->
+                             let entry_tbl = Hashtbl.create (List.length entries) in
+                             List.iter (fun (n, cn) -> Hashtbl.replace entry_tbl n cn) entries;
+                             List.iter (fun (name, v) ->
+                               match v, Hashtbl.find_opt entry_tbl name with
+                               | VComputedNode cn, Some logged_cn
+                                   when logged_cn.cn_path <> "" && logged_cn.cn_path <> Ast.unbuilt_path ->
+                                   (* name and logged_cn.cn_name are identical by construction —
+                                      both originate from the same node name in the pipeline JSON. *)
+                                   let resolved = { cn with
+                                     cn_path = logged_cn.cn_path;
+                                     cn_class = logged_cn.cn_class;
+                                     cn_runtime = logged_cn.cn_runtime;
+                                     cn_serializer = logged_cn.cn_serializer;
+                                   } in
+                                   let diag = Builder.logged_node_diagnostics resolved.cn_name resolved in
+                                   Ast.set_in_memory_node_value ~p_exprs:p.p_exprs ~node_name:name
+                                     (VNodeResult { v; node_name = name; diagnostics = diag })
+                               | _ -> ()
+                             ) p.p_nodes
+                         | Error e ->
+                             Printf.eprintf "[pipeline] warning: failed to read build log (%s) — in-memory diagnostics may be stale\n" e)
                    | None -> ())
               );
                out

--- a/src/packages/pipeline/populate_pipeline.ml
+++ b/src/packages/pipeline/populate_pipeline.ml
@@ -181,7 +181,26 @@ let register env =
                 if built > 0 || cached > 0 then
                   (match Builder.find_log_for_out_path out_path with
                    | Some log_path ->
-                       Hashtbl.replace Ast.pipeline_build_logs p.p_exprs log_path
+                       Hashtbl.replace Ast.pipeline_build_logs p.p_exprs log_path;
+                       (* Update in-memory cache with build-log diagnostics (warnings, errors). *)
+                       (match Builder_logs.read_log log_path with
+                        | Ok entries ->
+                            List.iter (fun (name, v) ->
+                              match v, List.assoc_opt name entries with
+                              | VComputedNode cn, Some logged_cn
+                                  when logged_cn.cn_path <> "" && logged_cn.cn_path <> "<unbuilt>" ->
+                                  let resolved = { cn with
+                                    cn_path = logged_cn.cn_path;
+                                    cn_class = logged_cn.cn_class;
+                                    cn_runtime = logged_cn.cn_runtime;
+                                    cn_serializer = logged_cn.cn_serializer;
+                                  } in
+                                  let diag = Builder.logged_node_diagnostics resolved.cn_name resolved in
+                                  Ast.set_in_memory_node_value ~p_exprs:p.p_exprs ~node_name:name
+                                    (VNodeResult { v; node_name = name; diagnostics = diag })
+                              | _ -> ()
+                            ) p.p_nodes
+                        | _ -> ())
                    | None -> ())
               );
                out

--- a/src/packages/pipeline/read_node.ml
+++ b/src/packages/pipeline/read_node.ml
@@ -285,7 +285,7 @@ let register env =
       List.iter (fun dep_name ->
         match Builder.latest_logged_computed_node dep_name with
         | Some dep_cn ->
-            if dep_cn.cn_path <> "" && dep_cn.cn_path <> "<unbuilt>" then (
+            if dep_cn.cn_path <> "" && dep_cn.cn_path <> Ast.unbuilt_path then (
               let store_dir = Filename.dirname dep_cn.cn_path in
               resolved_deps := (dep_name, store_dir, dep_cn.cn_serializer) :: !resolved_deps
             )
@@ -483,14 +483,14 @@ let read_fn named_args _env =
           let resolved_cn = !Ast.computed_node_resolver cn in
           let is_in_memory_placeholder v =
             match v with
-            | VNodeResult { v = VComputedNode inner; _ } -> inner.cn_path = "" || inner.cn_path = "<unbuilt>"
+            | VNodeResult { v = VComputedNode inner; _ } -> inner.cn_path = "" || inner.cn_path = Ast.unbuilt_path
             | _ -> false
           in
           match Ast.get_in_memory_node_value_for_cn cn with
           | Some v when not (is_in_memory_placeholder v) -> v
           | _ ->
             (match resolved_cn with
-              | cn when cn.cn_path = "<unbuilt>" ->
+              | cn when cn.cn_path = Ast.unbuilt_path ->
                   (match Ast.get_in_memory_node_value_for_cn cn with
                     | Some v when not (is_in_memory_placeholder v) -> v
                     | _ ->
@@ -722,7 +722,7 @@ let read_fn named_args _env =
           in
           let cn_path =
             if logged_cn.cn_path = "" then ""
-            else if cn.cn_path = "<unbuilt>" || cn.cn_path = ""
+            else if cn.cn_path = Ast.unbuilt_path || cn.cn_path = ""
             then logged_cn.cn_path
             else cn.cn_path
           in

--- a/src/pipeline/builder_read_node.ml
+++ b/src/pipeline/builder_read_node.ml
@@ -77,7 +77,7 @@ let rec collect_upstream_warnings ?(visited : string list = []) (dep_names : str
   | dep_name :: rest ->
       let from_this_dep =
         match !latest_logged_computed_node_forward dep_name with
-        | Some dep_cn when dep_cn.cn_path <> "" && dep_cn.cn_path <> "<unbuilt>" ->
+        | Some dep_cn when dep_cn.cn_path <> "" && dep_cn.cn_path <> Ast.unbuilt_path ->
             let dep_dir = Filename.dirname dep_cn.cn_path in
             let dep_warnings_path = Filename.concat dep_dir "warnings" in
             let dep_warnings = parse_node_warnings dep_warnings_path in
@@ -186,7 +186,7 @@ let read_standard_node_value cn =
 
 let read_logged_node_value name cn =
   let noop_build_detected =
-    if cn.cn_path <> "" && cn.cn_path <> "<unbuilt>" then
+    if cn.cn_path <> "" && cn.cn_path <> Ast.unbuilt_path then
       let noop_path = Filename.concat (Filename.dirname cn.cn_path) "NOOPBUILD" in
       Sys.file_exists noop_path
     else
@@ -387,7 +387,7 @@ let matching_pipeline_log_entries ?which_log (p : Ast.pipeline_result) =
 
 let merge_pipeline_nodes_with_latest_log ?which_log (p : Ast.pipeline_result) =
   let should_overlay_value = function
-    | VComputedNode cn -> cn.cn_path = "<unbuilt>" || cn.cn_path = ""
+    | VComputedNode cn -> cn.cn_path = Ast.unbuilt_path || cn.cn_path = ""
     | _ -> false
   in
   let overlay_in_memory pairs =

--- a/tests/pipeline/test_pipeline.ml
+++ b/tests/pipeline/test_pipeline.ml
@@ -1670,7 +1670,7 @@ p_cross = pipeline {
 p.t_step|}
     (Packages.init_env ()) in
   (match v_t_deferred with
-  | Ast.VComputedNode cn when cn.cn_path = "<unbuilt>" ->
+  | Ast.VComputedNode cn when cn.cn_path = Ast.unbuilt_path ->
       incr pass_count; Printf.printf "  ✓ T node is deferred when its sibling node is <unbuilt>\n"
   | other ->
       incr fail_count; Printf.printf "  ✗ T node should be deferred when sibling is <unbuilt>\n    Got: %s\n"
@@ -1702,7 +1702,7 @@ p.t_step|}
     (match Eval.rerun_pipeline (ref (Packages.init_env ())) p with
     | Ast.VPipeline rerun ->
       (match List.assoc_opt "t_step" rerun.p_nodes with
-      | Some (Ast.VComputedNode cn) when cn.cn_path = "<unbuilt>" ->
+      | Some (Ast.VComputedNode cn) when cn.cn_path = Ast.unbuilt_path ->
           incr pass_count; Printf.printf "  ✓ T node stays deferred after rerun when sibling is <unbuilt>\n"
       | Some other ->
           incr fail_count; Printf.printf "  ✗ T node should stay deferred after rerun\n    Got: %s\n"


### PR DESCRIPTION
…after Nix build

After a Nix build completes, warnings written to /warnings by flush_warnings_to_out (repl.ml:586) were never propagated back to the in-memory VNodeResult cache. This meant expect_warning() on any T expression pipeline node always failed with 'No warnings found on this node', even when warnings were present in the Nix store.

Fix: after registering the build log path, read the log entries, resolve each computed node with build-log metadata (path, class, runtime, serializer), call Builder.logged_node_diagnostics to load warnings from the Nix store warnings file, and update the cache via Ast.set_in_memory_node_value with the full diagnostics.