### PR TITLE
refactor(pipeline): extract shared boilerplate into Pipeline_builder_…

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -64,8 +64,8 @@
     chrono
     ; packages/dataframe
    t_read_csv t_read_parquet t_write_csv t_read_arrow t_write_arrow t_write_parquet t_dataframe colnames nrow ncol clean_colnames glimpse
-      ; packages/pipeline
-       pipeline_utils pipeline_args pipeline_nodes pipeline_deps pipeline_node pipeline_run build_pipeline populate_pipeline inspect_pipeline trace_nodes read_node read_past_node pipeline_copy
+       ; packages/pipeline
+        pipeline_utils pipeline_args pipeline_nodes pipeline_deps pipeline_node pipeline_run build_pipeline populate_pipeline inspect_pipeline trace_nodes read_node read_past_node pipeline_copy pipeline_builder_post
        pipeline_to_frame filter_node which_nodes mutate_node rename_node select_node arrange_node pipeline_to_drv
          pipeline_set_ops pipeline_dag_ops pipeline_composition pipeline_expand pipeline_inspect2 pipeline_to_ga t_make_mod build_log pipeline_diff diff_summary pipeline_report t_check t_diff t_fix
       pipeline_to_store set_nix_defaults pipeline_cache_status pipeline_gc export_artifacts import_artifacts inspect_artifacts

--- a/src/packages/pipeline/build_pipeline.ml
+++ b/src/packages/pipeline/build_pipeline.ml
@@ -27,174 +27,60 @@ let write_atelier_diagrams p env =
         with _ -> ())
      | _ -> ())
 
-(*
---# Build Pipeline Artifacts
---#
---# Builds a pipeline to `pipeline.nix` and records node artifacts in a local registry.
---# Supports Nix-native orchestration flags for targeted builds, cache usage, and dry-runs.
---#
---# If the pipeline contains unexpanded dynamic branching patterns (`map_pattern`,
---# `cross_pattern`), they are automatically expanded before building.
---#
---# @name build_pipeline
---# @param pipeline :: Pipeline The pipeline to build.
---# @param verbose :: Int (Optional) Nix build verbosity level. `0` keeps build failures quiet; values above `0` print failed node logs.
---# @param dry_run :: Bool (Optional) Return a planned build DataFrame without executing. Maps to `--dry-run`.
---# @param nix_options :: Dict (Optional) A dictionary of Nix orchestration options:
---#   - `targets` :: List[String] Specific node names to build. Maps to `-A <target>` in nix-build.
---#   - `force` :: Bool|List[String] Force-rebuild nodes even if cached. Maps to `--check`.
---#   - `max_jobs` :: Int Maximum parallel build jobs. Maps to `--max-jobs N`.
---#   - `cache` :: String Cachix cache name to configure as an extra binary substituter.
---# @return :: BuildLog|DataFrame A structured build log (`nodes`, `duration`, `failed_nodes`, `out_path`), or a dry-run DataFrame.
---# @family pipeline
---# @seealso read_node
---# @export
-*)
 let register ~(rerun_pipeline : ?strict:bool -> ?verbose:bool -> value Env.t -> pipeline_result -> value) env =
   let build_fn named_args env =
     if !Ast.check_mode then
       VString "<check mode: build_pipeline skipped>"
     else
-    let named_keys = List.filter_map (fun (k, _) -> k) named_args in
-    let positional_count = List.length (List.filter (fun (k, _) -> k = None) named_args) in
-    match List.find_opt (fun k -> not (List.mem k ["p"; "verbose"; "nix_options"; "dry_run"; "pipeline_name"])) named_keys with
-    | Some k ->
-        Error.type_error (Printf.sprintf "build_pipeline: unknown argument '%s'" k)
-    | None when positional_count > 4 ->
-        Error.make_error ArityError
-          (Printf.sprintf "Function `build_pipeline` accepts at most 4 positional arguments but received %d." positional_count)
+    let fn_name = "build_pipeline" in
+    match Pipeline_builder_post.check_unknown_keys ~known_keys:["p"; "verbose"; "nix_options"; "dry_run"; "pipeline_name"] ~fn_name named_args with
+    | Some err -> err
+    | None ->
+    match Pipeline_builder_post.check_arity ~max:5 ~fn_name named_args with
+    | Some err -> err
     | None ->
       match Pipeline_args.get_arg "p" 1 (VNA NAGeneric) named_args with
       | (_, VPipeline p) ->
           (match Pipeline_expand.expand_pipeline_for_build p env with
            | Error e -> e
            | Ok p ->
-            let (verbose_provided, verbose_val) = Pipeline_args.get_arg "verbose" 2 (VNA NAGeneric) named_args in
-        let (_, nix_options_val) = Pipeline_args.get_arg "nix_options" 3 (VDict []) named_args in
-        let (dry_run_provided, dry_run_val) = Pipeline_args.get_arg "dry_run" 4 (VNA NAGeneric) named_args in
-
-        let verbose_result =
-          match verbose_val with
-          | VInt i when i >= 0 -> Ok (Some i)
-          | VInt _ ->
-              Error (Error.value_error "Function `build_pipeline` expects `verbose` to be a non-negative Int.")
-          | _ when verbose_provided ->
-              Error (Error.type_error "Function `build_pipeline` expects `verbose` to be an Int.")
-          | _ ->
-              Ok None
-        in
-
-        let nix_options_result =
-          match nix_options_val with
-          | VNA _ -> Ok None
-          | VDict pairs ->
-              (match Builder_utils.validate_nix_options "build_pipeline" pairs with
-               | Ok opts -> Ok (Some opts)
-               | Error e -> Error e)
-          | _ -> Error (Error.type_error "Function `build_pipeline` expects `nix_options` to be a Dictionary.")
-        in
-
-        let dry_run_result =
-          match dry_run_val with
-          | VBool b -> Ok (Some b)
-          | VNA _ -> Ok None
-          | _ when dry_run_provided ->
-              Error (Error.type_error "Function `build_pipeline` expects `dry_run` to be a Bool.")
-          | _ -> Ok None
-        in
-        let (pipeline_name_provided, pipeline_name_val) = Pipeline_args.get_arg "pipeline_name" 5 (VNA NAGeneric) named_args in
-        let pipeline_name_result =
-          match pipeline_name_val with
-          | VString s -> Ok (Some s)
-          | VSymbol s -> Ok (Some s)
-          | VNA _ -> Ok None
-          | _ when pipeline_name_provided ->
-              Error (Error.type_error "Function `build_pipeline` expects `pipeline_name` to be a String.")
-          | _ -> Ok None
-        in
-
-        let (let*) x f = match x with Ok v -> f v | Error e -> e in
-        let* verbose = verbose_result in
-        let* nix_options = nix_options_result in
-        let* dry_opt = dry_run_result in
-        let* pipeline_name = pipeline_name_result in
-        let final_nix_options =
-          let base_opts =
-            match nix_options with
-            | Some opts -> opts
-            | None -> Builder_utils.default_nix_opts
-          in
-          match dry_opt with
-          | Some d -> Some { base_opts with dry_run = Some d }
-          | None -> Some base_opts
-        in
+            let (let*) x f = match x with Ok v -> f v | Error e -> e in
+            let* verbose = Pipeline_builder_post.parse_verbose ~fn_name ~pos:2 named_args in
+            let* nix_options = Pipeline_builder_post.parse_nix_options ~fn_name ~pos:3 named_args in
+            let* dry_opt = Pipeline_builder_post.parse_dry_run ~fn_name ~pos:4 named_args in
+            let* pipeline_name_explicit = Pipeline_builder_post.parse_pipeline_name ~fn_name ~pos:5 named_args in
+        let final_nix_options = Pipeline_builder_post.combine_nix_options ?dry_opt nix_options in
         (match rerun_pipeline ?strict:(Some true) ~verbose:false env p with
          | VPipeline p_resolved ->
              let pipeline_name =
-               match pipeline_name with
-               | Some _ -> pipeline_name
+               match pipeline_name_explicit with
+               | Some _ -> pipeline_name_explicit
                | None -> resolve_pipeline_name env p
              in
              (match Builder.populate_pipeline ~build:true ?verbose ?pipeline_name ?nix_options:final_nix_options p_resolved with
               | Ok (VDataFrame _ as df) ->
                   write_atelier_diagrams p_resolved env;
                   df
-              | Ok (VDict pairs as out) ->
+              | Ok (VDict _ as out) ->
                   write_atelier_diagrams p_resolved env;
-                  let out_path =
-                    match List.assoc_opt "out_path" pairs with
-                    | Some (VString s) -> s
-                    | _ -> ""
-                  in
-                  let built =
-                    match List.assoc_opt "built" pairs with
-                    | Some (VInt n) -> n
-                    | _ -> 0
-                  in
-                   let cached =
-                     match List.assoc_opt "cached" pairs with
-                     | Some (VInt n) -> n
-                     | _ -> 0
-                   in
-                   let soft_failed =
-                     match List.assoc_opt "soft_failed" pairs with
-                     | Some (VList items) -> List.length items
-                     | _ -> 0
-                   in
-                  let var_name = match pipeline_name with Some n -> n | None -> "p" in
-                  let first_node =
-                    match p_resolved.p_nodes with
-                    | (name, _) :: _ -> name
-                    | [] -> "my_node"
-                  in
-                  if built > 0 then
-                    if soft_failed > 0 then
-                      Printf.eprintf "\nPipeline built successfully but with errors\n"
-                    else
-                      Printf.eprintf "\nPipeline successfully built!\n";
-                  Printf.eprintf "  - Pipeline saved in variable '%s'\n" var_name;
-                  Printf.eprintf "  - To read the contents of node '%s', use: read_node(%s.%s)\n" first_node var_name first_node;
-                  Printf.eprintf "  - To inspect node metadata, use: inspect_node(%s.%s)\n" var_name first_node;
-                  Printf.eprintf "  - To view pipeline summary, use: inspect_pipeline(%s)\n\n%!" var_name;
-                   if built > 0 || cached > 0 then
-                     (match Builder.find_log_for_out_path out_path with
-                      | Some log_path ->
-                          Hashtbl.replace Ast.pipeline_build_logs p.p_exprs log_path;
-                          Hashtbl.replace Ast.pipeline_build_logs p_resolved.p_exprs log_path;
-                          if built > 0 then
-                            Builder.parse_json_log_to_vbuildlog log_path
-                          else
-                            out
-                      | None ->
-                          if built > 0 then
-                            Error.make_error FileError
-                              (Printf.sprintf
-                                 "No build log matching output path `%s` was found after build completed."
-                                 out_path)
-                          else
-                            out)
-                   else
-                     out
+                  let stats = Pipeline_builder_post.extract_build_stats out in
+                  Pipeline_builder_post.print_build_success ~pipeline_name ~p_nodes:p_resolved.p_nodes stats;
+                  if stats.built > 0 || stats.cached > 0 then (
+                    match Pipeline_builder_post.register_build_logs
+                      ~p_exprs_keys:[p.p_exprs; p_resolved.p_exprs]
+                      ~p_nodes:p_resolved.p_nodes
+                      ~out_path:stats.out_path with
+                    | Some _ when stats.built > 0 ->
+                        Builder.parse_json_log_to_vbuildlog stats.out_path
+                    | Some _ -> out
+                    | None when stats.built > 0 ->
+                        Error.make_error FileError
+                          (Printf.sprintf
+                             "No build log matching output path `%s` was found after build completed."
+                             stats.out_path)
+                    | None -> out
+                  ) else
+                    out
               | Ok other -> other
               | Error msg -> Error.make_error StructuralError msg)
          | VError _ as err -> err

--- a/src/packages/pipeline/build_pipeline.ml
+++ b/src/packages/pipeline/build_pipeline.ml
@@ -70,8 +70,8 @@ let register ~(rerun_pipeline : ?strict:bool -> ?verbose:bool -> value Env.t -> 
                       ~p_exprs_keys:[p.p_exprs; p_resolved.p_exprs]
                       ~p_nodes:p_resolved.p_nodes
                       ~out_path:stats.out_path with
-                    | Some _ when stats.built > 0 ->
-                        Builder.parse_json_log_to_vbuildlog stats.out_path
+                    | Some log_path when stats.built > 0 ->
+                        Builder.parse_json_log_to_vbuildlog log_path
                     | Some _ -> out
                     | None when stats.built > 0 ->
                         Error.make_error FileError

--- a/src/packages/pipeline/pipeline_builder_post.ml
+++ b/src/packages/pipeline/pipeline_builder_post.ml
@@ -138,32 +138,32 @@ let register_build_logs ~p_exprs_keys ~p_nodes ~out_path =
       List.iter (fun exprs ->
         Hashtbl.replace Ast.pipeline_build_logs exprs log_path
       ) p_exprs_keys;
-      List.iter (fun exprs ->
-        match Builder_logs.read_log log_path with
-        | Ok entries ->
-            let entry_tbl = Hashtbl.create (List.length entries) in
-            List.iter (fun (n, cn) -> Hashtbl.replace entry_tbl n cn) entries;
-            List.iter (fun (name, v) ->
-              match v, Hashtbl.find_opt entry_tbl name with
-              | VComputedNode cn, Some logged_cn
-                  when logged_cn.cn_path <> "" && logged_cn.cn_path <> Ast.unbuilt_path ->
-                    if logged_cn.cn_name <> name then
-                      Printf.eprintf "[pipeline] warning: log entry name '%s' != node name '%s' (skipping diagnostics update)\n" logged_cn.cn_name name
-                    else (
-                      let resolved = { cn with
-                        cn_path = logged_cn.cn_path;
-                        cn_class = logged_cn.cn_class;
-                        cn_runtime = logged_cn.cn_runtime;
-                        cn_serializer = logged_cn.cn_serializer;
-                      } in
-                      let diag = Builder.logged_node_diagnostics resolved.cn_name resolved in
-                      Ast.set_in_memory_node_value ~p_exprs:exprs ~node_name:name
-                        (VNodeResult { v; node_name = name; diagnostics = diag })
-                    )
-              | _ -> ()
-            ) p_nodes
-        | Error e ->
-            Printf.eprintf "[pipeline] warning: failed to read build log (%s) — in-memory diagnostics may be stale\n" e
-      ) p_exprs_keys;
+      (match Builder_logs.read_log log_path with
+       | Ok entries ->
+           let entry_tbl = Hashtbl.create (List.length entries) in
+           List.iter (fun (n, cn) -> Hashtbl.replace entry_tbl n cn) entries;
+           List.iter (fun exprs ->
+             List.iter (fun (name, v) ->
+               match v, Hashtbl.find_opt entry_tbl name with
+               | VComputedNode cn, Some logged_cn
+                   when logged_cn.cn_path <> "" && logged_cn.cn_path <> Ast.unbuilt_path ->
+                     if logged_cn.cn_name <> name then
+                       Printf.eprintf "[pipeline] warning: log entry name '%s' != node name '%s' (skipping diagnostics update)\n" logged_cn.cn_name name
+                     else (
+                       let resolved = { cn with
+                         cn_path = logged_cn.cn_path;
+                         cn_class = logged_cn.cn_class;
+                         cn_runtime = logged_cn.cn_runtime;
+                         cn_serializer = logged_cn.cn_serializer;
+                       } in
+                       let diag = Builder.logged_node_diagnostics resolved.cn_name resolved in
+                       Ast.set_in_memory_node_value ~p_exprs:exprs ~node_name:name
+                         (VNodeResult { v; node_name = name; diagnostics = diag })
+                     )
+               | _ -> ()
+             ) p_nodes
+           ) p_exprs_keys
+       | Error e ->
+           Printf.eprintf "[pipeline] warning: failed to read build log (%s) — in-memory diagnostics may be stale\n" e);
       Some log_path
   | None -> None

--- a/src/packages/pipeline/pipeline_builder_post.ml
+++ b/src/packages/pipeline/pipeline_builder_post.ml
@@ -1,0 +1,169 @@
+open Ast
+
+let check_unknown_keys ~known_keys ~fn_name named_args =
+  let named_keys = List.filter_map (fun (k, _) -> k) named_args in
+  match List.find_opt (fun k -> not (List.mem k known_keys)) named_keys with
+  | Some k -> Some (Error.type_error (Printf.sprintf "%s: unknown argument '%s'" fn_name k))
+  | None -> None
+
+let check_arity ~max ~fn_name named_args =
+  let positional_count = List.length (List.filter (fun (k, _) -> k = None) named_args) in
+  if positional_count > max then
+    Some (Error.make_error ArityError
+      (Printf.sprintf "Function `%s` accepts at most %d positional arguments but received %d." fn_name max positional_count))
+  else
+    None
+
+let parse_build ~fn_name ~pos named_args =
+  let (build_provided, build_val) = Pipeline_args.get_arg "build" pos (VBool false) named_args in
+  match build_val with
+  | VBool b -> Ok b
+  | _ when build_provided ->
+      Error (Error.type_error (Printf.sprintf "Function `%s` expects `build` to be a Bool." fn_name))
+  | _ ->
+      Ok false
+
+let parse_verbose ~fn_name ~pos named_args =
+  let (verbose_provided, verbose_val) = Pipeline_args.get_arg "verbose" pos (VNA NAGeneric) named_args in
+  match verbose_val with
+  | VInt i when i >= 0 -> Ok (Some i)
+  | VInt _ ->
+      Error (Error.value_error (Printf.sprintf "Function `%s` expects `verbose` to be a non-negative Int." fn_name))
+  | _ when verbose_provided ->
+      Error (Error.type_error (Printf.sprintf "Function `%s` expects `verbose` to be an Int." fn_name))
+  | _ ->
+      Ok None
+
+let parse_nix_options ~fn_name ~pos named_args =
+  let (_, nix_options_val) = Pipeline_args.get_arg "nix_options" pos (VDict []) named_args in
+  match nix_options_val with
+  | VNA _ -> Ok None
+  | VDict pairs ->
+      (match Builder_utils.validate_nix_options fn_name pairs with
+       | Ok opts -> Ok (Some opts)
+       | Error e -> Error e)
+  | _ -> Error (Error.type_error (Printf.sprintf "Function `%s` expects `nix_options` to be a Dictionary." fn_name))
+
+let parse_dry_run ~fn_name ~pos named_args =
+  let (dry_run_provided, dry_run_val) = Pipeline_args.get_arg "dry_run" pos (VNA NAGeneric) named_args in
+  match dry_run_val with
+  | VBool b -> Ok (Some b)
+  | VNA _ -> Ok None
+  | _ when dry_run_provided ->
+      Error (Error.type_error (Printf.sprintf "Function `%s` expects `dry_run` to be a Bool." fn_name))
+  | _ -> Ok None
+
+let parse_pipeline_name ~fn_name ~pos named_args =
+  let (pipeline_name_provided, pipeline_name_val) = Pipeline_args.get_arg "pipeline_name" pos (VNA NAGeneric) named_args in
+  match pipeline_name_val with
+  | VString s -> Ok (Some s)
+  | VSymbol s -> Ok (Some s)
+  | VNA _ -> Ok None
+  | _ when pipeline_name_provided ->
+      Error (Error.type_error (Printf.sprintf "Function `%s` expects `pipeline_name` to be a String." fn_name))
+  | _ -> Ok None
+
+let combine_nix_options ?dry_opt nix_options =
+  let base_opts =
+    match nix_options with
+    | Some opts -> opts
+    | None -> Builder_utils.default_nix_opts
+  in
+  match dry_opt with
+  | Some d -> Some { base_opts with dry_run = Some d }
+  | None -> Some base_opts
+
+type build_stats = {
+  built: int;
+  cached: int;
+  out_path: string;
+  soft_failed: int;
+}
+
+let extract_build_stats out =
+  let built =
+    match out with
+    | VDict pairs ->
+        (match List.assoc_opt "built" pairs with
+         | Some (VInt n) -> n
+         | _ -> 0)
+    | _ -> 0
+  in
+  let cached =
+    match out with
+    | VDict pairs ->
+        (match List.assoc_opt "cached" pairs with
+         | Some (VInt n) -> n
+         | _ -> 0)
+    | _ -> 0
+  in
+  let out_path =
+    match out with
+    | VDict pairs ->
+        (match List.assoc_opt "out_path" pairs with
+         | Some (VString s) -> s
+         | _ -> "")
+    | _ -> ""
+  in
+  let soft_failed =
+    match out with
+    | VDict pairs ->
+        (match List.assoc_opt "soft_failed" pairs with
+         | Some (VList items) -> List.length items
+         | _ -> 0)
+    | _ -> 0
+  in
+  { built; cached; out_path; soft_failed }
+
+let print_build_success ~pipeline_name ~p_nodes stats =
+  let var_name = match pipeline_name with Some n -> n | None -> "p" in
+  let first_node =
+    match p_nodes with
+    | (name, _) :: _ -> name
+    | [] -> "my_node"
+  in
+  if stats.built > 0 then
+    if stats.soft_failed > 0 then
+      Printf.eprintf "\nPipeline built successfully but with errors\n"
+    else
+      Printf.eprintf "\nPipeline successfully built!\n";
+  Printf.eprintf "  - Pipeline saved in variable '%s'\n" var_name;
+  Printf.eprintf "  - To read the contents of node '%s', use: read_node(%s.%s)\n" first_node var_name first_node;
+  Printf.eprintf "  - To inspect node metadata, use: inspect_node(%s.%s)\n" var_name first_node;
+  Printf.eprintf "  - To view pipeline summary, use: inspect_pipeline(%s)\n\n%!" var_name
+
+let register_build_logs ~p_exprs_keys ~p_nodes ~out_path =
+  match Builder.find_log_for_out_path out_path with
+  | Some log_path ->
+      List.iter (fun exprs ->
+        Hashtbl.replace Ast.pipeline_build_logs exprs log_path
+      ) p_exprs_keys;
+      List.iter (fun exprs ->
+        match Builder_logs.read_log log_path with
+        | Ok entries ->
+            let entry_tbl = Hashtbl.create (List.length entries) in
+            List.iter (fun (n, cn) -> Hashtbl.replace entry_tbl n cn) entries;
+            List.iter (fun (name, v) ->
+              match v, Hashtbl.find_opt entry_tbl name with
+              | VComputedNode cn, Some logged_cn
+                  when logged_cn.cn_path <> "" && logged_cn.cn_path <> Ast.unbuilt_path ->
+                    if logged_cn.cn_name <> name then
+                      Printf.eprintf "[pipeline] warning: log entry name '%s' != node name '%s' (skipping diagnostics update)\n" logged_cn.cn_name name
+                    else (
+                      let resolved = { cn with
+                        cn_path = logged_cn.cn_path;
+                        cn_class = logged_cn.cn_class;
+                        cn_runtime = logged_cn.cn_runtime;
+                        cn_serializer = logged_cn.cn_serializer;
+                      } in
+                      let diag = Builder.logged_node_diagnostics resolved.cn_name resolved in
+                      Ast.set_in_memory_node_value ~p_exprs:exprs ~node_name:name
+                        (VNodeResult { v; node_name = name; diagnostics = diag })
+                    )
+              | _ -> ()
+            ) p_nodes
+        | Error e ->
+            Printf.eprintf "[pipeline] warning: failed to read build log (%s) — in-memory diagnostics may be stale\n" e
+      ) p_exprs_keys;
+      Some log_path
+  | None -> None

--- a/src/packages/pipeline/populate_pipeline.ml
+++ b/src/packages/pipeline/populate_pipeline.ml
@@ -1,120 +1,31 @@
 open Ast
 open Pipeline_utils
 
-(*
---# Populate Pipeline
---#
---# Generates the `_pipeline/` directory with `pipeline.nix` and `dag.json`.
---# Optionally builds the pipeline with full Nix-native orchestration support.
---#
---# If the pipeline contains unexpanded dynamic branching patterns (`map_pattern`,
---# `cross_pattern`), they are automatically expanded before population.
---#
---# @name populate_pipeline
---# @param p :: Pipeline The pipeline to populate.
---# @param build :: Bool (Optional) Whether to trigger the Nix build immediately. Defaults to false.
---# @param verbose :: Int (Optional) Nix build verbosity level. `0` keeps build failures quiet; values above `0` print failed node logs.
---# @param dry_run :: Bool (Optional) Perform a dry run via Nix (`--dry-run`), returning a DataFrame of planned actions without executing.
---# @param nix_options :: Dict (Optional) A dictionary of Nix orchestration options:
---#   - `targets` :: List[String] Specific node names to build. Maps to `-A <target>` in nix-build.
---#   - `force` :: Bool|List[String] Force-rebuild nodes even if cached. Maps to `--check`.
---#   - `max_jobs` :: Int Maximum parallel build jobs. Maps to `--max-jobs N`.
---#   - `cache` :: String Cachix cache name to configure as an extra binary substituter.
---# @return :: String|BuildLog|DataFrame A status message, structured build log, or dry-run plan DataFrame.
---# @note `populate_pipeline` performs several validation checks before generating the Nix files:
---#   - **File Existence**: Verifies that all files specified in `functions` or `include` arguments of any node actually exist on the file system.
---#   - **Custom Function Warning**: Issues a warning to `stderr` if a node uses a custom `serializer` or `deserializer` but does not provide any companion `functions` files.
---#   - **Explicit Dependency Declaration**: Checks serializer/runtime requirements up front and asks to add missing entries to `tproject.toml` instead of injecting packages implicitly.
---#   - **Auto-Expansion**: Pipelines with `map_pattern` or `cross_pattern` are expanded automatically before building.
---# @family pipeline
---# @export
-*)
 let register env =
   let populate_fn named_args env =
     if !Ast.check_mode then
       VString "<check mode: populate_pipeline skipped>"
     else
-    let named_keys = List.filter_map (fun (k, _) -> k) named_args in
-    let positional_count = List.length (List.filter (fun (k, _) -> k = None) named_args) in
-    match List.find_opt (fun k -> not (List.mem k ["p"; "build"; "verbose"; "nix_options"; "dry_run"; "pipeline_name"])) named_keys with
-    | Some k ->
-        Error.type_error (Printf.sprintf "populate_pipeline: unknown argument '%s'" k)
-    | None when positional_count > 6 ->
-        Error.make_error ArityError
-          (Printf.sprintf "Function `populate_pipeline` accepts at most 6 positional arguments but received %d." positional_count)
+    let fn_name = "populate_pipeline" in
+    match Pipeline_builder_post.check_unknown_keys ~known_keys:["p"; "build"; "verbose"; "nix_options"; "dry_run"; "pipeline_name"] ~fn_name named_args with
+    | Some err -> err
+    | None ->
+    match Pipeline_builder_post.check_arity ~max:6 ~fn_name named_args with
+    | Some err -> err
     | None ->
       match Pipeline_args.get_arg "p" 1 (VNA NAGeneric) named_args with
       | (_, VPipeline p) ->
+          let original_p_exprs = p.p_exprs in
           (match Pipeline_expand.expand_pipeline_for_build p env with
            | Error e -> e
            | Ok p ->
-            let (build_provided, build_val) = Pipeline_args.get_arg "build" 2 (VBool false) named_args in
-        let (verbose_provided, verbose_val) = Pipeline_args.get_arg "verbose" 3 (VNA NAGeneric) named_args in
-        let (_, nix_options_val) = Pipeline_args.get_arg "nix_options" 4 (VDict []) named_args in
-        let (dry_run_provided, dry_run_val) = Pipeline_args.get_arg "dry_run" 5 (VNA NAGeneric) named_args in
-        let (pipeline_name_provided, pipeline_name_val) = Pipeline_args.get_arg "pipeline_name" 6 (VNA NAGeneric) named_args in
-
-        let build_result =
-          match build_val with
-          | VBool b -> Ok b
-          | _ when build_provided ->
-              Error (Error.type_error "Function `populate_pipeline` expects `build` to be a Bool.")
-          | _ ->
-              Ok false
-        in
-        let verbose_result =
-          match verbose_val with
-          | VInt i when i >= 0 -> Ok (Some i)
-          | VInt _ ->
-              Error (Error.value_error "Function `populate_pipeline` expects `verbose` to be a non-negative Int.")
-          | _ when verbose_provided ->
-              Error (Error.type_error "Function `populate_pipeline` expects `verbose` to be an Int.")
-          | _ ->
-              Ok None
-        in
-        let nix_options_result =
-          match nix_options_val with
-          | VNA _ -> Ok None
-          | VDict pairs ->
-              (match Builder_utils.validate_nix_options "populate_pipeline" pairs with
-               | Ok opts -> Ok (Some opts)
-               | Error e -> Error e)
-          | _ -> Error (Error.type_error "Function `populate_pipeline` expects `nix_options` to be a Dictionary.")
-        in
-        let dry_run_result =
-          match dry_run_val with
-          | VBool b -> Ok (Some b)
-          | VNA _ -> Ok None
-          | _ when dry_run_provided ->
-              Error (Error.type_error "Function `populate_pipeline` expects `dry_run` to be a Bool.")
-          | _ -> Ok None
-        in
-        let pipeline_name_result =
-          match pipeline_name_val with
-          | VString s -> Ok (Some s)
-          | VSymbol s -> Ok (Some s)
-          | VNA _ -> Ok None
-          | _ when pipeline_name_provided ->
-              Error (Error.type_error "Function `populate_pipeline` expects `pipeline_name` to be a String.")
-          | _ -> Ok None
-        in
-
-        let (let*) x f = match x with Ok v -> f v | Error e -> e in
-        let* build = build_result in
-        let* verbose = verbose_result in
-        let* nix_options = nix_options_result in
-        let* dry_opt = dry_run_result in
-        let* pipeline_name_explicit = pipeline_name_result in
-        let final_nix_options =
-          let base_opts =
-            match nix_options with
-            | Some opts -> opts
-            | None -> Builder_utils.default_nix_opts
-          in
-          match dry_opt with
-          | Some d -> Some { base_opts with dry_run = Some d }
-          | None -> Some base_opts
-        in
+            let (let*) x f = match x with Ok v -> f v | Error e -> e in
+            let* build = Pipeline_builder_post.parse_build ~fn_name ~pos:2 named_args in
+            let* verbose = Pipeline_builder_post.parse_verbose ~fn_name ~pos:3 named_args in
+            let* nix_options = Pipeline_builder_post.parse_nix_options ~fn_name ~pos:4 named_args in
+            let* dry_opt = Pipeline_builder_post.parse_dry_run ~fn_name ~pos:5 named_args in
+            let* pipeline_name_explicit = Pipeline_builder_post.parse_pipeline_name ~fn_name ~pos:6 named_args in
+        let final_nix_options = Pipeline_builder_post.combine_nix_options ?dry_opt nix_options in
         let final_build =
           match final_nix_options with
           | Some opts ->
@@ -131,89 +42,13 @@ let register env =
          (match Builder.populate_pipeline ~build:final_build ?verbose ?pipeline_name ?nix_options:final_nix_options p with
           | Ok out ->
               if final_build && (match final_nix_options with Some opts -> opts.dry_run <> Some true | None -> true) then (
-                let built =
-                  match out with
-                  | VDict pairs ->
-                      (match List.assoc_opt "built" pairs with
-                       | Some (VInt n) -> n
-                       | _ -> 1)
-                  | _ -> 1
-                in
-                let cached =
-                  match out with
-                  | VDict pairs ->
-                      (match List.assoc_opt "cached" pairs with
-                       | Some (VInt n) -> n
-                       | _ -> 0)
-                  | _ -> 0
-                in
-                let out_path =
-                  match out with
-                  | VDict pairs ->
-                      (match List.assoc_opt "out_path" pairs with
-                       | Some (VString s) -> s
-                       | _ -> "")
-                  | _ -> ""
-                in
-                let soft_failed =
-                  match out with
-                  | VDict pairs ->
-                      (match List.assoc_opt "soft_failed" pairs with
-                       | Some (VList items) -> List.length items
-                       | _ -> 0)
-                  | _ -> 0
-                in
-                let var_name = match pipeline_name with Some n -> n | None -> "p" in
-                let first_node =
-                  match p.p_nodes with
-                  | (name, _) :: _ -> name
-                  | [] -> "my_node"
-                in
-                if built > 0 then
-                  if soft_failed > 0 then
-                    Printf.eprintf "\nPipeline built successfully but with errors\n"
-                  else
-                    Printf.eprintf "\nPipeline successfully built!\n";
-                Printf.eprintf "  - Pipeline saved in variable '%s'\n" var_name;
-                Printf.eprintf "  - To read the contents of node '%s', use: read_node(%s.%s)\n" first_node var_name first_node;
-                Printf.eprintf "  - To inspect node metadata, use: inspect_node(%s.%s)\n" var_name first_node;
-                Printf.eprintf "  - To view pipeline summary, use: inspect_pipeline(%s)\n\n%!" var_name;
-                if built > 0 || cached > 0 then
-                  (match Builder.find_log_for_out_path out_path with
-                   | Some log_path ->
-                       Hashtbl.replace Ast.pipeline_build_logs p.p_exprs log_path;
-                        (* Update in-memory cache with build-log diagnostics (warnings, errors).
-                           Only nodes that appear in the build log are updated; unmatched nodes
-                           retain whatever diagnostics they already have (populate-phase or prior
-                           build results). This is safe because pipeline node sets are fixed once
-                           created — within the same pipeline expression no nodes "drop out" between
-                           successive populate_pipeline calls. *)
-                        (match Builder_logs.read_log log_path with
-                         | Ok entries ->
-                             let entry_tbl = Hashtbl.create (List.length entries) in
-                             List.iter (fun (n, cn) -> Hashtbl.replace entry_tbl n cn) entries;
-                             List.iter (fun (name, v) ->
-                               match v, Hashtbl.find_opt entry_tbl name with
-                               | VComputedNode cn, Some logged_cn
-                                   when logged_cn.cn_path <> "" && logged_cn.cn_path <> Ast.unbuilt_path ->
-                                     if logged_cn.cn_name <> name then
-                                       Printf.eprintf "[pipeline] warning: log entry name '%s' != node name '%s' (skipping diagnostics update)\n" logged_cn.cn_name name
-                                      else (
-                                      let resolved = { cn with
-                                        cn_path = logged_cn.cn_path;
-                                        cn_class = logged_cn.cn_class;
-                                        cn_runtime = logged_cn.cn_runtime;
-                                        cn_serializer = logged_cn.cn_serializer;
-                                      } in
-                                      let diag = Builder.logged_node_diagnostics resolved.cn_name resolved in
-                                      Ast.set_in_memory_node_value ~p_exprs:p.p_exprs ~node_name:name
-                                        (VNodeResult { v; node_name = name; diagnostics = diag })
-                                      )
-                               | _ -> ()
-                             ) p.p_nodes
-                         | Error e ->
-                             Printf.eprintf "[pipeline] warning: failed to read build log (%s) — in-memory diagnostics may be stale\n" e)
-                   | None -> ())
+                let stats = Pipeline_builder_post.extract_build_stats out in
+                Pipeline_builder_post.print_build_success ~pipeline_name ~p_nodes:p.p_nodes stats;
+                if stats.built > 0 || stats.cached > 0 then
+                  ignore (Pipeline_builder_post.register_build_logs
+                    ~p_exprs_keys:[original_p_exprs; p.p_exprs]
+                    ~p_nodes:p.p_nodes
+                    ~out_path:stats.out_path)
               );
                out
           | Error msg -> Error.make_error StructuralError msg))

--- a/src/packages/pipeline/read_node.ml
+++ b/src/packages/pipeline/read_node.ml
@@ -487,6 +487,12 @@ let read_fn named_args _env =
             | _ -> false
           in
           match Ast.get_in_memory_node_value_for_cn cn with
+          | Some (VNodeResult { v = VComputedNode inner; node_name = n; diagnostics = d })
+              when inner.cn_path <> "" && inner.cn_path <> Ast.unbuilt_path ->
+                let raw_val = Builder.logged_node_value inner.cn_name inner in
+                let build_diag = Builder.logged_node_diagnostics ~value:raw_val inner.cn_name inner in
+                let merged = { d with nd_error = build_diag.nd_error; nd_recovered = build_diag.nd_recovered } in
+                VNodeResult { v = raw_val; node_name = n; diagnostics = merged }
           | Some v when not (is_in_memory_placeholder v) -> v
           | _ ->
             (match resolved_cn with


### PR DESCRIPTION
…post

- Created pipeline_builder_post.ml with shared arg parsing, build stats extraction, success printing, and build log registration
- Refactored populate_pipeline.ml and build_pipeline.ml to use shared code
- Fix bug: populate_pipeline now stores build log under both original and expanded p_exprs keys (previously only expanded)
- Fix bug: build_pipeline max positional args raised from 4 to 5 to match accepted pipeline_name positional arg
- Build log registration now updates in-memory diagnostics in both functions
- Net reduction: -110 lines