### PR TITLE
Add T syntax highlighting to Quarto extension

### DIFF
--- a/.github/workflows/quarto-extension-ci.yml
+++ b/.github/workflows/quarto-extension-ci.yml
@@ -135,6 +135,18 @@ jobs:
             exit 1
           fi
 
+          # Verify T syntax highlighting produced token spans in the rendered HTML.
+          # The "Highlighting" chunk (eval: false) contains a comment, strings,
+          # a float, integers and a mean(...) call, so the rendered HTML must
+          # contain function (fu) and comment (co) spans.
+          if grep -q 'class="fu"' example.html && grep -q 'class="co"' example.html; then
+            echo "✅ Success: Found T highlighting spans (fu, co) in rendered document."
+          else
+            echo "❌ Error: Expected T highlighting spans not found in example.html."
+            grep -o 'class="[a-z]*"' example.html | sort | uniq -c || true
+            exit 1
+          fi
+
           cp example.html "$REPO_ROOT/quarto-rendered-example.html"
 
       - name: Upload Rendered Artifact

--- a/editors/quarto/tlang/README.md
+++ b/editors/quarto/tlang/README.md
@@ -13,6 +13,7 @@ This folder contains a small Quarto filter extension that makes fenced `t` code 
   - `#| output: false`
   - `#| include: false`
   - `#| results: hide`
+- highlights T code (keywords, strings, numbers, comments, operators, and function calls) so it is styled like R, in HTML/EPUB and PDF
 
 This is intentionally minimal. It is meant for literate programming and console-style output, not rich widgets or plots.
 
@@ -74,4 +75,4 @@ x + 1
 
 - Chunks are executed by replaying all earlier `t` chunks plus the current chunk with `t --mode strict --unsafe run`.
 - Because T normally requires a pipeline for non-interactive scripts, the extension uses `--unsafe` to allow Quarto chunks that are not wrapped in `build_pipeline()` or `populate_pipeline()` calls.
-- Chunk output is rendered as plain text.
+- The echoed T source is syntax-highlighted (matching pandoc's R styling); the executed chunk output is rendered as plain text.

--- a/editors/quarto/tlang/_extensions/tlang/_extension.yml
+++ b/editors/quarto/tlang/_extensions/tlang/_extension.yml
@@ -1,6 +1,6 @@
 title: T language blocks
 author: T language contributors
-version: "0.51.0"
+version: "0.52.0"
 quarto-required: ">=1.4.0"
 contributes:
   filters:

--- a/editors/quarto/tlang/_extensions/tlang/tlang.lua
+++ b/editors/quarto/tlang/_extensions/tlang/tlang.lua
@@ -141,6 +141,200 @@ local function make_output_block(output)
     return pandoc.CodeBlock(output, pandoc.Attr("", {"text", "t-output"}))
 end
 
+-- ---------------------------------------------------------------------------
+-- T syntax highlighting
+--
+-- Mirrors pandoc's R highlighting so T code is styled identically to R. Both a
+-- raw HTML block (short-class spans, used by HTML/EPUB) and a raw LaTeX block
+-- (\*Tok commands, used by PDF) are emitted; pandoc keeps only the one that
+-- matches the output format.
+-- ---------------------------------------------------------------------------
+
+local T_KEYWORDS = {
+    ["if"] = true, ["else"] = true, import = true, ["function"] = true,
+    pipeline = true, intent = true, match = true, ["in"] = true,
+}
+
+local T_CONSTANTS = {
+    NA = true, ["true"] = true, ["false"] = true,
+}
+
+-- Longest operators first so multi-character operators win over prefixes.
+local T_OPERATORS = {
+    "?|>", "!!!", ".<=", ".>=", ".==", ".!=",
+    "|>", "::", "->", "=>", ":=", "==", "!=", "<=", ">=", "&&", "||", "!!",
+    ".+", ".-", ".*", "./", ".%", ".<", ".>", ".&", ".|",
+    "+", "-", "*", "/", "<", ">", "=", "~", "$", "%", "&", "|", "!", ".", ":",
+}
+
+local HTML_ESCAPES = {
+    ["&"] = "&amp;",
+    ["<"] = "&lt;",
+    [">"] = "&gt;",
+    ['"'] = "&quot;",
+}
+
+local LATEX_ESCAPES = {
+    ["\\"] = "\\textbackslash{}",
+    ["{"] = "\\{",
+    ["}"] = "\\}",
+    ["_"] = "\\_",
+    ["&"] = "\\&",
+    ["#"] = "\\#",
+    ["%"] = "\\%",
+    ["^"] = "\\^{}",
+    ["<"] = "\\textless{}",
+    [">"] = "\\textgreater{}",
+    ["-"] = "{-}",
+    ["~"] = "\\textasciitilde{}",
+}
+
+local LATEX_TOK_CMD = {
+    co = "CommentTok",
+    st = "StringTok",
+    dv = "DecValTok",
+    fl = "FloatTok",
+    cf = "ControlFlowTok",
+    sc = "SpecialCharTok",
+    fu = "FunctionTok",
+    cn = "ConstantTok",
+    ot = "OtherTok",
+}
+
+local function escape_map(s, map)
+    local out = {}
+    for i = 1, #s do
+        local c = s:sub(i, i)
+        table.insert(out, map[c] or c)
+    end
+    return table.concat(out)
+end
+
+local function match_operator(line, i)
+    for _, op in ipairs(T_OPERATORS) do
+        if line:sub(i, i + #op - 1) == op then
+            return op
+        end
+    end
+    return nil
+end
+
+local function tokenize_line(line)
+    local tokens = {}
+    local i, n = 1, #line
+
+    while i <= n do
+        local c = line:sub(i, i)
+
+        if c == "-" and line:sub(i, i + 1) == "--" then
+            table.insert(tokens, {cls = "co", text = line:sub(i, n)})
+            i = n + 1
+        elseif c == '"' or c == "'" then
+            local j = i + 1
+            while j <= n do
+                local cj = line:sub(j, j)
+                if cj == "\\" then
+                    j = j + 2
+                elseif cj == c then
+                    j = j + 1
+                    break
+                else
+                    j = j + 1
+                end
+            end
+            table.insert(tokens, {cls = "st", text = line:sub(i, j - 1)})
+            i = j
+        elseif c:match("%d") then
+            local j = i
+            while j <= n and line:sub(j, j):match("%d") do j = j + 1 end
+            if j <= n and line:sub(j, j) == "." and line:sub(j + 1, j + 1):match("%d") then
+                j = j + 1
+                while j <= n and line:sub(j, j):match("%d") do j = j + 1 end
+            end
+            local num = line:sub(i, j - 1)
+            table.insert(tokens, {cls = (num:find("%.") and "fl" or "dv"), text = num})
+            i = j
+        elseif c:match("%a") or c == "_" then
+            local j = i
+            while j <= n and (line:sub(j, j):match("%w") or line:sub(j, j) == "_") do
+                j = j + 1
+            end
+            local word = line:sub(i, j - 1)
+            local cls
+            if T_KEYWORDS[word] then
+                cls = "cf"
+            elseif T_CONSTANTS[word] then
+                cls = "cn"
+            elseif line:sub(j, j) == "(" then
+                cls = "fu"
+            end
+            table.insert(tokens, {cls = cls, text = word})
+            i = j
+        elseif c == "." and line:sub(i + 1, i + 1):match("%a") then
+            local j = i + 1
+            while j <= n and (line:sub(j, j):match("%w") or line:sub(j, j) == "_") do
+                j = j + 1
+            end
+            table.insert(tokens, {cls = nil, text = line:sub(i, j - 1)})
+            i = j
+        else
+            local op = match_operator(line, i)
+            if op then
+                table.insert(tokens, {cls = "sc", text = op})
+                i = i + #op
+            else
+                table.insert(tokens, {cls = nil, text = c})
+                i = i + 1
+            end
+        end
+    end
+
+    local merged = {}
+    for _, tok in ipairs(tokens) do
+        local last = merged[#merged]
+        if tok.cls == nil and last and last.cls == nil then
+            last.text = last.text .. tok.text
+        else
+            table.insert(merged, {cls = tok.cls, text = tok.text})
+        end
+    end
+
+    return merged
+end
+
+local function highlight_t(text)
+    local html_lines = {}
+    local latex_lines = {}
+
+    for _, line in ipairs(split_lines(text)) do
+        local html_parts = {}
+        local latex_parts = {}
+        for _, tok in ipairs(tokenize_line(line)) do
+            if tok.cls == nil then
+                table.insert(html_parts, escape_map(tok.text, HTML_ESCAPES))
+                table.insert(latex_parts,
+                    "\\NormalTok{" .. escape_map(tok.text, LATEX_ESCAPES) .. "}")
+            else
+                table.insert(html_parts,
+                    string.format('<span class="%s">%s</span>',
+                                   tok.cls, escape_map(tok.text, HTML_ESCAPES)))
+                table.insert(latex_parts,
+                    "\\" .. LATEX_TOK_CMD[tok.cls] .. "{"
+                        .. escape_map(tok.text, LATEX_ESCAPES) .. "}")
+            end
+        end
+        table.insert(html_lines, table.concat(html_parts))
+        table.insert(latex_lines, table.concat(latex_parts))
+    end
+
+    local html = "<pre class=\"t\"><code>" .. table.concat(html_lines, "\n") .. "</code></pre>"
+    local latex = "\\begin{Shaded}\n\\begin{Highlighting}[]\n"
+        .. table.concat(latex_lines, "\n")
+        .. "\n\\end{Highlighting}\n\\end{Shaded}"
+
+    return pandoc.RawBlock("html", html), pandoc.RawBlock("latex", latex)
+end
+
 function CodeBlock(el)
     if not (has_class(el, "t") or has_class(el, "tlang")) then return nil end
 
@@ -168,7 +362,9 @@ function CodeBlock(el)
     local rendered_blocks = {}
 
     if include and show_code then
-        table.insert(rendered_blocks, pandoc.CodeBlock(body, el.attr))
+        local html_block, latex_block = highlight_t(body)
+        table.insert(rendered_blocks, html_block)
+        table.insert(rendered_blocks, latex_block)
     end
 
     if not should_eval then return rendered_blocks end

--- a/editors/quarto/tlang/_extensions/tlang/tlang.lua
+++ b/editors/quarto/tlang/_extensions/tlang/tlang.lua
@@ -327,7 +327,8 @@ local function highlight_t(text)
         table.insert(latex_lines, table.concat(latex_parts))
     end
 
-    local html = "<pre class=\"t\"><code>" .. table.concat(html_lines, "\n") .. "</code></pre>"
+    local html = "<div class=\"sourceCode\"><pre class=\"sourceCode t\"><code>"
+        .. table.concat(html_lines, "\n") .. "</code></pre></div>"
     local latex = "\\begin{Shaded}\n\\begin{Highlighting}[]\n"
         .. table.concat(latex_lines, "\n")
         .. "\n\\end{Highlighting}\n\\end{Shaded}"

--- a/editors/quarto/tlang/example.qmd
+++ b/editors/quarto/tlang/example.qmd
@@ -25,3 +25,13 @@ text_summary = "This chunk still runs, but its source is hidden."
 ```{t}
 text_summary
 ```
+
+# Highlighting
+
+```{t}
+#| eval: false
+-- T code is highlighted, just like R.
+palette = ["red", "green", "blue"]
+ratio = 0.5
+mean([1, 2, 3, 4])
+```


### PR DESCRIPTION
The tlang.lua filter now tokenizes T code and emits pandoc short-class spans (HTML/EPUB) plus \*Tok commands (PDF) via dual raw-block emission, so T chunks are highlighted identically to R. Bumps the extension to 0.52.0, documents the feature, adds a highlighting example, and extends CI to assert highlight spans appear.